### PR TITLE
proposed short term solution for import new window

### DIFF
--- a/orcid-web/src/main/webapp/static/javascript/script.js
+++ b/orcid-web/src/main/webapp/static/javascript/script.js
@@ -189,15 +189,7 @@ $(function () {
     	}    
  
     }
-    
-    $('#confirmationForm').submit(function() {
-    	if (window.location != window.parent.location) {
-    		parent.$.colorbox.close();
-    		this.target = '_blank';
-    	}
-    	return true;
-    });
- 
+     
     $('#denialForm').submit(function() {
     	if (window.location != window.parent.location) parent.$.colorbox.close();
     	return true;
@@ -216,7 +208,21 @@ $(function () {
 			$('#cookie-check-msg').css("display","inline");	
 		}
     }
-
+	
+	$('.third-party-colorbox').click(function(e) {
+		e.preventDefault();
+		var href = $(this).attr('href');
+		if (window.location != window.parent.location) {
+			parent.$.colorbox.close();
+		} else {
+			//alert('here 2');
+			$.colorbox.close();
+		}
+		var newWin = window.open(href);
+		if (!newWin) window.location.href = href;
+		return false;
+	});
+	
 	// jquery browser is deprecated, when you upgrade 
 	// to 1.9 or higher you will need to use the pluggin
 	var oldBrowserFlag =  false;


### PR DESCRIPTION
https://trello.com/card/scopus-wizard-error/50a2a79da535468428000174/275

Basically IE is having trouble posting the authorise form into a new window. Instead we open the new window one screen before that.

Before:
Import Research Activities -> Select Scopus -> Authorise click opens new window

This patch:
Import Research Activities -> Select Scopus click opens new window -> Authorise  
