### PR TITLE
Corrected regression in admin switch user functionality

### DIFF
--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/ManageProfileController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/ManageProfileController.java
@@ -921,7 +921,7 @@ public class ManageProfileController extends BaseWorkspaceController {
             return erroredView;
         }
 
-        OrcidProfile profile = getCurrentUser().getRealProfile();
+        OrcidProfile profile = getCurrentUser().getEffectiveProfile();
         // Update profile with values that comes from user request
         changePersonalInfoForm.mergeOrcidBioDetails(profile);
 


### PR DESCRIPTION
Corrected regression in admin switch user functionality that caused the problem to reappear where effective profile changes are saved into the
real profile when updating bio.
