### PR TITLE
Fixed hashCode in Country

### DIFF
--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/Country.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/Country.java
@@ -90,26 +90,6 @@ public class Country implements Serializable, VisibilityType {
         this.content = value;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
-        Country country = (Country) o;
-
-        if (!content.equals(country.content))
-            return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return content.hashCode();
-    }
-
     public Visibility getVisibility() {
         return visibility;
     }
@@ -117,4 +97,30 @@ public class Country implements Serializable, VisibilityType {
     public void setVisibility(Visibility visibility) {
         this.visibility = visibility;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((content == null) ? 0 : content.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Country other = (Country) obj;
+        if (content == null) {
+            if (other.content != null)
+                return false;
+        } else if (!content.equals(other.content))
+            return false;
+        return true;
+    }
+
 }


### PR DESCRIPTION
...which was causing an obscure bug that broke your session when visiting the update bio lightbox - but only when spring security logging level was set to debug.

The bug was not seen on QA or production because of the logging levels configured there.
