### PR TITLE
Switched the order of URL and Description fields.  Removed verbose

### DIFF
--- a/orcid-web/src/main/resources/freemarker/manage_bio_settings.ftl
+++ b/orcid-web/src/main/resources/freemarker/manage_bio_settings.ftl
@@ -157,7 +157,7 @@
                  		<#list changePersonalInfoForm.externalIdentifiers.externalIdentifier as externalIdentifier>     		  	
                  			<tr>
                  				<td>${(externalIdentifier.externalIdCommonName.content)!"Information not provided"}</td>
-            					<td><a href="${(externalIdentifier.externalIdUrl.value)!}">${(externalIdentifier.externalIdReference.content)!"Information not provided"}</td>
+            					<td><a href="${(externalIdentifier.externalIdUrl.value)!}" target="_blank">${(externalIdentifier.externalIdReference.content)!"Information not provided"}</a></td>
                  			</tr>     		    
                         </#list>
                     </table>                     


### PR DESCRIPTION
descriptions from External Identifier Tables. Changed link to extenral
resource to "Link To Site" instead of full URL since there is no room. 
This is a temp fix -- designing/coding a tableless form/page in the near
future - BRD
