### PR TITLE
Fixing external identifiers issue: The external identifiers where cached...

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/manager/ExternalIdentifierManager.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/ExternalIdentifierManager.java
@@ -16,8 +16,21 @@
  */
 package org.orcid.core.manager;
 
+import java.util.List;
+
+import org.orcid.persistence.jpa.entities.ExternalIdentifierEntity;
+
 public interface ExternalIdentifierManager {
 
+    /**
+     * Get the list of external identifiers associated with an specific account
+     * @param orcid
+     *          The orcid of the owner
+     * @return
+     *          A list that contains all external identifiers for the specific account
+     * */
+    public List<ExternalIdentifierEntity> getExternalIdentifiers(String orcid);
+    
     /**
      * Removes an external identifier from database based on his ID.
      * The ID for external identifiers consists of the "orcid" of the owner and

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/ExternalIdentifierManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/ExternalIdentifierManagerImpl.java
@@ -16,15 +16,30 @@
  */
 package org.orcid.core.manager.impl;
 
+import java.util.List;
+
 import javax.annotation.Resource;
 
 import org.orcid.core.manager.ExternalIdentifierManager;
 import org.orcid.persistence.dao.ExternalIdentifierDao;
+import org.orcid.persistence.jpa.entities.ExternalIdentifierEntity;
 
 public class ExternalIdentifierManagerImpl implements ExternalIdentifierManager {
 
     @Resource
     private ExternalIdentifierDao externalIdentifierDao;
+    
+    
+    /**
+     * Get the list of external identifiers associated with an specific account
+     * @param orcid
+     *          The orcid of the owner
+     * @return
+     *          A list that contains all external identifiers for the specific account
+     * */
+    public List<ExternalIdentifierEntity> getExternalIdentifiers(String orcid){
+        return externalIdentifierDao.getExternalIdentifiers(orcid);
+    }
     
     /**
      * Removes an external identifier from database based on his ID.

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ExternalIdentifierDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ExternalIdentifierDao.java
@@ -16,7 +16,20 @@
  */
 package org.orcid.persistence.dao;
 
+import java.util.List;
+
+import org.orcid.persistence.jpa.entities.ExternalIdentifierEntity;
+
 public interface ExternalIdentifierDao {
+    
+    /**
+     * Get the list of external identifiers associated with an specific account
+     * @param orcid
+     *          The orcid of the owner
+     * @return
+     *          A list that contains all external identifiers for the specific account
+     * */
+    List<ExternalIdentifierEntity> getExternalIdentifiers(String orcid);
     
     /**
      * Removes an external identifier from database based on his ID.

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ExternalIdentifierDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ExternalIdentifierDaoImpl.java
@@ -16,6 +16,8 @@
  */
 package org.orcid.persistence.dao.impl;
 
+import java.util.List;
+
 import javax.persistence.Query;
 
 import org.orcid.persistence.dao.ExternalIdentifierDao;
@@ -29,6 +31,21 @@ public class ExternalIdentifierDaoImpl extends GenericDaoImpl<ExternalIdentifier
         super(ExternalIdentifierEntity.class);
     }
 
+    /**
+     * Get the list of external identifiers associated with an specific account
+     * @param orcid
+     *          The orcid of the owner
+     * @return
+     *          A list that contains all external identifiers for the specific account
+     * */
+    @Override  
+    @SuppressWarnings("unchecked")
+    public List<ExternalIdentifierEntity> getExternalIdentifiers(String orcid){
+        Query query = entityManager.createQuery("FROM ExternalIdentifierEntity WHERE owner.id=:orcid ORDER BY externalIdCommonName");
+        query.setParameter("orcid", orcid);
+        return query.getResultList();
+    }
+    
     /**
      * Removes an external identifier from database based on his ID.
      * The ID for external identifiers consists of the "orcid" of the owner and


### PR DESCRIPTION
..., so, if you remove an external identifier and reload the page, the removed external identifier was displayed again, eventhough it was already deleted from database
