### PR TITLE
Made Spring reload messages from the classpath

### DIFF
--- a/orcid-core/src/main/resources/orcid-core-context.xml
+++ b/orcid-core/src/main/resources/orcid-core-context.xml
@@ -125,6 +125,7 @@
         class="org.springframework.context.support.ReloadableResourceBundleMessageSource">
         <property name="basename" value="classpath:i18n/messages" />
         <property name="defaultEncoding" value="UTF-8"/>
+        <property name="cacheSeconds" value="${org.orcid.core.messages.cacheSeconds:5}" />
     </bean>
 
 	<cache:annotation-driven />


### PR DESCRIPTION
This will mean messages can be added/modified without
restarting Tomcat if you have JRebel installed, and as long as you have
done a mvn jrebel:generate (need to redo after mvn clean).
