### PR TITLE
RDF support for orcid - FOAF profile

### DIFF
--- a/orcid-api-common/pom.xml
+++ b/orcid-api-common/pom.xml
@@ -79,6 +79,10 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-core</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
 

--- a/orcid-api-common/src/main/java/org/orcid/api/common/OrcidApiConstants.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/OrcidApiConstants.java
@@ -31,6 +31,12 @@ public class OrcidApiConstants {
 
     public static final String ORCID_XML = "application/orcid+xml; qs=3";
     public static final String ORCID_JSON = "application/orcid+json; qs=2";
+    public static final String TEXT_TURTLE = "text/turtle; qs=3";
+    public static final String TEXT_TURTLE_UTF8 = "text/turtle; charset=utf8; qs=3";
+    public static final String TEXT_N3 = "text/n3; qs=2";
+    public static final String TEXT_N3_UTF8 = "text/n3; charset=utf8; qs=2";
+
+    public static final String APPLICATION_RDFXML = "application/rdf+xml; qs=2";
     public static final String VND_ORCID_XML = "application/vnd.orcid+xml; qs=5";
     public static final String VND_ORCID_JSON = "application/vnd.orcid+json; qs=4";
 

--- a/orcid-api-common/src/main/java/org/orcid/api/common/OrcidApiService.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/OrcidApiService.java
@@ -78,6 +78,33 @@ public interface OrcidApiService<T> {
     T viewBioDetailsJson(@PathParam("orcid") String orcid);
 
     /**
+     * GETs the RDF/XML representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF/XML representation of the ORCID record
+     */
+    @GET
+    @Produces(value = { APPLICATION_RDFXML })
+    @Path(BIO_PATH)
+    T viewBioDetailsRdf(@PathParam("orcid") String orcid);
+
+    
+    /**
+     * GETs the RDF Turtle representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF Turtle representation of the ORCID record
+     */
+    @GET
+    @Produces(value = { TEXT_N3, TEXT_TURTLE })
+    @Path(BIO_PATH)
+    T viewBioDetailsTurtle(@PathParam("orcid") String orcid);
+    
+    /**
      * GETs the HTML representation of the ORCID external identifiers
      * 
      * @param orcid

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/rdf/RDFMessageBodyWriter.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/rdf/RDFMessageBodyWriter.java
@@ -1,0 +1,604 @@
+/**
+ * =============================================================================
+ *
+ * ORCID (R) Open Source
+ * http://orcid.org
+ *
+ * Copyright (c) 2012-2013 ORCID, Inc.
+ * Licensed under an MIT-Style License (MIT)
+ * http://orcid.org/open-source-license
+ *
+ * This copyright and license information (including a link to the full license)
+ * shall be included in its entirety in all copies or substantial portion of
+ * the software.
+ *
+ * =============================================================================
+ */
+package org.orcid.api.common.writer.rdf;
+
+import static org.orcid.api.common.OrcidApiConstants.APPLICATION_RDFXML;
+import static org.orcid.api.common.OrcidApiConstants.PROFILE_POST_PATH;
+import static org.orcid.api.common.OrcidApiConstants.TEXT_N3;
+import static org.orcid.api.common.OrcidApiConstants.TEXT_TURTLE;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.orcid.api.common.OrcidApiService;
+import org.orcid.jaxb.model.message.Address;
+import org.orcid.jaxb.model.message.Biography;
+import org.orcid.jaxb.model.message.ContactDetails;
+import org.orcid.jaxb.model.message.Email;
+import org.orcid.jaxb.model.message.ErrorDesc;
+import org.orcid.jaxb.model.message.LastModifiedDate;
+import org.orcid.jaxb.model.message.OrcidBio;
+import org.orcid.jaxb.model.message.OrcidHistory;
+import org.orcid.jaxb.model.message.OrcidMessage;
+import org.orcid.jaxb.model.message.OrcidProfile;
+import org.orcid.jaxb.model.message.PersonalDetails;
+import org.orcid.jaxb.model.message.ResearcherUrl;
+import org.orcid.jaxb.model.message.ResearcherUrls;
+import org.springframework.beans.factory.annotation.Value;
+
+import com.hp.hpl.jena.datatypes.xsd.XSDDatatype;
+import com.hp.hpl.jena.ontology.DatatypeProperty;
+import com.hp.hpl.jena.ontology.Individual;
+import com.hp.hpl.jena.ontology.ObjectProperty;
+import com.hp.hpl.jena.ontology.OntClass;
+import com.hp.hpl.jena.ontology.OntModel;
+import com.hp.hpl.jena.ontology.Ontology;
+import com.hp.hpl.jena.rdf.model.Literal;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+
+/**
+ * 2013 ORCID
+ * 
+ * @author Stian Soiland-Reyes
+ */
+@Provider
+@Produces( { APPLICATION_RDFXML, TEXT_TURTLE, TEXT_N3 })
+public class RDFMessageBodyWriter implements MessageBodyWriter<OrcidMessage> {
+    
+    private static final String MEMBER_API = "https://api.orcid.org/";
+    private static final String EN = "en";
+    private static final String FOAF_RDF = "foaf.rdf";
+    private static final String PAV = "http://purl.org/pav/";
+    private static final String PAV_RDF = "pav.rdf";
+    private static final String PROV_O_RDF = "prov-o.rdf";
+    private static final String PROV = "http://www.w3.org/ns/prov#";
+    private static final String PROV_O = "http://www.w3.org/ns/prov-o#";
+    private static final String FOAF_0_1 = "http://xmlns.com/foaf/0.1/";
+    protected static final String TMP_BASE = "app://614879b4-48c3-45ab-a828-2a72e43f80d9/";
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+    
+    private DatatypeProperty foafName;
+    private DatatypeProperty foafGivenName;
+    private DatatypeProperty foafFamilyName;
+    private OntClass foafPerson;
+    private OntClass foafOnlineAccount;
+    private ObjectProperty foafAccount;
+    private ObjectProperty foafAccountServiceHomepage;
+
+    @Value("${org.orcid.core.baseUri:http://orcid.org}")
+    private String baseUri = "http://orcid.org";
+    private DatatypeProperty foafAccountName;
+    private ObjectProperty foafPrimaryTopic;
+    private ObjectProperty foafPublications;
+    private OntClass foafPersonalProfileDocument;
+    private OntModel prov;
+    private OntModel foaf;
+    private OntModel pav;
+
+    @Context
+    private UriInfo uriInfo;
+    private ObjectProperty pavCreatedWith;
+    private ObjectProperty pavCreatedBy;
+    private OntClass provPerson;
+    private OntClass provSoftwareAgent;
+    private OntClass provAgent;
+    private ObjectProperty provWasAttributedTo;
+    private DatatypeProperty provGeneratedAt;
+    private ObjectProperty pavCuratedBy;
+    private ObjectProperty foafMbox;
+    private ObjectProperty foafMaker;
+    private DatatypeProperty foafPlan;
+    private ObjectProperty foafPage;
+    private ObjectProperty foafHomepage;
+    private ObjectProperty foafBasedNear;
+    private DatatypeProperty pavLastUpdateAt;
+    private ObjectProperty provAlternateOf;
+    private ObjectProperty pavImportedBy;
+    private DatatypeProperty pavCreatedOn;
+    private DatatypeProperty provInvalidatedAt;
+    private DatatypeProperty pavContributedOn;
+
+    
+    /**
+     * Ascertain if the MessageBodyWriter supports a particular type.
+     * 
+     * @param type
+     *            the class of object that is to be written.
+     * @param genericType
+     *            the type of object to be written, obtained either by
+     *            reflection of a resource method return type or via inspection
+     *            of the returned instance.
+     *            {@link javax.ws.rs.core.GenericEntity} provides a way to
+     *            specify this information at runtime.
+     * @param annotations
+     *            an array of the annotations on the resource method that
+     *            returns the object.
+     * @param mediaType
+     *            the media type of the HTTP entity.
+     * @return true if the type is supported, otherwise false.
+     */
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return OrcidMessage.class.isAssignableFrom(type);
+    }
+
+    /**
+     * Called before <code>writeTo</code> to ascertain the length in bytes of
+     * the serialized form of <code>t</code>. A non-negative return value is
+     * used in a HTTP <code>Content-Length</code> header.
+     * 
+     * @param message
+     *            the instance to write
+     * @param type
+     *            the class of object that is to be written.
+     * @param genericType
+     *            the type of object to be written, obtained either by
+     *            reflection of a resource method return type or by inspection
+     *            of the returned instance.
+     *            {@link javax.ws.rs.core.GenericEntity} provides a way to
+     *            specify this information at runtime.
+     * @param annotations
+     *            an array of the annotations on the resource method that
+     *            returns the object.
+     * @param mediaType
+     *            the media type of the HTTP entity.
+     * @return length in bytes or -1 if the length cannot be determined in
+     *         advance
+     */
+    @Override
+    public long getSize(OrcidMessage message, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        // TODO: Can we calculate the size in advance? 
+        // It would mean buffering up the actual RDF
+        return -1;
+    }
+
+    /**
+     * Write a type to an HTTP response. The response header map is mutable but
+     * any changes must be made before writing to the output stream since the
+     * headers will be flushed prior to writing the response body.
+     * 
+     * @param message
+     *            the instance to write.
+     * @param type
+     *            the class of object that is to be written.
+     * @param genericType
+     *            the type of object to be written, obtained either by
+     *            reflection of a resource method return type or by inspection
+     *            of the returned instance.
+     *            {@link javax.ws.rs.core.GenericEntity} provides a way to
+     *            specify this information at runtime.
+     * @param annotations
+     *            an array of the annotations on the resource method that
+     *            returns the object.
+     * @param mediaType
+     *            the media type of the HTTP entity.
+     * @param httpHeaders
+     *            a mutable map of the HTTP response headers.
+     * @param entityStream
+     *            the {@link java.io.OutputStream} for the HTTP entity. The
+     *            implementation should not close the output stream.
+     * @throws java.io.IOException
+     *             if an IO error arises
+     * @throws javax.ws.rs.WebApplicationException
+     *             if a specific HTTP error response needs to be produced. Only
+     *             effective if thrown prior to the response being committed.
+     */
+    @Override
+    public void writeTo(OrcidMessage xml, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+        OutputStream entityStream) throws IOException, WebApplicationException {
+
+        OntModel m = getOntModel();
+
+        if (xml.getErrorDesc() != null) {
+            describeError(xml.getErrorDesc(), m);
+        }
+        
+        OrcidProfile orcidProfile = xml.getOrcidProfile();
+        System.out.println(httpHeaders);
+        if (orcidProfile != null) {        
+            Individual person = describePerson(orcidProfile, m);        
+            if (person != null) {
+                Individual account = describeAccount(orcidProfile, m, person);
+            }
+        }
+        MediaType rdfXml = new MediaType("application", "rdf+xml");
+        if (mediaType.isCompatible(rdfXml)) {
+            m.write(entityStream, "RDF/XML", TMP_BASE); 
+        } else {
+            // Silly workaround to generate relative URIs 
+
+
+            // The below would not correctly relativize according to TMP_BASE
+            // https://issues.apache.org/jira/browse/JENA-132 
+            // m.write(entityStream, "N3", TMP_BASE);
+
+            StringWriter writer = new StringWriter();
+            m.write(writer, "N3", TMP_BASE);
+            String relativizedTurtle = writer.toString().replace(TMP_BASE, "");            
+            entityStream.write(relativizedTurtle.getBytes(UTF8));           
+        } 
+    }
+
+    protected void describeError(ErrorDesc errorDesc, OntModel m) {
+        String error = errorDesc.getContent();
+        Individual root = m.createIndividual(TMP_BASE, null);
+        root.setLabel("Error", EN);
+        root.setComment(error, EN);
+    }
+
+    private Individual describeAccount(OrcidProfile orcidProfile, OntModel m, Individual person) {
+        // Add /orcid-profile to identify the profile itself
+        String orcidProfileUri = orcidProfile.getOrcidId() + PROFILE_POST_PATH;
+
+        Individual account = m.createIndividual(orcidProfileUri, foafOnlineAccount);
+        person.addProperty(foafAccount, account);
+        Individual webSite = null;
+        if (baseUri != null) {
+            webSite = m.createIndividual(baseUri, null);
+            account.addProperty(foafAccountServiceHomepage, webSite);
+        }
+        String orcId = orcidProfile.getOrcid().getValue();
+        account.addProperty(foafAccountName, orcId);
+        account.addLabel(orcId, null);
+        
+        // The account as a potential foaf:PersonalProfileDocument
+        account.addProperty(foafPrimaryTopic, person);
+        OrcidHistory history = orcidProfile.getOrcidHistory();
+        if (history != null) {
+            if (history.isClaimed().booleanValue()) {
+                // Set account as PersonalProfileDocument
+                account.addRDFType(foafPersonalProfileDocument);
+                account.addProperty(foafMaker, person);
+                
+            }
+            // Who made the profile?
+            switch (history.getCreationMethod()) {
+            case WEBSITE:
+                account.addProperty(pavCreatedBy, person);
+                account.addProperty(provWasAttributedTo, person);                
+                if (webSite != null) {
+                    account.addProperty(pavCreatedWith, webSite);
+                }
+                break;
+            case API:
+                Individual api = m.createIndividual(MEMBER_API, provSoftwareAgent);
+                account.addProperty(pavImportedBy, api);
+
+                if (history.isClaimed().booleanValue()) {
+                    account.addProperty(pavCuratedBy, person);
+                }
+
+                
+                break;
+            default:
+                // Some unknown agent!
+                account.addProperty(pavCreatedWith, m.createIndividual(null, provAgent));
+            }
+
+            if (history.getLastModifiedDate() != null) {
+                Literal when = calendarAsLiteral(history.getLastModifiedDate().getValue(), m);
+                account.addLiteral(pavLastUpdateAt, when);
+                account.addLiteral(provGeneratedAt, when);
+            }            
+            if (history.getSubmissionDate() != null) {
+                account.addLiteral(pavCreatedOn, 
+                        calendarAsLiteral(history.getSubmissionDate().getValue(), m));
+            }           
+            if (history.getCompletionDate() != null) {
+                account.addLiteral(pavContributedOn, calendarAsLiteral(history.getDeactivationDate().getValue(), m));
+            }            
+            if (history.getDeactivationDate() != null) {
+                account.addLiteral(provInvalidatedAt, calendarAsLiteral(history.getDeactivationDate().getValue(), m));
+            }
+            
+        }
+
+        if (uriInfo != null) {
+            // Links to publications resource
+            UriBuilder builder = uriInfo.getBaseUriBuilder();
+            // CHECK - does this get orcid-pub-web vs. orcid-web etc. wrong?
+            URI worksDetails = builder.path(OrcidApiService.class, "viewWorksDetailsXml").build(orcId);        
+            person.addProperty(foafPublications, m.createIndividual(worksDetails.toASCIIString(), null));
+        }
+        
+        return account;
+    }
+
+    private Literal calendarAsLiteral(XMLGregorianCalendar cal, OntModel m) {
+        return m.createTypedLiteral(cal.toXMLFormat(), XSDDatatype.XSDdateTime);
+    }
+
+    private Individual describePerson(OrcidProfile orcidProfile, OntModel m) {
+        String orcidUri = orcidProfile.getOrcidId();
+        Individual person = m.createIndividual(orcidUri, foafPerson);
+        person.addRDFType(provPerson);
+        
+        if (orcidProfile.getOrcidBio() == null) {
+            return person;
+        }
+        OrcidBio orcidBio = orcidProfile.getOrcidBio();
+        if (orcidBio == null) {
+            return person;
+        }
+        
+        describePersonalDetails(orcidBio.getPersonalDetails(), person, m);
+        describeContactDetails(orcidBio.getContactDetails(), person, m);
+        describeBiography(orcidBio.getBiography(), person, m);
+        describeResearcherUrls(orcidBio.getResearcherUrls(), person, m);
+        return person;
+    }
+
+    private void describeResearcherUrls(ResearcherUrls researcherUrls, Individual person, OntModel m) {
+        if (researcherUrls == null || researcherUrls.getResearcherUrl() == null) {
+            return;
+        }
+        for (ResearcherUrl url : researcherUrls.getResearcherUrl()) {
+            Individual page = m.createIndividual(url.getUrl().getValue(), null);
+            if (isHomePage(url)) {
+                person.addProperty(foafHomepage, page);
+            } else if(isFoaf(url)) {
+                // TODO: Is this the proper way to link to other FOAF URIs?
+                // What if we want to link to the URL of the other FOAF *Profile*?
+                
+                // Note: We don't dear to do owl:sameAs or prov:specializationOf
+                // as we don't know the extent of the other FOAF profile - we'll 
+                // suffice to say it's an alternate view of the same person
+                person.addProperty(provAlternateOf, page);
+                page.addRDFType(foafPerson);
+                page.addRDFType(provPerson);
+                person.addSeeAlso(page);
+            } else {
+                person.addProperty(foafPage, page);
+            }
+        }
+    }
+
+    private boolean isFoaf(ResearcherUrl url) {
+        if (url.getUrlName() == null || url.getUrlName().getContent() == null) {
+            return false;
+        }
+        return url.getUrlName().getContent().equalsIgnoreCase("foaf");
+    }
+
+    /**
+     * There's no indication in ORCID if the URL is a homepage or some other
+     * page, so we'll guess based on it's name, it be something similar to
+     * "home page".
+     */
+    private boolean isHomePage(ResearcherUrl url) {
+        if (url.getUrlName() == null || url.getUrlName().getContent() == null) {
+            return false;
+        }
+        String name = url.getUrlName().getContent().toLowerCase();
+        List<String> candidates = Arrays.asList("homepage", "home", "home page", "personal", 
+                "personal homepage", "personal home page");
+        return candidates.contains(name);
+    }
+
+    private void describeBiography(Biography biography, Individual person, OntModel m) {
+        if (biography != null) {
+            // FIXME: Which language is the biography written in? Can't assume EN
+            person.addProperty(foafPlan, biography.getContent());
+       }
+    }
+
+    private void describeContactDetails(ContactDetails contactDetails, Individual person, OntModel m) {
+       if (contactDetails == null) {
+           return;
+       }
+
+       List<Email> emails = contactDetails.getEmail();
+       if (emails != null) {
+           for (Email email : emails) {
+               if (email.isCurrent()) {
+                   
+                Individual mbox = m.createIndividual("mailto:" + email.getValue(), null);
+                person.addProperty(foafMbox, mbox);
+               }
+           }
+       }
+       
+       Address addr = contactDetails.getAddress();
+       if (addr != null) {
+           if (addr.getCountry() != null) {
+               String country = addr.getCountry().getContent();
+               // TODO: Add a proper 'country' property
+               Individual position = m.createIndividual(null, null);
+               position.addLabel(country, null);
+               position.addComment("Country code: " + country, EN);
+               person.addProperty(foafBasedNear, position);
+           }
+       }
+    }
+
+    private void describePersonalDetails(PersonalDetails personalDetails, Individual person, OntModel m) {
+        if (personalDetails == null) {
+            return;
+        }
+        
+        if (personalDetails.getCreditName() != null) {
+            String creditName = personalDetails.getCreditName().getContent();
+            person.addProperty(foafName, creditName);
+            person.addLabel(creditName, null);
+        } else if (personalDetails.getGivenNames() != null && personalDetails.getFamilyName() != null ){
+            // Naive combination assuming givenNames ~= first name and familyName ~= lastName
+            // See http://www.w3.org/International/questions/qa-personal-names for further
+            // considerations -- we don't report this as foaf:name as we can't be sure
+            // NOTE: ORCID gui is westernized asking for "First name" and
+            // "Last name" and assuming the above mapping
+            String label = personalDetails.getGivenNames() + " "  + personalDetails.getFamilyName();
+            person.addLabel(label, null);
+        }
+        
+        if (personalDetails.getGivenNames() != null) {
+            person.addProperty(foafGivenName, personalDetails.getGivenNames().getContent());
+        }
+        if (personalDetails.getFamilyName() != null) {
+            person.addProperty(foafFamilyName, personalDetails.getFamilyName().getContent());
+        }
+        
+    }
+
+    protected OntModel getOntModel() {
+        if (foaf == null) {
+            loadFoaf();
+        }
+        if (prov == null) {
+            loadProv();
+        }
+        if (pav == null) {
+            loadPav();
+        }
+        
+        
+        OntModel ontModel = ModelFactory.createOntologyModel();
+        ontModel.setNsPrefix("foaf", FOAF_0_1);
+        ontModel.setNsPrefix("prov", PROV);
+        ontModel.setNsPrefix("pav", PAV);
+        //ontModel.getDocumentManager().loadImports(foaf.getOntModel());
+        return ontModel;
+    }
+
+    protected synchronized void loadPav() {
+        if (pav != null) {
+            return;
+        }
+        OntModel ontModel = loadOntologyFromClasspath(PAV_RDF, PAV);         
+        
+        pavCreatedBy = ontModel.getObjectProperty(PAV + "createdBy");
+        pavCuratedBy = ontModel.getObjectProperty(PAV + "curatedBy");
+        pavImportedBy = ontModel.getObjectProperty(PAV + "importedBy");
+        pavCreatedWith = ontModel.getObjectProperty(PAV + "createdWith");
+        
+        pavCreatedOn = ontModel.getDatatypeProperty(PAV + "createdOn");
+        pavLastUpdateAt = ontModel.getDatatypeProperty(PAV + "lastUpdateOn");
+        pavContributedOn = ontModel.getDatatypeProperty(PAV + "contributedOn");
+        
+        checkNotNull(pavCreatedBy, pavCuratedBy, pavImportedBy, pavCreatedWith,
+                pavCreatedOn, pavLastUpdateAt, pavContributedOn);
+        pav = ontModel;            
+    }
+    
+    private void checkNotNull(Object... possiblyNulls) {
+        int i=0;
+        for (Object check : possiblyNulls) {
+            if (check == null) {
+                throw new IllegalStateException("Could not load item #" + i);
+            }
+            i++;
+        }
+        
+    }
+
+    protected synchronized void loadProv() {
+        if (prov != null) {
+            return;
+        }
+        OntModel ontModel = loadOntologyFromClasspath(PROV_O_RDF, PROV_O);
+        
+        provPerson =  ontModel.getOntClass(PROV + "Person");
+        provAgent = ontModel.getOntClass(PROV + "Agent");
+        provSoftwareAgent =  ontModel.getOntClass(PROV + "SoftwareAgent");
+        provWasAttributedTo = ontModel.getObjectProperty(PROV + "wasAttributedTo");
+        provAlternateOf = ontModel.getObjectProperty(PROV + "alternateOf");
+        provGeneratedAt = ontModel.getDatatypeProperty(PROV + "generatedAtTime");
+        provInvalidatedAt = ontModel.getDatatypeProperty(PROV + "invalidatedAtTime");
+        
+        checkNotNull(provPerson, provAgent, provSoftwareAgent, provWasAttributedTo, provAlternateOf, provGeneratedAt, provInvalidatedAt);
+        prov = ontModel;
+    }
+
+    protected OntModel loadOntologyFromClasspath(String classPathUri, String uri) {
+        OntModel ontModel = ModelFactory.createOntologyModel();
+
+        // Load from classpath
+        InputStream inStream = getClass().getResourceAsStream(classPathUri);
+        if (inStream == null) {
+            throw new IllegalArgumentException("Can't load " + classPathUri);
+        }
+        Ontology ontology = ontModel.createOntology(uri);
+        ontModel.read(inStream, uri);
+        return ontModel;
+    }
+
+    protected synchronized void loadFoaf() {
+        if (foaf != null) {
+            return;
+        }
+
+        OntModel ontModel = loadOntologyFromClasspath(FOAF_RDF, FOAF_0_1);            
+        
+        // foaf = ontModel.getOntology(FOAF_0_1);
+
+        // classes from foaf
+        foafPerson =  ontModel.getOntClass(FOAF_0_1 + "Person");
+        foafOnlineAccount =  ontModel.getOntClass(FOAF_0_1 + "OnlineAccount");
+        foafPersonalProfileDocument =  ontModel.getOntClass(FOAF_0_1 + "PersonalProfileDocument");
+        
+        // properties from foaf
+        foafName = ontModel.getDatatypeProperty(FOAF_0_1 + "name");
+        foafGivenName = ontModel.getDatatypeProperty(FOAF_0_1 + "givenName");
+        foafFamilyName = ontModel.getDatatypeProperty(FOAF_0_1 + "familyName");
+        foafAccountName = ontModel.getDatatypeProperty(FOAF_0_1 + "accountName");
+        foafPlan = ontModel.getDatatypeProperty(FOAF_0_1 + "plan");
+        foafMbox = ontModel.getObjectProperty(FOAF_0_1 + "mbox");
+        foafBasedNear = ontModel.getObjectProperty(FOAF_0_1 + "based_near");
+        
+        
+        foafPrimaryTopic = ontModel.getObjectProperty(FOAF_0_1 + "primaryTopic");
+        foafMaker = ontModel.getObjectProperty(FOAF_0_1 + "maker");
+        foafPage = ontModel.getObjectProperty(FOAF_0_1 + "page");
+        foafHomepage = ontModel.getObjectProperty(FOAF_0_1 + "homepage");
+        foafPublications = ontModel.getObjectProperty(FOAF_0_1 + "publications");
+        
+        foafAccount = ontModel.getObjectProperty(FOAF_0_1 + "account");
+        foafAccountServiceHomepage = ontModel.getObjectProperty(FOAF_0_1 + "accountServiceHomepage");
+
+        checkNotNull(foafPerson,foafOnlineAccount,foafPersonalProfileDocument, foafName, foafGivenName, foafFamilyName, foafAccountName,
+                foafPlan, foafMbox, foafBasedNear, foafPrimaryTopic, foafMaker, foafPage, foafHomepage, foafPublications, foafAccount, 
+                foafAccountServiceHomepage);
+                
+        foaf = ontModel;            
+    }
+
+    public UriInfo getUriInfo() {
+        return uriInfo;
+    }
+
+    public void setUriInfo(UriInfo uriInfo) {
+        this.uriInfo = uriInfo;
+    }
+}

--- a/orcid-api-common/src/main/resources/org/orcid/api/common/writer/rdf/foaf.rdf
+++ b/orcid-api-common/src/main/resources/org/orcid/api/common/writer/rdf/foaf.rdf
@@ -1,0 +1,606 @@
+<!-- This is the FOAF formal vocabulary description, expressed using W3C RDFS and OWL markup. foaf/spec version -->
+<!-- For more information about FOAF:                                            -->
+<!--   see the FOAF project homepage, http://www.foaf-project.org/               -->
+<!--   FOAF specification, http://xmlns.com/foaf/spec/                             -->
+<!--                                                                             -->
+<!-- first we introduce a number of RDF namespaces we will be using... -->
+<rdf:RDF 
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" 
+	xmlns:owl="http://www.w3.org/2002/07/owl#" 
+	xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#" 
+	xmlns:foaf="http://xmlns.com/foaf/0.1/" 
+	xmlns:wot="http://xmlns.com/wot/0.1/" 
+	xmlns:dc="http://purl.org/dc/elements/1.1/">
+<!-- Here we describe general characteristics of the FOAF vocabulary ('ontology'). -->
+  <owl:Ontology rdf:about="http://xmlns.com/foaf/0.1/" dc:title="Friend of a Friend (FOAF) vocabulary" dc:description="The Friend of a Friend (FOAF) RDF vocabulary, described using W3C RDF Schema and the Web Ontology Language." >
+  </owl:Ontology>
+
+
+  <!-- OWL/RDF interop section - geeks only -->
+  <!--  most folk can ignore this lot. the game here is to make FOAF
+  	work with vanilla RDF/RDFS tools, and with the stricter OWL DL 
+	profile of OWL. At the moment we're in the OWL Full flavour of OWL. 
+	The following are tricks to try have the spec live in both worlds
+	at once. See
+		http://phoebus.cs.man.ac.uk:9999/OWL/Validator
+		http://www.mindswap.org/2003/pellet/demo.shtml
+	...for some tools that help. 					-->
+  <owl:AnnotationProperty rdf:about="http://xmlns.com/wot/0.1/assurance"/>
+  <owl:AnnotationProperty rdf:about="http://xmlns.com/wot/0.1/src_assurance"/>
+  <owl:AnnotationProperty rdf:about="http://www.w3.org/2003/06/sw-vocab-status/ns#term_status"/>
+  <!--  DC terms are NOT annotation properties in general, so we consider the following 
+	claims scoped to this document. They may be removed in future revisions if
+	OWL tools become more flexible. -->
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/description"/>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title"/>
+  <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
+  <owl:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Class"/>
+
+<!--  <owl:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  <owl:Class rdf:about="http://www.w3.org/2000/01/rdf-schema#Literal"/> -->
+  <!-- end of OWL/RDF interop voodoo. mostly. -->
+
+  <!-- utility class, a candidate for replacing the pattern of subproperty-ing rdfs:label -->
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/LabelProperty" vs:term_status="unstable">
+    <rdfs:label>Label Property</rdfs:label>
+    <rdfs:comment>A foaf:LabelProperty is any RDF property with texual values that serve as labels.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdfs:Class>
+
+<!-- FOAF classes (types) are listed first. -->
+
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/Person" rdfs:label="Person" rdfs:comment="A person." vs:term_status="stable">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+<!--    <rdfs:subClassOf><owl:Class rdf:about="http://xmlns.com/wordnet/1.6/Person"/></rdfs:subClassOf> -->
+    <rdfs:subClassOf><owl:Class rdf:about="http://xmlns.com/foaf/0.1/Agent"/></rdfs:subClassOf>
+<!--    <rdfs:subClassOf><owl:Class rdf:about="http://xmlns.com/wordnet/1.6/Agent"/></rdfs:subClassOf> -->
+    <rdfs:subClassOf><owl:Class rdf:about="http://www.w3.org/2000/10/swap/pim/contact#Person" rdfs:label="Person"/></rdfs:subClassOf>
+    <rdfs:subClassOf><owl:Class rdf:about="http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing" rdfs:label="Spatial Thing"/></rdfs:subClassOf>
+    <!-- aside: 
+	are spatial things always spatially located? 
+	Person includes imaginary people... discuss... -->
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+
+<!--    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/> this was a mistake; tattoo'd people, for example. -->
+
+    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Project"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/Document" rdfs:label="Document" rdfs:comment="A document." vs:term_status="testing">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+<!--    <rdfs:subClassOf rdf:resource="http://xmlns.com/wordnet/1.6/Document"/> -->
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Project"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/Organization" rdfs:label="Organization" rdfs:comment="An organization." vs:term_status="stable">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+<!--    <rdfs:subClassOf><owl:Class rdf:about="http://xmlns.com/wordnet/1.6/Organization"/></rdfs:subClassOf> -->
+    <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/Group" vs:term_status="stable" rdfs:label="Group" rdfs:comment="A class of Agents.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/Agent" vs:term_status="stable" rdfs:label="Agent" rdfs:comment="An agent (eg. person, group, software or physical artifact).">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <owl:equivalentClass rdf:resource="http://purl.org/dc/terms/Agent"/>
+<!--    <rdfs:subClassOf><owl:Class rdf:about="http://xmlns.com/wordnet/1.6/Agent-3"/></rdfs:subClassOf> -->
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/Project" vs:term_status="testing" rdfs:label="Project" rdfs:comment="A project (a collective endeavour of some kind).">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+<!--    <rdfs:subClassOf><owl:Class rdf:about="http://xmlns.com/wordnet/1.6/Project"/></rdfs:subClassOf> -->
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+<!-- arguably a subclass of Agent; to be discussed -->
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/Image" vs:term_status="testing" rdfs:label="Image" rdfs:comment="An image.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+<!--    <rdfs:subClassOf><owl:Class rdf:about="http://xmlns.com/wordnet/1.6/Document"/></rdfs:subClassOf> -->
+    <rdfs:subClassOf><owl:Class rdf:about="http://xmlns.com/foaf/0.1/Document"/></rdfs:subClassOf>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdfs:Class>
+
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/PersonalProfileDocument" rdfs:label="PersonalProfileDocument" rdfs:comment="A personal profile RDF document." vs:term_status="testing">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+  </rdfs:Class>
+	
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/OnlineAccount" vs:term_status="testing" rdfs:label="Online Account" rdfs:comment="An online account.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing" rdfs:label="Thing"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/OnlineGamingAccount" vs:term_status="unstable" rdfs:label="Online Gaming Account" rdfs:comment="An online gaming account.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/OnlineAccount"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/OnlineEcommerceAccount" vs:term_status="unstable" rdfs:label="Online E-commerce Account" rdfs:comment="An online e-commerce account.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/OnlineAccount"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://xmlns.com/foaf/0.1/OnlineChatAccount" vs:term_status="unstable" rdfs:label="Online Chat Account" rdfs:comment="An online chat account.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/OnlineAccount"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdfs:Class>
+<!-- FOAF properties (ie. relationships). -->
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/mbox" vs:term_status="stable" rdfs:label="personal mailbox" rdfs:comment="A 
+personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox. This is a 'static inverse functional property', in that  there is (across time and change) at most one individual that ever has any particular value for foaf:mbox.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/mbox_sha1sum" vs:term_status="testing" rdfs:label="sha1sum of a personal mailbox URI name" rdfs:comment="The sha1sum of the URI of an Internet mailbox associated with exactly one owner, the  first owner of the mailbox.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+
+<!--
+put it back in again 2006-01-29 - see 
+http://chatlogs.planetrdf.com/swig/2006-01-29.html#T21-12-35
+I have mailed rdfweb-dev@vapours.rdfweb.org for discussion.
+Libby
+
+Commenting out as a kindness to OWL DL users. The semantics didn't quite cover
+our usage anyway, since (a) we want static-across-time, which is so beyond OWL as 
+to be from another planet (b) we want identity reasoning invariant across xml:lang 
+tagging. FOAF code will know what to do. OWL folks note, this assertion might return. 
+
+danbri
+-->
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/gender" vs:term_status="testing" 
+rdfs:label="gender" 
+rdfs:comment="The gender of this Agent (typically but not necessarily 'male' or 'female').">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <!-- whatever one's gender is, and we are liberal in leaving room for more options 
+    than 'male' and 'female', we model this so that an agent has only one gender. -->
+  </rdf:Property>
+
+
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/geekcode" vs:term_status="archaic" rdfs:label="geekcode" rdfs:comment="A textual geekcode for this person, see http://www.geekcode.com/geek.html">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/dnaChecksum" vs:term_status="archaic" rdfs:label="DNA checksum" rdfs:comment="A checksum for the DNA of some thing. Joke.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/sha1" vs:term_status="unstable" rdfs:label="sha1sum (hex)" rdfs:comment="A sha1sum hash, in hex.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+<!-- rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty" -->
+<!-- IFP under discussion -->
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/based_near" vs:term_status="testing" rdfs:label="based near" rdfs:comment="A location that something is based near, for some broadly human notion of near.">
+<!-- see http://esw.w3.org/topic/GeoOnion for extension  ideas -->
+<!-- this was ranged as Agent... hmm -->
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+<!-- FOAF naming properties -->
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/title" vs:term_status="testing" rdfs:label="title" rdfs:comment="Title (Mr, Mrs, Ms, Dr. etc)">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/nick" vs:term_status="testing" rdfs:label="nickname" rdfs:comment="A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames).">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+<!-- ......................... chat IDs ........................... -->
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/jabberID" vs:term_status="testing" rdfs:label="jabber ID" rdfs:comment="A jabber ID for something.">
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+<!--
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/nick"/>
+...different to the other IM IDs, as Jabber has wider usage, so 
+we don't want the implied rdfs:domain here.
+
+-->
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <!-- there is a case for using resources/URIs here, ... -->
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/aimChatID" vs:term_status="testing" rdfs:label="AIM chat ID" rdfs:comment="An AIM chat ID">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/nick"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/skypeID" vs:term_status="testing" rdfs:label="Skype ID" rdfs:comment="A Skype ID">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/nick"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <!-- todo: OWL2 easy key definition -->
+  </rdf:Property>
+
+<!-- http://www.stud.uni-karlsruhe.de/~uck4/ICQ/Packet-112.html -->
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/icqChatID" vs:term_status="testing" rdfs:label="ICQ chat ID" rdfs:comment="An ICQ chat ID">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/nick"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/yahooChatID" vs:term_status="testing" rdfs:label="Yahoo chat ID" rdfs:comment="A Yahoo chat ID">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/nick"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/msnChatID" vs:term_status="testing" rdfs:label="MSN chat ID" rdfs:comment="An MSN chat ID">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/nick"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+  </rdf:Property>
+<!-- ....................................................... -->
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/name" vs:term_status="testing" rdfs:label="name" rdfs:comment="A name for some thing.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/firstName" vs:term_status="testing" rdfs:label="firstName" rdfs:comment="The first name of a person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/lastName" vs:term_status="testing" rdfs:label="lastName" rdfs:comment="The last name of a person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/givenName" vs:term_status="testing" rdfs:label="Given name" rdfs:comment="The given name of some person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/givenname" vs:term_status="archaic" rdfs:label="Given name" rdfs:comment="The given name of some person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/surname" vs:term_status="archaic" rdfs:label="Surname" rdfs:comment="The surname of some person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/family_name" vs:term_status="archaic" rdfs:label="family_name" rdfs:comment="The family name of some person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/familyName" vs:term_status="testing" rdfs:label="familyName" rdfs:comment="The family name of some person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+<!-- end of naming properties. See http://rdfweb.org/issues/show_bug.cgi?id=7
+	   for open issue / re-design discussions.
+	-->
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/phone" vs:term_status="testing" rdfs:label="phone" rdfs:comment="A phone,  specified using fully qualified tel: URI scheme (refs: http://www.w3.org/Addressing/schemes.html#tel).">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/homepage" vs:term_status="stable" rdfs:label="homepage" rdfs:comment="A homepage for some thing.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/page"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/isPrimaryTopicOf"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+    <!--  previously: rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent" -->
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/weblog" vs:term_status="testing" rdfs:label="weblog" rdfs:comment="A weblog of some thing (whether person, group, company etc.).">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/page"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/openid" vs:term_status="testing" rdfs:label="openid" rdfs:comment="An OpenID for an Agent.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/isPrimaryTopicOf"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/tipjar" vs:term_status="testing" rdfs:label="tipjar" rdfs:comment="A tipjar document for this agent, describing means for payment and reward.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/page"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/plan" vs:term_status="testing" rdfs:label="plan" rdfs:comment="A .plan comment, in the tradition of finger and '.plan' files.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/made" vs:term_status="stable" rdfs:label="made" rdfs:comment="Something that was made by this agent.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <owl:inverseOf rdf:resource="http://xmlns.com/foaf/0.1/maker"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/maker"  vs:term_status="stable" rdfs:label="maker" rdfs:comment="An agent that 
+made this thing.">
+    <owl:equivalentProperty rdf:resource="http://purl.org/dc/terms/creator"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <owl:inverseOf rdf:resource="http://xmlns.com/foaf/0.1/made"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/img" vs:term_status="testing" rdfs:label="image" rdfs:comment="An image that can be used to represent some thing (ie. those depictions which are particularly representative of something, eg. one's photo on a homepage).">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Image"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/depiction"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/depiction" vs:term_status="testing" rdfs:label="depiction" rdfs:comment="A depiction of some thing.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Image"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <owl:inverseOf rdf:resource="http://xmlns.com/foaf/0.1/depicts"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/depicts" vs:term_status="testing" rdfs:label="depicts" rdfs:comment="A thing depicted in this representation.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Image"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <owl:inverseOf rdf:resource="http://xmlns.com/foaf/0.1/depiction"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/thumbnail" vs:term_status="testing" rdfs:label="thumbnail" rdfs:comment="A derived thumbnail image.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Image"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Image"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/myersBriggs" vs:term_status="testing" rdfs:label="myersBriggs" rdfs:comment="A Myers Briggs (MBTI) personality classification.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/workplaceHomepage" vs:term_status="testing" rdfs:label="workplace homepage" rdfs:comment="A workplace homepage of some person; the homepage of an organization they work for.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/workInfoHomepage" vs:term_status="testing" rdfs:label="work info homepage" rdfs:comment="A work info homepage of some person; a page about their work for some organization.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/schoolHomepage" vs:term_status="testing" rdfs:label="schoolHomepage" rdfs:comment="A homepage of a school attended by the person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/knows" vs:term_status="stable" rdfs:label="knows" rdfs:comment="A person known by this person (indicating some level of reciprocated interaction between the parties).">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/interest" vs:term_status="testing" rdfs:label="interest" rdfs:comment="A page about a topic of interest to this person.">
+<!-- we should distinguish the page from the topic more carefully. danbri 2002-07-08 -->
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/topic_interest" vs:term_status="testing" rdfs:label="topic_interest" rdfs:comment="A thing of interest to this person.">
+<!-- we should distinguish the page from the topic more carefully. danbri 2002-07-08 -->
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/publications" vs:term_status="testing" rdfs:label="publications" rdfs:comment="A link to the publications of this person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+<!-- by libby for ILRT mappings 2001-10-31 -->
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/currentProject" vs:term_status="testing" rdfs:label="current project" rdfs:comment="A current project this person works on.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/pastProject" vs:term_status="testing" rdfs:label="past project" rdfs:comment="A project this person has previously worked on.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/fundedBy" vs:term_status="archaic" rdfs:label="funded by" rdfs:comment="An organization funding a project or person.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/logo" vs:term_status="testing" rdfs:label="logo" rdfs:comment="A logo representing some thing.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/topic" vs:term_status="testing" rdfs:label="topic" rdfs:comment="A topic of some page or document.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <owl:inverseOf rdf:resource="http://xmlns.com/foaf/0.1/page"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"
+ vs:term_status="stable" rdfs:label="primary topic" rdfs:comment="The primary topic of some page or document.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <owl:inverseOf rdf:resource="http://xmlns.com/foaf/0.1/isPrimaryTopicOf"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/focus"  vs:term_status="testing" rdfs:label="focus" rdfs:comment="The underlying or 'focal' entity associated with some SKOS-described concept.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2004/02/skos/core#Concept" rdfs:label="Concept"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/isPrimaryTopicOf"
+ vs:term_status="stable" rdfs:label="is primary topic of" rdfs:comment="A document that this thing is the primary topic of.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/page"/>
+    <owl:inverseOf rdf:resource="http://xmlns.com/foaf/0.1/primaryTopic"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/page" vs:term_status="testing" rdfs:label="page" rdfs:comment="A page or document about this thing.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+    <owl:inverseOf rdf:resource="http://xmlns.com/foaf/0.1/topic"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/theme" vs:term_status="archaic" rdfs:label="theme" rdfs:comment="A theme.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/account" vs:term_status="testing" rdfs:label="account" rdfs:comment="Indicates an account held by this agent.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/OnlineAccount"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/holdsAccount" vs:term_status="archaic" rdfs:label="account" rdfs:comment="Indicates an account held by this agent.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/OnlineAccount"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/accountServiceHomepage" vs:term_status="testing" rdfs:label="account service homepage" rdfs:comment="Indicates a homepage of the service provide for this online account.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/OnlineAccount"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/accountName" vs:term_status="testing" rdfs:label="account name" rdfs:comment="Indicates the name (identifier) associated with this online account.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/OnlineAccount"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/member" vs:term_status="stable" rdfs:label="member" rdfs:comment="Indicates a member of a Group">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Group"/>
+    <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/membershipClass" vs:term_status="unstable" rdfs:label="membershipClass" rdfs:comment="Indicates the class of individuals that are a member of a Group">
+    <!-- maybe we should just use SPARQL or Rules, instead of trying to use OWL here -->
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+    <!-- Added to keep OWL DL from bluescreening. DON'T CROSS THE STREAMERS, etc. -->
+    <!-- This may get dropped if it means non-DL tools don't expose it as a real property.
+	 Should be fine though; I think only OWL stuff cares about AnnotationProperty.
+	 Dan									 -->
+
+<!--    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Group"/> prose only for now...-->
+<!--    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/> -->
+<!--    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Class"/> -->
+
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+
+  <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/birthday" vs:term_status="unstable" rdfs:label="birthday" rdfs:comment="The birthday of this Agent, represented in mm-dd string form, eg. '12-31'.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+  </rdf:Property>
+
+   <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/age" vs:term_status="unstable" rdfs:label="age" rdfs:comment="The age in years of some agent.">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+     <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+     <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+   </rdf:Property>
+
+   <rdf:Property rdf:about="http://xmlns.com/foaf/0.1/status" vs:term_status="unstable" rdfs:label="status" rdfs:comment="A string expressing what the user is happy for the general public (normally) to know about their current activity.">
+     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+     <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+     <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+   </rdf:Property>
+
+</rdf:RDF>
+

--- a/orcid-api-common/src/main/resources/org/orcid/api/common/writer/rdf/pav.rdf
+++ b/orcid-api-common/src/main/resources/org/orcid/api/common/writer/rdf/pav.rdf
@@ -1,0 +1,552 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="owl2html.xslt"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY pav "http://purl.org/pav/" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY prov "http://www.w3.org/ns/prov#" >
+    <!ENTITY foaf "http://xmlns.com/foaf/0.1/" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY pav1 "http://swan.mindinformatics.org/ontologies/1.2/pav/" >
+]>
+
+
+<rdf:RDF xmlns="&pav;"
+     xml:base="&pav;"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:prov="http://www.w3.org/ns/prov#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:pav1="http://swan.mindinformatics.org/ontologies/1.2/pav/"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:pav="http://purl.org/pav/"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="http://purl.org/pav/">
+        <prov:has_provenance rdf:resource="provenance.ttl" />
+        <rdfs:label xml:lang="en">Provenance, Authoring and Versioning (PAV)</rdfs:label>
+        <owl:versionInfo rdf:datatype="&xsd;string">2.1.1</owl:versionInfo>
+        <dct:modified rdf:datatype="&xsd;dateTime">2013-03-26T14:49:00Z</dct:modified>
+        <dc:contributor rdf:datatype="&xsd;string">Marco Ocana</dc:contributor>
+        <dc:creator rdf:datatype="&xsd;string">Paolo Ciccarese</dc:creator>
+        <dc:contributor rdf:datatype="&xsd;string">Stian Soiland-Reyes</dc:contributor>
+        <dct:format rdf:datatype="&xsd;string">application/rdf+xml</dct:format>
+        <dct:language rdf:datatype="&xsd;language">en</dct:language>
+        <dct:issued rdf:datatype="&xsd;dateTime">2013-03-27T16:03:24Z</dct:issued>
+        <dct:title xml:lang="en">PAV - Provenance, Authoring and Versioning</dct:title>
+        <rdfs:comment xml:lang="en">PAV is a lightweight ontology for tracking Provenance, Authoring and Versioning. PAV specializes the W3C provenance ontology PROV-O in order to describe authorship, curation and digital creation of online resources.
+
+This ontology describes the defined PAV properties and their usage. Note that PAV does not define any explicit classes or domain/ranges, as every property is meant to be used directly on the described online resource.</rdfs:comment>
+        <dc:description xml:lang="en">PAV supplies terms for distinguishing between the different roles of the agents contributing content in current web based systems: contributors, authors, curators and digital artifact creators. The ontology also provides terms for tracking provenance of digital entities that are published on the web and then accessed, transformed and consumed. In order to support broader interoperability, PAV specializes the general purpose W3C PROV provenance model (PROV-O).
+
+PAV distinguishes between the data related to the digital artifact - named Provenance - and those related to the actual knowledge creation and therefore to the intellectual property aspects – named Authoring. The Versioning axis describes the evolution of digital entities in time. 
+
+Using PAV, descriptions can define the Authors that originate or gave existence to the work that is expressed in the digital resource (pav:authoredBy); curators (pav:curatedBy) who are content specialists responsible for shaping the expression in an appropriate format, and contributors (super-property pav:contributedBy) that provided some help in conceiving the resource or in the expressed knowledge creation/extraction.
+
+These provenance aspects can be detailed with dates using pav:curatedOn, pav:authoredOn, etc. Further details about the creation activities, such as different authors contributing specific parts of the resource at different dates are out of scope for PAV and should be defined using vocabularies like PROV-O and additional intermediate entities to describe the different states. 
+
+For resources based on other resources, PAV allows specification of direct retrieval (pav:retrievedFrom), import through transformations (pav:importedFrom) and sources that were merely consulted (pav:sourceAccessedAt). These aspects can also define the agents responsible using pav:retrievedBy, pav:importedBy and pav:sourceAccessedBy. Version information can be specified using pav:previousVersion and pav:version. 
+
+The creation of the digital representation, for instance an RDF graph, can in many cases be different from the authorship of the knowledge, and in PAV this digital creation is specified using pav:createdBy, pav:createdWith and pav:createdOn. 
+
+PAV 2.1 updates PAV 2.0 with PROV-O specializations and more detailed descriptions of the defined terms. Note that PROV-O is not imported directly by this ontology as PAV can be used independent of PROV. PAV 2 is based on PAV 1.2 but in a new namespace ( http://purl.org/pav/ ). Terms compatible with 1.2 are indicated in this ontology using owl:equivalentProperty. 
+
+The ontology IRI http://purl.org/pav/ always resolve to the latest version of PAV 2. Particular versionIRIs such as http://purl.org/pav/2.1 can be used by clients to force imports of a particular version - note however that all terms are defined directly in the http://purl.org/pav/ namespace.
+
+The goal of PAV is to provide a lightweight, straight forward way to give the essential information about authorship, provenance and versioning, and therefore these properties are described directly on the published resource. As such, PAV does not define any classes or restrict domain/ranges, as all properties are applicable to any online resource.</dc:description>
+        <dc:description rdf:resource="http://pav-ontology.googlecode.com/svn/branches/2.1/images/pav-overview.svg" />
+        <rdfs:seeAlso rdf:resource="http://code.google.com/p/pav-ontology/"/>
+        <rdfs:seeAlso rdf:resource="http://pav-ontology.googlecode.com/svn/trunk/1.2/pav.owl"/>
+        <!--
+        <owl:imports rdf:resource="http://pav-ontology.googlecode.com/svn/trunk/1.2/pav.owl"/>
+        <owl:imports rdf:resource="http://www.w3.org/ns/prov#"/>
+        -->
+        <owl:versionIRI rdf:resource="&pav;2.1"/>
+        <rdfs:seeAlso rdf:resource="&pav;doc"/>
+        <owl:backwardCompatibleWith rdf:resource="&pav;2.0/"/>
+        <owl:priorVersion rdf:resource="&pav;2.0/"/>
+        <owl:backwardCompatibleWith rdf:resource="&pav;authoring/2.0/"/>
+        <owl:backwardCompatibleWith rdf:resource="&pav;provenance/2.0/"/>
+        <owl:backwardCompatibleWith rdf:resource="&pav;versioning/2.0/"/>
+        <dct:contributor rdf:resource="http://soiland-reyes.com/stian/#me"/>
+        <dct:publisher rdf:resource="http://swan.mindinformatics.org/"/>
+        <owl:incompatibleWith rdf:resource="http://swan.mindinformatics.org/ontologies/1.2/pav.owl"/>
+        <dct:license rdf:resource="http://www.apache.org/licenses/LICENSE-2.0"/>
+        <dct:creator rdf:resource="http://www.hcklab.org/foaf.rdf#me"/>
+        <dct:creator rdf:resource="http://www.paolociccarese.info/"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#"/>
+    </owl:Ontology>
+    
+
+
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.org/pav/authoredBy -->
+
+    <owl:ObjectProperty rdf:about="&pav;authoredBy">
+        <rdfs:label xml:lang="en">Authored by</rdfs:label>
+        <rdfs:comment xml:lang="en">An agent that originated or gave existence to the work that is expressed by the digital resource.
+
+The author of the content of a resource may be different from the creator of the resource representation (although they are often the same). See pav:createdBy for a discussion.
+
+The date of authoring can be expressed using pav:authoredOn - note however in the case of multiple authors that there is no relationship in PAV identifying which agent contributed when or what. If capturing such lineage is desired, it should be additionally expressed using activity-centric provenance vocabularies, for instance with prov:wasGeneratedBy and prov:qualifiedAssocation.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;authoredOn"/>
+        <rdfs:subPropertyOf rdf:resource="&pav;contributedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;createdBy"/>
+        <owl:equivalentProperty rdf:resource="&pav1;authoredBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/contributedBy -->
+
+    <owl:ObjectProperty rdf:about="&pav;contributedBy">
+        <rdfs:label xml:lang="en">Contributed by</rdfs:label>
+        <rdfs:comment xml:lang="en">The resource was contributed to by the given agent.
+
+The agent provided any sort of help in conceiving the work that is expressed by the digital artifact. Superproperty of pav:authoredBy and pav:curatedBy.
+
+Note that as pav:contributedBy identifies only agents that contributed to the work, knowledge or intellectual property, and not agents that made the digital artifact or representation (pav:createdBy), thus this property can be considered more precise than dct:contributor. See pav:createdBy for a discussion.
+
+The date of contribution can be expressed using pav:contributedOn - note however in the case of multiple contributors that there is no relationship in PAV identifying which agent contributed when or what. If capturing such lineage is desired, it should be additionally expressed using activity-centric provenance vocabularies, for instance with prov:wasGeneratedBy and prov:qualifiedAssocation.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;contributedOn"/>
+        <rdfs:seeAlso rdf:resource="&pav;createdBy"/>
+        <owl:equivalentProperty rdf:resource="&pav1;contributedBy"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasAttributedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/createdAt -->
+
+    <owl:ObjectProperty rdf:about="&pav;createdAt">
+        <rdfs:label xml:lang="en">Created at</rdfs:label>
+        <rdfs:comment xml:lang="en">The geo-location of the agents when creating the resource (pav:createdBy). For instance  a photographer takes a picture of the Eiffel Tower while standing in front of it.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;createdBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/createdBy -->
+
+    <owl:ObjectProperty rdf:about="&pav;createdBy">
+        <rdfs:label xml:lang="en">Created by</rdfs:label>
+        <rdfs:comment xml:lang="en">An agent primary responsible for making the digital artifact or resource representation.
+
+This property is distinct from forming the content, which is indicated with pav:contributedBy or its subproperties; pav:authoredBy, which identifies who authored the knowledge expressed by this resource; and pav:curatedBy, which identifies who curated the knowledge into its current form. 
+
+pav:createdBy is more specific than dct:createdBy - which might or might not be interpreted to cover this creator.
+
+For instance, the author wrote &apos;this species has bigger wings than normal&apos; in his log book. The curator, going through the log book and identifying important knowledge, formalizes this as &apos;locus perculus has wingspan &gt; 0.5m&apos;. The creator enters this knowledge as a digital resource in the knowledge system, thus creating the digital artifact (say as JSON, RDF, XML or HTML).
+
+A different example is a news article. pav:authoredBy indicates the journalist who wrote the article. pav:contributedBy can indicate the artist who added an illustration. pav:curatedBy can indicate the editor who made the article conform to the news paper&apos;s style. pav:createdBy can indicate who put the article on the web site.
+
+The software tool used by the creator to make the digital resource (say Protege, Wordpress or OpenOffice) can be indicated with pav:createdWith.
+
+The date the digital resource was created can be indicated with pav:createdOn.
+
+The location the agent was at when creating the digital resource can be made using pav:createdAt.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;authoredBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;createdAt"/>
+        <rdfs:seeAlso rdf:resource="&pav;createdOn"/>
+        <rdfs:seeAlso rdf:resource="&pav;curatedBy"/>
+        <owl:equivalentProperty rdf:resource="&pav1;createdBy"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasAttributedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/createdWith -->
+
+    <owl:ObjectProperty rdf:about="&pav;createdWith">
+        <rdfs:label xml:lang="en">Created with</rdfs:label>
+        <rdfs:comment xml:lang="en">The software/tool used by the creator (pav:createdBy) when making the digital resource, for instance a word processor or an annotation tool. A more independent software agent that creates the resource without direct interaction by a human creator should instead should instead by indicated using pav:createdBy.
+</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;createdBy"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasAttributedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/curatedBy -->
+
+    <owl:ObjectProperty rdf:about="&pav;curatedBy">
+        <rdfs:label xml:lang="en">Curated by</rdfs:label>
+        <rdfs:comment xml:lang="en">An agent specialist responsible for shaping the expression in an appropriate format. Often the primary agent responsible for ensuring the quality of the representation.
+
+The curator may be different from the creator of the author (pav:authoredBy) and the creator of the digital resource (pav:createdBy).  
+
+The date of curating can be expressed using pav:curatedOn - note however in the case of multiple curators that there is no relationship in PAV identifying which agent contributed when or what. If capturing such lineage is desired, it should be additionally expressed using activity-centric provenance vocabularies, for instance with prov:wasGeneratedBy and prov:qualifiedAssocation.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="&pav;contributedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;createdBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;curatedOn"/>
+        <owl:equivalentProperty rdf:resource="&pav1;curatedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/curates -->
+
+    <owl:ObjectProperty rdf:about="&pav;curates">
+        <rdfs:label xml:lang="en">Curates</rdfs:label>
+        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+        <rdfs:comment xml:lang="en">Provided for backwards compatibility with PAV 1.2 only. Use instead the inverse pav:curatedBy.</rdfs:comment>
+        <owl:inverseOf rdf:resource="&pav;curatedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/derivedFrom -->
+
+    <owl:ObjectProperty rdf:about="&pav;derivedFrom">
+        <rdfs:label xml:lang="en">Derived from</rdfs:label>
+        <rdfs:comment xml:lang="en">Derived from a different resource. Derivation conserns itself with derived knowledge. If this resource has the same content as the other resource, but has simply been transcribed to fit a different model (like XML -&gt; RDF or SQL -&gt; CVS), use pav:importedFrom. If a resource was simply retrieved, use pav:retrievedFrom. If the content has however been further refined or modified, pav:derivedFrom should be used.
+
+Details about who performed the derivation may be indicated with pav:contributedBy and its subproperties.
+</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;importedFrom"/>
+        <rdfs:seeAlso rdf:resource="&pav;previousVersion"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasDerivedFrom"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/importedBy -->
+
+    <owl:ObjectProperty rdf:about="&pav;importedBy">
+        <rdfs:label xml:lang="en">Imported by</rdfs:label>
+        <rdfs:comment xml:lang="en">An entity responsible for importing the data. 
+
+The importer is usually a software entity which has done the transcription from the original source. 
+Note that pav:importedBy may overlap with pav:createdWith.
+
+The source for the import should be given with pav:importedFrom. The time of the import should be given with pav:importedOn.
+
+See pav:importedFrom for a discussion of import vs. retrieve vs. derived.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;importedFrom"/>
+        <owl:equivalentProperty rdf:resource="&pav1;importedBy"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasAttributedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/importedFrom -->
+
+    <owl:ObjectProperty rdf:about="&pav;importedFrom">
+        <rdfs:label xml:lang="en">Imported from</rdfs:label>
+        <rdfs:comment xml:lang="en">The original source of imported information. 
+
+Import means that the content has been preserved, but transcribed somehow, for instance to fit a different representation model. Examples of import are when the original was JSON and the current resource is RDF, or where the original was an document scan, and this resource is the plain text found through OCR. 
+
+The imported resource does not have to be complete, but should be consistent with the knowledge conveyed by the original resource.
+
+If additional knowledge has been contributed, pav:derivedFrom would be more appropriate.
+
+If the resource has been copied verbatim from the original representation (e.g. downloaded), use pav:retrievedFrom.
+
+To indicate which agent(s) performed the import, use pav:importedBy. Use pav:importedOn to indicate when it happened. </rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;derivedFrom"/>
+        <rdfs:seeAlso rdf:resource="&pav;importedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;importedOn"/>
+        <rdfs:seeAlso rdf:resource="&pav;retrievedFrom"/>
+        <owl:equivalentProperty rdf:resource="&pav1;importedFromSource"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasDerivedFrom"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/previousVersion -->
+
+    <owl:ObjectProperty rdf:about="&pav;previousVersion">
+        <rdfs:label xml:lang="en">Previous version</rdfs:label>
+        <rdfs:comment xml:lang="en">The previous version of a resource in a lineage. For instance a news article updated to correct factual information would point to the previous version of the article with pav:previousVersion. If however the content has significantly changed so that the two resources no longer share lineage (say a new news article that talks about the same facts), they should be related using pav:derivedFrom.
+
+A version number of this resource can be provided using the data property pav:version.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;derivedFrom"/>
+        <rdfs:seeAlso rdf:resource="&pav;version"/>
+        <owl:equivalentProperty rdf:resource="&pav1;previousVersion"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasRevisionOf"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/providedBy -->
+
+    <owl:ObjectProperty rdf:about="&pav;providedBy">
+        <rdfs:label xml:lang="en">Provided by</rdfs:label>
+        <rdfs:comment xml:lang="en">The original provider of the encoded information (e.g. PubMed, UniProt, Science Commons).
+
+The provider might not coincide with the dct:publisher, which would describe the current publisher of the resource. For instance if the resource was retrieved, imported or derived from a source, that source was published by the original provider. pav:providedBy provides a shortcut to indicate the original provider on the new resource.  </rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&dct;publisher"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/retrievedBy -->
+
+    <owl:ObjectProperty rdf:about="&pav;retrievedBy">
+        <rdfs:label xml:lang="en">Retrieved by</rdfs:label>
+        <rdfs:comment xml:lang="en">An entity responsible for retrieving the data from an external source. 
+
+The retrieving agent is usually a software entity, which has done the retrieval from the original source without performing any transcription.
+
+The source that was retrieved should be given with pav:retrievedFrom. The time of the retrieval should be indicated using pav:retrievedOn.
+
+See pav:importedFrom for a discussion of import vs. retrieve vs. derived.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;importedFrom"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasAttributedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/retrievedFrom -->
+
+    <owl:ObjectProperty rdf:about="&pav;retrievedFrom">
+        <rdfs:label xml:lang="en">Retrieved from</rdfs:label>
+        <rdfs:comment xml:lang="en">The URI where a resource has been retrieved from.
+
+Retrieval indicates that this resource has the same representation as the original resource. If the resource has been somewhat transformed, use pav:importedFrom instead.
+
+The time of the retrieval should be indicated using pav:retrievedOn. The agent may be indicated with pav:retrievedBy.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;retrievedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;retrievedOn"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasDerivedFrom"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/sourceAccessedAt -->
+
+    <owl:ObjectProperty rdf:about="&pav;sourceAccessedAt">
+        <rdfs:label xml:lang="en">Source accessed at</rdfs:label>
+        <rdfs:comment xml:lang="en">The resource is related to a given source which was accessed or consulted (but not retrieved, imported or derived from). This access can be detailed with pav:sourceAccessedBy and pav:sourceAccessedOn.
+
+For instance, a curator (pav:curatedBy) might have consulted figures in a published paper to confirm that a dataset was correctly pav:importedFrom the paper&apos;s supplementary CSV file.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;importedFrom"/>
+        <rdfs:seeAlso rdf:resource="&pav;retrievedFrom"/>
+        <rdfs:seeAlso rdf:resource="&pav;sourceAccessedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;sourceAccessedOn"/>
+        <rdfs:seeAlso rdf:resource="&pav;sourceLastAccessedOn"/>
+        <rdfs:subPropertyOf rdf:resource="&prov;wasInfluencedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/pav/sourceAccessedBy -->
+
+    <owl:ObjectProperty rdf:about="&pav;sourceAccessedBy">
+        <rdfs:label xml:lang="en">Source accessed by</rdfs:label>
+        <rdfs:comment xml:lang="en">The resource is related to a source which was accessed or consulted 
+by the given agent. The source(s) should be specified using pav:sourceAccessedAt, and the time with pav:sourceAccessedOn.
+
+For instance, the given agent could be a curator (also pav:curatedBy) which consulted figures in a published paper to confirm that a dataset was correctly pav:importedFrom the paper&apos;s supplementary CSV file.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;sourceAccessedAt"/>
+    </owl:ObjectProperty>
+    
+
+
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.org/pav/authoredOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;authoredOn">
+        <rdfs:label xml:lang="en">Authored on</rdfs:label>
+        <rdfs:comment xml:lang="en">The date this resource was authored.
+
+pav:authoredBy gives the authoring agent.
+
+Note that pav:authoredOn is different from pav:createdOn, although they are often the same. See pav:createdBy for a discussion.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;authoredBy"/>
+        <rdfs:subPropertyOf rdf:resource="&pav;contributedOn"/>
+        <rdfs:seeAlso rdf:resource="&pav;createdBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;createdOn"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/contributedOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;contributedOn">
+        <rdfs:label xml:lang="en">Contributed on</rdfs:label>
+        <rdfs:comment xml:lang="en">The date this resource was contributed to.
+
+pav:contributedBy provides the agent(s) that contributed.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;contributedBy"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/createdOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;createdOn">
+        <rdfs:label xml:lang="en">Created On</rdfs:label>
+        <rdfs:comment xml:lang="en">The date of creation of the resource.
+
+pav:createdBy provides the agent(s) that created the resource.
+</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;createdBy"/>
+        <owl:equivalentProperty rdf:resource="&pav1;createdOn"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/curatedOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;curatedOn">
+        <rdfs:label xml:lang="en">Curated on</rdfs:label>
+        <rdfs:comment xml:lang="en">The date this resource was curated. 
+
+pav:curatedBy gives the agent(s) that performed the curation.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="&pav;contributedOn"/>
+        <rdfs:seeAlso rdf:resource="&pav;curatedBy"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/importedOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;importedOn">
+        <rdfs:label xml:lang="en">Imported on</rdfs:label>
+        <rdfs:comment xml:lang="en">The date this resource was imported from a source (pav:importedFrom). 
+
+Note that pav:importedOn may overlap with pav:createdOn, but in cases where they differ, the import time indicates the time of the retrieval and transcription of the original source, while the creation time indicates when the final resource was made, for instance after user approval.
+
+If the source is later reimported, this should be indicated with pav:lastRefreshedOn.
+
+The source of the import should be given with pav:importedFrom. The agent that performed the import should be given with pav:importedBy.
+
+See pav:importedFrom for a discussion about import vs. retrieval.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;importedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;importedFrom"/>
+        <owl:equivalentProperty rdf:resource="&pav1;importedOn"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/lastRefreshedOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;lastRefreshedOn">
+        <rdfs:label xml:lang="en">Last refreshed on</rdfs:label>
+        <rdfs:comment xml:lang="en">The date of the last re-import of the resource. This property is used in addition to pav:importedOn if this version has been updated due to a re-import. If the re-import created a new resource rather than refreshing an existing, then pav:importedOn should be used together with pav:previousVersion.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;importedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;importedFrom"/>
+        <rdfs:seeAlso rdf:resource="&pav;importedOn"/>
+        <rdfs:seeAlso rdf:resource="&pav;previousVersion"/>
+        <owl:equivalentProperty rdf:resource="&pav1;importedLastOn"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/lastUpdateOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;lastUpdateOn">
+        <rdfs:label xml:lang="en">Last updated on</rdfs:label>
+        <rdfs:comment xml:lang="en">The date of the last update of the resource. An update is a change which did not warrant making a new resource related using pav:previousVersion, for instance correcting a spelling mistake.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;createdOn"/>
+        <rdfs:seeAlso rdf:resource="&pav;previousVersion"/>
+        <owl:equivalentProperty rdf:resource="&pav1;lastUpdateOn"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/retrievedOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;retrievedOn">
+        <rdfs:label xml:lang="en">Retrieved on</rdfs:label>
+        <rdfs:comment xml:lang="en">The date the source for this resource was retrieved. 
+
+The source that was retrieved should be indicated with pav:retrievedFrom. The agent that performed the retrieval may be specified with pav:retrievedBy.
+</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;retrievedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;retrievedFrom"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/sourceAccessedOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;sourceAccessedOn">
+        <rdfs:label xml:lang="en">Source accessed on</rdfs:label>
+        <rdfs:comment xml:lang="en">The resource is related to a source which was originally accessed or consulted on the given date as part of creating or authoring the resource. The source(s) should be specified using pav:sourceAccessedAt. If the source is subsequently checked again (say to verify validity), this should be indicated with pav:sourceLastAccessedOn.
+
+In the case multiple sources being accessed at different times or by different agents, PAV does not distinguish who accessed when what. If such details are required, they may be provided by additionally using prov:qualifiedInfluence.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;createdAt"/>
+        <rdfs:seeAlso rdf:resource="&pav;sourceAccessedAt"/>
+        <rdfs:seeAlso rdf:resource="&pav;sourceAccessedBy"/>
+        <rdfs:seeAlso rdf:resource="&pav;sourceLastAccessedOn"/>
+        <owl:equivalentProperty rdf:resource="&pav1;sourceAccessedOn"/>
+        <owl:equivalentProperty rdf:resource="&pav1;sourceFirstAccessedOn"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/sourceLastAccessedOn -->
+
+    <owl:DatatypeProperty rdf:about="&pav;sourceLastAccessedOn">
+        <rdfs:label xml:lang="en">Source last accessed on</rdfs:label>
+        <rdfs:comment xml:lang="en">The resource is related to a source which was last accessed or consulted on the given date. The source(s) should be specified using pav:sourceAccessedAt. Usage of this property indicates that the source has been checked previously, which the initial time should be indicated with pav:sourceAccessedOn.
+
+This property can be useful together with pav:lastRefreshedOn or pav:lastUpdateOn in order to indicate a re-import or update, but could also be used alone, for instance when a source was simply verified and no further action was taken for the resource,</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;createdAt"/>
+        <rdfs:seeAlso rdf:resource="&pav;sourceAccessedAt"/>
+        <rdfs:seeAlso rdf:resource="&pav;sourceAccessedBy"/>
+        <owl:equivalentProperty rdf:resource="&pav1;sourceLastAccessedOn"/>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.org/pav/version -->
+
+    <owl:DatatypeProperty rdf:about="&pav;version">
+        <rdfs:label xml:lang="en">Version</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string">The version number of a resource. This is a freetext string, typical values are &quot;1.5&quot; or &quot;21&quot;. The URI identifying the previous version can be provided using prov:previousVersion.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="&pav;previousVersion"/>
+        <owl:equivalentProperty rdf:resource="&pav1;versionNumber"/>
+        <rdfs:range rdf:resource="&xsd;string"/>
+    </owl:DatatypeProperty>
+    
+
+
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.3.1957) http://owlapi.sourceforge.net -->
+

--- a/orcid-api-common/src/main/resources/org/orcid/api/common/writer/rdf/prov-o.rdf
+++ b/orcid-api-common/src/main/resources/org/orcid/api/common/writer/rdf/prov-o.rdf
@@ -1,0 +1,1788 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+]>
+
+
+<rdf:RDF xmlns="http://www.w3.org/ns/prov#"
+     xml:base="http://www.w3.org/ns/prov"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="http://www.w3.org/ns/prov-o#">
+        <rdfs:label xml:lang="en">W3C PROVenance Interchange Ontology (PROV-O)</rdfs:label>
+        <owl:versionInfo xml:lang="en">Recommendation version 2013-04-30</owl:versionInfo>
+        <rdfs:comment xml:lang="en">This document is published by the Provenance Working Group (http://www.w3.org/2011/prov/wiki/Main_Page). 
+
+If you wish to make comments regarding this document, please send them to public-prov-comments@w3.org (subscribe public-prov-comments-request@w3.org, archives http://lists.w3.org/Archives/Public/public-prov-comments/). All feedback is welcome.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/TR/prov-o/"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov"/>
+        <specializationOf rdf:resource="http://www.w3.org/ns/prov-o"/>
+        <wasRevisionOf rdf:resource="http://www.w3.org/ns/prov-o-20120312"/>
+        <owl:versionIRI rdf:resource="http://www.w3.org/ns/prov-o-20130430"/>
+    </owl:Ontology>
+    
+    <owl:Ontology rdf:about="http://www.w3.org/ns/prov#"/>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#unqualifiedForm">
+        <rdfs:comment xml:lang="en">Classes and properties used to qualify relationships are annotated with prov:unqualifiedForm to indicate the property used to assert an unqualified provenance relation.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="&rdfs;seeAlso"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#wasRevisionOf">
+        <rdfs:label>wasRevisionOf</rdfs:label>
+        <component>derivations</component>
+        <rdfs:comment xml:lang="en">A revision is a derivation that revises an entity into a revised version.</rdfs:comment>
+        <inverse>hadRevision</inverse>
+        <category>expanded</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Revision"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedRevision"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#aq">
+        <rdfs:subPropertyOf rdf:resource="&rdfs;seeAlso"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#sharesDefinitionWith">
+        <rdfs:subPropertyOf rdf:resource="&rdfs;seeAlso"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#definition">
+        <rdfs:comment xml:lang="en">A definition quoted from PROV-DM or PROV-CONSTRAINTS that describes the concept expressed with this OWL term.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#editorialNote">
+        <rdfs:comment xml:lang="en">A note by the OWL development team about how this term expresses the PROV-DM concept, or how it should be used in context of semantic web or linked data.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="&rdfs;label">
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#inverse">
+        <rdfs:comment xml:lang="en">PROV-O does not define all property inverses. The directionalities defined in PROV-O should be given preference over those not defined. However, if users wish to name the inverse of a PROV-O property, the local name given by prov:inverse should be used.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/TR/prov-o/#names-of-inverse-properties"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="&rdfs;comment">
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#constraints">
+        <rdfs:comment xml:lang="en">A reference to the principal section of the PROV-CONSTRAINTS document that describes this concept.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="&rdfs;seeAlso"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="&rdfs;seeAlso">
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="&owl;versionInfo"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#specializationOf">
+        <rdfs:label>specializationOf</rdfs:label>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-specialization</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-specialization</n>
+        <component>alternate</component>
+        <inverse>generalizationOf</inverse>
+        <category>expanded</category>
+        <definition xml:lang="en">An entity that is a specialization of another shares all aspects of the latter, and additionally presents more specific aspects of the same thing as the latter. In particular, the lifetime of the entity being specialized contains that of any specialization. Examples of aspects include a time period, an abstraction, and a context associated with the entity.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#alternateOf"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#dm">
+        <rdfs:comment xml:lang="en">A reference to the principal section of the PROV-DM document that describes this concept.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="&rdfs;seeAlso"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#category">
+        <rdfs:comment xml:lang="en">Classify prov-o terms into three categories, including &#39;starting-point&#39;, &#39;qualifed&#39;, and &#39;extended&#39;. This classification is used by the prov-o html document to gently introduce prov-o terms to its users. </rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#order">
+        <rdfs:comment xml:lang="en">The position that this OWL term should be listed within documentation. The scope of the documentation (e.g., among all terms, among terms within a prov:category, among properties applying to a particular class, etc.) is unspecified.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="&rdfs;isDefinedBy"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#editorsDefinition">
+        <rdfs:comment xml:lang="en">When the prov-o term does not have a definition drawn from prov-dm, and the prov-o editor provides one.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#definition"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#component">
+        <rdfs:comment xml:lang="en">Classify prov-o terms into six components according to prov-dm, including &#39;agents-responsibility&#39;, &#39;alternate&#39;, &#39;annotations&#39;, &#39;collections&#39;, &#39;derivations&#39;, and &#39;entities-activities&#39;. This classification is used so that readers of prov-o specification can find its correspondence with the prov-dm specification.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#qualifiedForm">
+        <rdfs:comment xml:lang="en">This annotation property links a subproperty of prov:wasInfluencedBy with the subclass of prov:Influence and the qualifying property that are used to qualify it. 
+
+Example annotation:
+
+    prov:wasGeneratedBy prov:qualifiedForm prov:qualifiedGeneration, prov:Generation .
+
+Then this unqualified assertion:
+
+    :entity1 prov:wasGeneratedBy :activity1 .
+
+can be qualified by adding:
+
+   :entity1 prov:qualifiedGeneration :entity1Gen .
+   :entity1Gen 
+       a prov:Generation, prov:Influence;
+       prov:activity :activity1;
+       :customValue 1337 .
+
+Note how the value of the unqualified influence (prov:wasGeneratedBy :activity1) is mirrored as the value of the prov:activity (or prov:entity, or prov:agent) property on the influence class.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="&rdfs;seeAlso"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#todo"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#n">
+        <rdfs:comment xml:lang="en">A reference to the principal section of the PROV-DM document that describes this concept.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="&rdfs;seeAlso"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/ns/prov#actedOnBehalfOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#actedOnBehalfOf">
+        <rdfs:label>actedOnBehalfOf</rdfs:label>
+        <component>agents-responsibility</component>
+        <inverse>hadDelegate</inverse>
+        <rdfs:comment xml:lang="en">An object property to express the accountability of an agent towards another agent. The subordinate agent acted on behalf of the responsible agent in an actual activity. </rdfs:comment>
+        <category>starting-point</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Delegation"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedDelegation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedDelegation"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#agent"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#activity -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#activity">
+        <rdfs:label>activity</rdfs:label>
+        <editorsDefinition>The prov:activity property references an prov:Activity which influenced a resource. This property applies to an prov:ActivityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent.</editorsDefinition>
+        <inverse>activityOfInfluence</inverse>
+        <editorialNote xml:lang="en">This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple.</editorialNote>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#ActivityInfluence"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#influencer"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#agent -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#agent">
+        <rdfs:label>agent</rdfs:label>
+        <editorsDefinition xml:lang="en">The prov:agent property references an prov:Agent which influenced a resource. This property applies to an prov:AgentInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent.</editorsDefinition>
+        <inverse>agentOfInfluence</inverse>
+        <editorialNote xml:lang="en">This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple.</editorialNote>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#AgentInfluence"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#influencer"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#alternateOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#alternateOf">
+        <rdfs:label>alternateOf</rdfs:label>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-alternate</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-alternate</n>
+        <definition xml:lang="en">Two alternate entities present aspects of the same thing. These aspects may be the same or different, and the alternate entities may or may not overlap in time.</definition>
+        <category>expanded</category>
+        <component>alternate</component>
+        <inverse>alternateOf</inverse>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#specializationOf"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#atLocation -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#atLocation">
+        <rdfs:label>atLocation</rdfs:label>
+        <rdfs:comment xml:lang="en">The Location of any resource.</rdfs:comment>
+        <inverse>locationOf</inverse>
+        <editorialNote xml:lang="en">The naming of prov:atLocation parallels prov:atTime, and is not named prov:hadLocation to avoid conflicting with the convention that prov:had* properties are used on prov:Influence classes.</editorialNote>
+        <rdfs:comment>This property has multiple RDFS domains to suit multiple OWL Profiles. See &lt;a href=&quot;#owl-profile&quot;&gt;PROV-O OWL Profile&lt;/a&gt;.</rdfs:comment>
+        <editorialNote xml:lang="en">This property is not functional because the many values could be at a variety of granularies (In this building, in this room, in that chair).</editorialNote>
+        <category>expanded</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Location"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Location"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Activity"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Agent"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Entity"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#entity -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#entity">
+        <rdfs:label>entity</rdfs:label>
+        <editorsDefinition>The prov:entity property references an prov:Entity which influenced a resource. This property applies to an prov:EntityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent.</editorsDefinition>
+        <inverse>entityOfInfluence</inverse>
+        <editorialNote xml:lang="en">This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple.</editorialNote>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#EntityInfluence"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#influencer"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#generated -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#generated">
+        <rdfs:label>generated</rdfs:label>
+        <component>entities-activities</component>
+        <inverse>wasGeneratedBy</inverse>
+        <category>expanded</category>
+        <editorialNote xml:lang="en">prov:generated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions.</editorialNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Generation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#influenced"/>
+        <owl:inverseOf rdf:resource="http://www.w3.org/ns/prov#wasGeneratedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#hadActivity -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#hadActivity">
+        <rdfs:label>hadActivity</rdfs:label>
+        <rdfs:comment>This property has multiple RDFS domains to suit multiple OWL Profiles. See &lt;a href=&quot;#owl-profile&quot;&gt;PROV-O OWL Profile&lt;/a&gt;.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The _optional_ Activity of an Influence, which used, generated, invalidated, or was the responsibility of some Entity. This property is _not_ used by ActivityInfluence (use prov:activity instead).</rdfs:comment>
+        <editorialNote xml:lang="en">The multiple rdfs:domain assertions are intended. One is simpler and works for OWL-RL, the union is more specific but is not recognized by OWL-RL.</editorialNote>
+        <component>derivations</component>
+        <category>qualified</category>
+        <inverse>wasActivityOfInfluence</inverse>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Delegation"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Derivation"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#End"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Start"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#hadGeneration -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#hadGeneration">
+        <rdfs:label>hadGeneration</rdfs:label>
+        <inverse>generatedAsDerivation</inverse>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">The _optional_ Generation involved in an Entity&#39;s Derivation.</rdfs:comment>
+        <component>derivations</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Derivation"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Generation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Generation"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#hadMember -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#hadMember">
+        <rdfs:label>hadMember</rdfs:label>
+        <category>expanded</category>
+        <component>expanded</component>
+        <inverse>wasMemberOf</inverse>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Collection"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Collection"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <rdfs:comment xml:lang="en">A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections.</rdfs:comment>
+        <dm>http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection</dm>
+        <owl:annotatedProperty rdf:resource="&rdfs;range"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#hadMember"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#hadPlan -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#hadPlan">
+        <rdfs:label>hadPlan</rdfs:label>
+        <category>qualified</category>
+        <component>agents-responsibility</component>
+        <inverse>wasPlanOf</inverse>
+        <rdfs:comment xml:lang="en">The _optional_ Plan adopted by an Agent in Association with some Activity. Plan specifications are out of the scope of this specification.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Association"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Plan"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Plan"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#hadPrimarySource -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#hadPrimarySource">
+        <rdfs:label>hadPrimarySource</rdfs:label>
+        <component>derivations</component>
+        <category>expanded</category>
+        <inverse>wasPrimarySourceOf</inverse>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#PrimarySource"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedPrimarySource"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedPrimarySource"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#entity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <rdfs:comment>hadPrimarySource property is a particular case of wasDerivedFrom (see http://www.w3.org/TR/prov-dm/#term-original-source) that aims to give credit to the source that originated some information.</rdfs:comment>
+        <owl:annotatedProperty rdf:resource="&rdfs;subPropertyOf"/>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#hadPrimarySource"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#hadRole -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#hadRole">
+        <rdfs:label>hadRole</rdfs:label>
+        <component>agents-responsibility</component>
+        <inverse>wasRoleIn</inverse>
+        <rdfs:comment>This property has multiple RDFS domains to suit multiple OWL Profiles. See &lt;a href=&quot;#owl-profile&quot;&gt;PROV-O OWL Profile&lt;/a&gt;.</rdfs:comment>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">The _optional_ Role that an Entity assumed in the context of an Activity. For example, :baking prov:used :spoon; prov:qualified [ a prov:Usage; prov:entity :spoon; prov:hadRole roles:mixing_implement ].</rdfs:comment>
+        <editorsDefinition xml:lang="en">prov:hadRole references the Role (i.e. the function of an entity with respect to an activity), in the context of an instantaneous usage, generation, association, start, and end.</editorsDefinition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Role"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Role"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Association"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#hadUsage -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#hadUsage">
+        <rdfs:label>hadUsage</rdfs:label>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">The _optional_ Usage involved in an Entity&#39;s Derivation.</rdfs:comment>
+        <inverse>wasUsedInDerivation</inverse>
+        <component>derivations</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Derivation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Usage"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Usage"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#influenced -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#influenced">
+        <rdfs:label>influenced</rdfs:label>
+        <inverse>wasInfluencedBy</inverse>
+        <component>agents-responsibility</component>
+        <category>expanded</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <owl:inverseOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#influencer -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#influencer">
+        <rdfs:label>influencer</rdfs:label>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence</dm>
+        <category>qualified</category>
+        <inverse>hadInfluence</inverse>
+        <rdfs:comment xml:lang="en">Subproperties of prov:influencer are used to cite the object of an unqualified PROV-O triple whose predicate is a subproperty of prov:wasInfluencedBy (e.g. prov:used, prov:wasGeneratedBy). prov:influencer is used much like rdf:object is used.</rdfs:comment>
+        <editorialNote xml:lang="en">This property and its subproperties are used in the same way as the rdf:object property, i.e. to reference the object of an unqualified prov:wasInfluencedBy or prov:influenced triple.</editorialNote>
+        <editorsDefinition xml:lang="en">This property is used as part of the qualified influence pattern. Subclasses of prov:Influence use these subproperties to reference the resource (Entity, Agent, or Activity) whose influence is being qualified.</editorsDefinition>
+        <rdfs:range rdf:resource="&owl;Thing"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#invalidated -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#invalidated">
+        <rdfs:label>invalidated</rdfs:label>
+        <category>expanded</category>
+        <inverse>wasInvalidatedBy</inverse>
+        <component>entities-activities</component>
+        <editorialNote xml:lang="en">prov:invalidated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions.</editorialNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Invalidation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#influenced"/>
+        <owl:inverseOf rdf:resource="http://www.w3.org/ns/prov#wasInvalidatedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedAssociation -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedAssociation">
+        <rdfs:label>qualifiedAssociation</rdfs:label>
+        <inverse>qualifiedAssociationOf</inverse>
+        <rdfs:comment xml:lang="en">If this Activity prov:wasAssociatedWith Agent :ag, then it can qualify the Association using prov:qualifiedAssociation [ a prov:Association;  prov:agent :ag; :foo :bar ].</rdfs:comment>
+        <component>agents-responsibility</component>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Association"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Association"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasAssociatedWith"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedAttribution -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedAttribution">
+        <rdfs:label>qualifiedAttribution</rdfs:label>
+        <inverse>qualifiedAttributionOf</inverse>
+        <category>qualified</category>
+        <component>agents-responsibility</component>
+        <rdfs:comment xml:lang="en">If this Entity prov:wasAttributedTo Agent :ag, then it can qualify how it was influenced using prov:qualifiedAttribution [ a prov:Attribution;  prov:agent :ag; :foo :bar ].</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Attribution"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Attribution"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasAttributedTo"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedCommunication -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedCommunication">
+        <rdfs:label>qualifiedCommunication</rdfs:label>
+        <inverse>qualifiedCommunicationOf</inverse>
+        <component>entities-activities</component>
+        <rdfs:comment xml:lang="en">If this Activity prov:wasInformedBy Activity :a, then it can qualify how it was influenced using prov:qualifiedCommunication [ a prov:Communication;  prov:activity :a; :foo :bar ].</rdfs:comment>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Communication"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Communication"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Communication"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedDelegation -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedDelegation">
+        <rdfs:label>qualifiedDelegation</rdfs:label>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">If this Agent prov:actedOnBehalfOf Agent :ag, then it can qualify how with prov:qualifiedResponsibility [ a prov:Responsibility;  prov:agent :ag; :foo :bar ].</rdfs:comment>
+        <inverse>qualifiedDelegationOf</inverse>
+        <component>agents-responsibility</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Delegation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Delegation"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#actedOnBehalfOf"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedDerivation -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedDerivation">
+        <rdfs:label>qualifiedDerivation</rdfs:label>
+        <component>derivations</component>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">If this Entity prov:wasDerivedFrom Entity :e, then it can qualify how it was derived using prov:qualifiedDerivation [ a prov:Derivation;  prov:entity :e; :foo :bar ].</rdfs:comment>
+        <inverse>qualifiedDerivationOf</inverse>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Derivation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Derivation"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedEnd -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedEnd">
+        <rdfs:label>qualifiedEnd</rdfs:label>
+        <category>qualified</category>
+        <inverse>qualifiedEndOf</inverse>
+        <component>entities-activities</component>
+        <rdfs:comment xml:lang="en">If this Activity prov:wasEndedBy Entity :e1, then it can qualify how it was ended using prov:qualifiedEnd [ a prov:End;  prov:entity :e1; :foo :bar ].</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#End"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#End"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasEndedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedGeneration -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedGeneration">
+        <rdfs:label>qualifiedGeneration</rdfs:label>
+        <inverse>qualifiedGenerationOf</inverse>
+        <component>entities-activities</component>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">If this Activity prov:generated Entity :e, then it can qualify how it performed the Generation using prov:qualifiedGeneration [ a prov:Generation;  prov:entity :e; :foo :bar ].</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Generation"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Generation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasGeneratedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedInfluence -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedInfluence">
+        <rdfs:label>qualifiedInfluence</rdfs:label>
+        <rdfs:comment xml:lang="en">Because prov:qualifiedInfluence is a broad relation, the more specific relations (qualifiedCommunication, qualifiedDelegation, qualifiedEnd, etc.) should be used when applicable.</rdfs:comment>
+        <category>qualified</category>
+        <inverse>qualifiedInfluenceOf</inverse>
+        <component>derivations</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Activity"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Agent"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Entity"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedInvalidation -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedInvalidation">
+        <rdfs:label>qualifiedInvalidation</rdfs:label>
+        <rdfs:comment xml:lang="en">If this Entity prov:wasInvalidatedBy Activity :a, then it can qualify how it was invalidated using prov:qualifiedInvalidation [ a prov:Invalidation;  prov:activity :a; :foo :bar ].</rdfs:comment>
+        <component>entities-activities</component>
+        <category>qualified</category>
+        <inverse>qualifiedInvalidationOf</inverse>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Invalidation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Invalidation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasInvalidatedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedPrimarySource -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedPrimarySource">
+        <rdfs:label>qualifiedPrimarySource</rdfs:label>
+        <rdfs:comment xml:lang="en">If this Entity prov:hadPrimarySource Entity :e, then it can qualify how using prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity :e; :foo :bar ].</rdfs:comment>
+        <component>derivations</component>
+        <category>qualified</category>
+        <inverse>qualifiedSourceOf</inverse>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#PrimarySource"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#PrimarySource"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#hadPrimarySource"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedQuotation -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedQuotation">
+        <rdfs:label>qualifiedQuotation</rdfs:label>
+        <category>qualified</category>
+        <inverse>qualifiedQuotationOf</inverse>
+        <rdfs:comment xml:lang="en">If this Entity prov:wasQuotedFrom Entity :e, then it can qualify how using prov:qualifiedQuotation [ a prov:Quotation;  prov:entity :e; :foo :bar ].</rdfs:comment>
+        <component>derivations</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Quotation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Quotation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasQuotedFrom"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedRevision -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedRevision">
+        <rdfs:label>qualifiedRevision</rdfs:label>
+        <rdfs:comment xml:lang="en">If this Entity prov:wasRevisionOf Entity :e, then it can qualify how it was revised using prov:qualifiedRevision [ a prov:Revision;  prov:entity :e; :foo :bar ].</rdfs:comment>
+        <category>qualified</category>
+        <inverse>revisedEntity</inverse>
+        <component>derivations</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Revision"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Revision"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasRevisionOf"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedStart -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedStart">
+        <rdfs:label>qualifiedStart</rdfs:label>
+        <inverse>qualifiedStartOf</inverse>
+        <category>qualified</category>
+        <component>entities-activities</component>
+        <rdfs:comment xml:lang="en">If this Activity prov:wasStartedBy Entity :e1, then it can qualify how it was started using prov:qualifiedStart [ a prov:Start;  prov:entity :e1; :foo :bar ].</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Start"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Start"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasStartedBy"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#qualifiedUsage -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#qualifiedUsage">
+        <rdfs:label>qualifiedUsage</rdfs:label>
+        <category>qualified</category>
+        <inverse>qualifiedUsingActivity</inverse>
+        <component>entities-activities</component>
+        <rdfs:comment xml:lang="en">If this Activity prov:used Entity :e, then it can qualify how it used it using prov:qualifiedUsage [ a prov:Usage; prov:entity :e; :foo :bar ].</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Usage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Usage"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#used"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#specializationOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#specializationOf">
+        <rdfs:label>specializationOf</rdfs:label>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-specialization</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-specialization</n>
+        <component>alternate</component>
+        <category>expanded</category>
+        <inverse>generalizationOf</inverse>
+        <definition xml:lang="en">An entity that is a specialization of another shares all aspects of the latter, and additionally presents more specific aspects of the same thing as the latter. In particular, the lifetime of the entity being specialized contains that of any specialization. Examples of aspects include a time period, an abstraction, and a context associated with the entity.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#alternateOf"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#alternateOf"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#used -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#used">
+        <rdfs:label>used</rdfs:label>
+        <inverse>wasUsedBy</inverse>
+        <rdfs:comment xml:lang="en">A prov:Entity that was used by this prov:Activity. For example, :baking prov:used :spoon, :egg, :oven .</rdfs:comment>
+        <category>starting-point</category>
+        <component>entities-activities</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Usage"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedUsage"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedUsage"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#entity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasAssociatedWith -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasAssociatedWith">
+        <rdfs:label>wasAssociatedWith</rdfs:label>
+        <component>agents-responsibility</component>
+        <inverse>wasAssociateFor</inverse>
+        <rdfs:comment xml:lang="en">An prov:Agent that had some (unspecified) responsibility for the occurrence of this prov:Activity.</rdfs:comment>
+        <category>starting-point</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Association"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedAssociation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedAssociation"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#agent"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasAttributedTo -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasAttributedTo">
+        <rdfs:label>wasAttributedTo</rdfs:label>
+        <component>agents-responsibility</component>
+        <category>starting-point</category>
+        <inverse>contributed</inverse>
+        <definition xml:lang="en">Attribution is the ascribing of an entity to an agent.</definition>
+        <rdfs:comment xml:lang="en">Attribution is the ascribing of an entity to an agent.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Attribution"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedAttribution"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedAttribution"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#agent"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <rdfs:comment>Attribution is a particular case of trace (see http://www.w3.org/TR/prov-dm/#concept-trace), in the sense that it links an entity to the agent that ascribed it.</rdfs:comment>
+        <definition>IF wasAttributedTo(e2,ag1,aAttr) holds, THEN wasInfluencedBy(e2,ag1) also holds. </definition>
+        <owl:annotatedProperty rdf:resource="&rdfs;subPropertyOf"/>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasAttributedTo"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasDerivedFrom -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasDerivedFrom">
+        <rdfs:label>wasDerivedFrom</rdfs:label>
+        <inverse>hadDerivation</inverse>
+        <definition xml:lang="en">A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity.</definition>
+        <category>starting-point</category>
+        <rdfs:comment xml:lang="en">The more specific subproperties of prov:wasDerivedFrom (i.e., prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource) should be used when applicable.</rdfs:comment>
+        <component>derivations</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Derivation"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedDerivation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedDerivation"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#entity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <rdfs:comment>Derivation is a particular case of trace (see http://www.w3.org/TR/prov-dm/#term-trace), since it links an entity to another entity that contributed to its existence.</rdfs:comment>
+        <owl:annotatedProperty rdf:resource="&rdfs;subPropertyOf"/>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasEndedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasEndedBy">
+        <rdfs:label>wasEndedBy</rdfs:label>
+        <category>expanded</category>
+        <component>entities-activities</component>
+        <rdfs:comment xml:lang="en">End is when an activity is deemed to have ended. An end may refer to an entity, known as trigger, that terminated the activity.</rdfs:comment>
+        <inverse>ended</inverse>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#End"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedEnd"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedEnd"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#entity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasGeneratedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasGeneratedBy">
+        <rdfs:label>wasGeneratedBy</rdfs:label>
+        <inverse>generated</inverse>
+        <category>starting-point</category>
+        <component>entities-activities</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Generation"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedGeneration"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedGeneration"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#activity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasInfluencedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasInfluencedBy">
+        <rdfs:label>wasInfluencedBy</rdfs:label>
+        <rdfs:comment xml:lang="en">Because prov:wasInfluencedBy is a broad relation, its more specific subproperties (e.g. prov:wasInformedBy, prov:actedOnBehalfOf, prov:wasEndedBy, etc.) should be used when applicable.</rdfs:comment>
+        <editorialNote xml:lang="en">The sub-properties of prov:wasInfluencedBy can be elaborated in more detail using the Qualification Pattern. For example, the binary relation :baking prov:used :spoon can be qualified by asserting :baking prov:qualifiedUsage [ a prov:Usage; prov:entity :spoon; prov:atLocation :kitchen ] .
+
+Subproperties of prov:wasInfluencedBy may also be asserted directly without being qualified.
+
+prov:wasInfluencedBy should not be used without also using one of its subproperties. 
+</editorialNote>
+        <rdfs:comment>This property has multiple RDFS domains to suit multiple OWL Profiles. See &lt;a href=&quot;#owl-profile&quot;&gt;PROV-O OWL Profile&lt;/a&gt;.</rdfs:comment>
+        <category>qualified</category>
+        <inverse>influenced</inverse>
+        <component>agents-responsibility</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedInfluence"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Activity"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Agent"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Entity"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Activity"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Agent"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Entity"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <definition>influencer: an identifier (o1) for an ancestor entity, activity, or agent that the former depends on;</definition>
+        <dm>http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence</dm>
+        <owl:annotatedProperty rdf:resource="&rdfs;range"/>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Activity"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Agent"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Entity"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    <owl:Axiom>
+        <definition>influencee: an identifier (o2) for an entity, activity, or agent; </definition>
+        <dm>http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence</dm>
+        <owl:annotatedProperty rdf:resource="&rdfs;domain"/>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Activity"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Agent"/>
+                    <rdf:Description rdf:about="http://www.w3.org/ns/prov#Entity"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasInformedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasInformedBy">
+        <rdfs:label>wasInformedBy</rdfs:label>
+        <inverse>informed</inverse>
+        <rdfs:comment xml:lang="en">An activity a2 is dependent on or informed by another activity a1, by way of some unspecified entity that is generated by a1 and used by a2.</rdfs:comment>
+        <category>starting-point</category>
+        <component>entities-activities</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Communication"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedCommunication"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedCommunication"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#activity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasInvalidatedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasInvalidatedBy">
+        <rdfs:label>wasInvalidatedBy</rdfs:label>
+        <component>entities-activities</component>
+        <inverse>invalidated</inverse>
+        <category>expanded</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Invalidation"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedInvalidation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedInvalidation"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#activity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasQuotedFrom -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasQuotedFrom">
+        <rdfs:label>wasQuotedFrom</rdfs:label>
+        <category>expanded</category>
+        <component>derivations</component>
+        <inverse>quotedAs</inverse>
+        <rdfs:comment xml:lang="en">An entity is derived from an original entity by copying, or &#39;quoting&#39;, some or all of it.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Quotation"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedQuotation"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedQuotation"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#entity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <rdfs:comment>Quotation is a particular case of derivation (see http://www.w3.org/TR/prov-dm/#term-quotation) in which an entity is derived from an original entity by copying, or &quot;quoting&quot;, some or all of it. </rdfs:comment>
+        <owl:annotatedProperty rdf:resource="&rdfs;subPropertyOf"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasQuotedFrom"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasRevisionOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasRevisionOf">
+        <rdfs:label>wasRevisionOf</rdfs:label>
+        <rdfs:comment xml:lang="en">A revision is a derivation that revises an entity into a revised version.</rdfs:comment>
+        <component>derivations</component>
+        <inverse>hadRevision</inverse>
+        <category>expanded</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Revision"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedRevision"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedRevision"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#entity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <rdfs:comment>Revision is a derivation (see http://www.w3.org/TR/prov-dm/#term-Revision). Moreover, according to 
+http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#term-Revision 23 April 2012 &#39;wasRevisionOf is a strict sub-relation of wasDerivedFrom since two entities e2 and e1 may satisfy wasDerivedFrom(e2,e1) without being a variant of each other.&#39;</rdfs:comment>
+        <owl:annotatedProperty rdf:resource="&rdfs;subPropertyOf"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/ns/prov#wasRevisionOf"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasStartedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/prov#wasStartedBy">
+        <rdfs:label>wasStartedBy</rdfs:label>
+        <inverse>started</inverse>
+        <category>expanded</category>
+        <component>entities-activities</component>
+        <rdfs:comment xml:lang="en">Start is when an activity is deemed to have started. A start may refer to an entity, known as trigger, that initiated the activity.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Start"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#qualifiedStart"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedStart"/>
+            <rdf:Description rdf:about="http://www.w3.org/ns/prov#entity"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/ns/prov#atTime -->
+
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/prov#atTime">
+        <rdfs:label>atTime</rdfs:label>
+        <component>entities-activities</component>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">The time at which an InstantaneousEvent occurred, in the form of xsd:dateTime.</rdfs:comment>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <sharesDefinitionWith rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#endedAtTime"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#generatedAtTime"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#invalidatedAtTime"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#startedAtTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#endedAtTime -->
+
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/prov#endedAtTime">
+        <rdfs:label>endedAtTime</rdfs:label>
+        <component>entities-activities</component>
+        <editorialNote xml:lang="en">It is the intent that the property chain holds: (prov:qualifiedEnd o prov:atTime) rdfs:subPropertyOf prov:endedAtTime.</editorialNote>
+        <rdfs:comment xml:lang="en">The time at which an activity ended. See also prov:startedAtTime.</rdfs:comment>
+        <category>starting-point</category>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#End"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#atTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#generatedAtTime -->
+
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/prov#generatedAtTime">
+        <rdfs:label>generatedAtTime</rdfs:label>
+        <category>expanded</category>
+        <component>entities-activities</component>
+        <editorialNote xml:lang="en">It is the intent that the property chain holds: (prov:qualifiedGeneration o prov:atTime) rdfs:subPropertyOf prov:generatedAtTime.</editorialNote>
+        <rdfs:comment xml:lang="en">The time at which an entity was completely created and is available for use.</rdfs:comment>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Generation"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#atTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#invalidatedAtTime -->
+
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/prov#invalidatedAtTime">
+        <rdfs:label>invalidatedAtTime</rdfs:label>
+        <editorialNote xml:lang="en">It is the intent that the property chain holds: (prov:qualifiedInvalidation o prov:atTime) rdfs:subPropertyOf prov:invalidatedAtTime.</editorialNote>
+        <category>expanded</category>
+        <rdfs:comment xml:lang="en">The time at which an entity was invalidated (i.e., no longer usable).</rdfs:comment>
+        <component>entities-activities</component>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Invalidation"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#atTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#startedAtTime -->
+
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/prov#startedAtTime">
+        <rdfs:label>startedAtTime</rdfs:label>
+        <category>starting-point</category>
+        <editorialNote xml:lang="en">It is the intent that the property chain holds: (prov:qualifiedStart o prov:atTime) rdfs:subPropertyOf prov:startedAtTime.</editorialNote>
+        <component>entities-activities</component>
+        <rdfs:comment xml:lang="en">The time at which an activity started. See also prov:endedAtTime.</rdfs:comment>
+        <rdfs:range rdf:resource="&xsd;dateTime"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Activity"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#Start"/>
+        <qualifiedForm rdf:resource="http://www.w3.org/ns/prov#atTime"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#value -->
+
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/prov#value">
+        <rdfs:label>value</rdfs:label>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-value</dm>
+        <category>expanded</category>
+        <editorialNote>The editor&#39;s definition comes from http://www.w3.org/TR/rdf-primer/#rdfvalue</editorialNote>
+        <definition xml:lang="en">Provides a value that is a direct representation of an entity.</definition>
+        <component>entities-activities</component>
+        <editorialNote xml:lang="en">This property serves the same purpose as rdf:value, but has been reintroduced to avoid some of the definitional ambiguity in the RDF specification (specifically, &#39;may be used in describing structured values&#39;).</editorialNote>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#Thing -->
+
+    <owl:Class rdf:about="&owl;Thing"/>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Activity -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Activity">
+        <rdfs:label>Activity</rdfs:label>
+        <owl:disjointWith rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Activity</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Activity</n>
+        <component>entities-activities</component>
+        <category>starting-point</category>
+        <definition>An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#ActivityInfluence -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#ActivityInfluence">
+        <rdfs:label>ActivityInfluence</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.w3.org/ns/prov#hadActivity"/>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:maxCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="http://www.w3.org/ns/prov#EntityInfluence"/>
+        <editorsDefinition xml:lang="en">ActivitiyInfluence is the capacity of an activity to have an effect on the character, development, or behavior of another by means of generation, invalidation, communication, or other.</editorsDefinition>
+        <rdfs:comment xml:lang="en">ActivityInfluence provides additional descriptions of an Activity&#39;s binary influence upon any other kind of resource. Instances of ActivityInfluence use the prov:activity property to cite the influencing Activity.</rdfs:comment>
+        <rdfs:comment xml:lang="en">It is not recommended that the type ActivityInfluence be asserted without also asserting one of its more specific subclasses.</rdfs:comment>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#activity"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Agent -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Agent">
+        <rdfs:label>Agent</rdfs:label>
+        <owl:disjointWith rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Agent</n>
+        <definition xml:lang="en">An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent&#39;s activity. </definition>
+        <category>starting-point</category>
+        <component>agents-responsibility</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#AgentInfluence -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#AgentInfluence">
+        <rdfs:label>AgentInfluence</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <editorsDefinition xml:lang="en">AgentInfluence is the capacity of an agent to have an effect on the character, development, or behavior of another by means of attribution, association, delegation, or other.</editorsDefinition>
+        <rdfs:comment xml:lang="en">AgentInfluence provides additional descriptions of an Agent&#39;s binary influence upon any other kind of resource. Instances of AgentInfluence use the prov:agent property to cite the influencing Agent.</rdfs:comment>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">It is not recommended that the type AgentInfluence be asserted without also asserting one of its more specific subclasses.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#agent"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Association -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Association">
+        <rdfs:label>Association</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#AgentInfluence"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association</n>
+        <component>agents-responsibility</component>
+        <rdfs:comment xml:lang="en">An instance of prov:Association provides additional descriptions about the binary prov:wasAssociatedWith relation from an prov:Activity to some prov:Agent that had some responsiblity for it. For example, :baking prov:wasAssociatedWith :baker; prov:qualifiedAssociation [ a prov:Association; prov:agent :baker; :foo :bar ].</rdfs:comment>
+        <category>qualified</category>
+        <definition xml:lang="en">An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasAssociatedWith"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Attribution -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Attribution">
+        <rdfs:label>Attribution</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#AgentInfluence"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribution</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribution</n>
+        <rdfs:comment xml:lang="en">An instance of prov:Attribution provides additional descriptions about the binary prov:wasAttributedTo relation from an prov:Entity to some prov:Agent that had some responsible for it. For example, :cake prov:wasAttributedTo :baker; prov:qualifiedAttribution [ a prov:Attribution; prov:entity :baker; :foo :bar ].</rdfs:comment>
+        <definition xml:lang="en">Attribution is the ascribing of an entity to an agent.
+
+When an entity e is attributed to agent ag, entity e was generated by some unspecified activity that in turn was associated to agent ag. Thus, this relation is useful when the activity is not known, or irrelevant.</definition>
+        <category>qualified</category>
+        <component>agents-responsibility</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasAttributedTo"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Bundle -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Bundle">
+        <rdfs:label>Bundle</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-bundle-entity</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-bundle-declaration</n>
+        <category>expanded</category>
+        <definition xml:lang="en">A bundle is a named set of provenance descriptions, and is itself an Entity, so allowing provenance of provenance to be expressed.</definition>
+        <rdfs:comment xml:lang="en">Note that there are kinds of bundles (e.g. handwritten letters, audio recordings, etc.) that are not expressed in PROV-O, but can be still be described by PROV-O.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Collection -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Collection">
+        <rdfs:label>Collection</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection</dm>
+        <component>collections</component>
+        <category>expanded</category>
+        <definition xml:lang="en">A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Communication -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Communication">
+        <rdfs:label>Communication</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#ActivityInfluence"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Communication</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-wasInformedBy</n>
+        <component>entities-activities</component>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">An instance of prov:Communication provides additional descriptions about the binary prov:wasInformedBy relation from an informed prov:Activity to the prov:Activity that informed it. For example, :you_jumping_off_bridge prov:wasInformedBy :everyone_else_jumping_off_bridge; prov:qualifiedCommunication [ a prov:Communication; prov:activity :everyone_else_jumping_off_bridge; :foo :bar ].</rdfs:comment>
+        <definition>Communication is the exchange of an entity by two activities, one activity using the entity generated by the other.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasInformedBy"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Delegation -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Delegation">
+        <rdfs:label>Delegation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#AgentInfluence"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-delegation</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-delegation</n>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">An instance of prov:Delegation provides additional descriptions about the binary prov:actedOnBehalfOf relation from a performing prov:Agent to some prov:Agent for whom it was performed. For example, :mixing prov:wasAssociatedWith :toddler . :toddler prov:actedOnBehalfOf :mother; prov:qualifiedDelegation [ a prov:Delegation; prov:entity :mother; :foo :bar ].</rdfs:comment>
+        <definition xml:lang="en">Delegation is the assignment of authority and responsibility to an agent (by itself or by another agent) to carry out a specific activity as a delegate or representative, while the agent it acts on behalf of retains some responsibility for the outcome of the delegated work.
+
+For example, a student acted on behalf of his supervisor, who acted on behalf of the department chair, who acted on behalf of the university; all those agents are responsible in some way for the activity that took place but we do not say explicitly who bears responsibility and to what degree.</definition>
+        <component>agents-responsibility</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#actedOnBehalfOf"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Derivation -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Derivation">
+        <rdfs:label>Derivation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#EntityInfluence"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Derivation</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#Derivation-Relation</n>
+        <definition xml:lang="en">A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity.</definition>
+        <component>derivations</component>
+        <rdfs:comment xml:lang="en">An instance of prov:Derivation provides additional descriptions about the binary prov:wasDerivedFrom relation from some derived prov:Entity to another prov:Entity from which it was derived. For example, :chewed_bubble_gum prov:wasDerivedFrom :unwrapped_bubble_gum; prov:qualifiedDerivation [ a prov:Derivation; prov:entity :unwrapped_bubble_gum; :foo :bar ].</rdfs:comment>
+        <rdfs:comment xml:lang="en">The more specific forms of prov:Derivation (i.e., prov:Revision, prov:Quotation, prov:PrimarySource) should be asserted if they apply.</rdfs:comment>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasDerivedFrom"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#EmptyCollection -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#EmptyCollection">
+        <rdfs:label xml:lang="en">EmptyCollection</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Collection"/>
+        <category>expanded</category>
+        <component>collections</component>
+        <definition xml:lang="en">An empty collection is a collection without members.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#End -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#End">
+        <rdfs:label>End</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#EntityInfluence"/>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-End</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-End</n>
+        <rdfs:comment xml:lang="en">An instance of prov:End provides additional descriptions about the binary prov:wasEndedBy relation from some ended prov:Activity to an prov:Entity that ended it. For example, :ball_game prov:wasEndedBy :buzzer; prov:qualifiedEnd [ a prov:End; prov:entity :buzzer; :foo :bar; prov:atTime &#39;2012-03-09T08:05:08-05:00&#39;^^xsd:dateTime ].</rdfs:comment>
+        <category>qualified</category>
+        <definition xml:lang="en">End is when an activity is deemed to have been ended by an entity, known as trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity&#39;s end. An end may refer to a trigger entity that terminated the activity, or to an activity, known as ender that generated the trigger.</definition>
+        <component>entities-activities</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasEndedBy"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Entity -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Entity">
+        <rdfs:label>Entity</rdfs:label>
+        <owl:disjointWith rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-entity</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Entity</n>
+        <component>entities-activities</component>
+        <definition xml:lang="en">An entity is a physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary. </definition>
+        <category>starting-point</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#EntityInfluence -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#EntityInfluence">
+        <rdfs:label>EntityInfluence</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Influence"/>
+        <editorsDefinition xml:lang="en">EntityInfluence is the capacity of an entity to have an effect on the character, development, or behavior of another by means of usage, start, end, derivation, or other. </editorsDefinition>
+        <rdfs:comment xml:lang="en">EntityInfluence provides additional descriptions of an Entity&#39;s binary influence upon any other kind of resource. Instances of EntityInfluence use the prov:entity property to cite the influencing Entity.</rdfs:comment>
+        <rdfs:comment xml:lang="en">It is not recommended that the type EntityInfluence be asserted without also asserting one of its more specific subclasses.</rdfs:comment>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#entity"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Generation -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Generation">
+        <rdfs:label>Generation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#ActivityInfluence"/>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Generation</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Generation</n>
+        <rdfs:comment xml:lang="en">An instance of prov:Generation provides additional descriptions about the binary prov:wasGeneratedBy relation from a generated prov:Entity to the prov:Activity that generated it. For example, :cake prov:wasGeneratedBy :baking; prov:qualifiedGeneration [ a prov:Generation; prov:activity :baking; :foo :bar ].</rdfs:comment>
+        <category>qualified</category>
+        <component>entities-activities</component>
+        <definition xml:lang="en">Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasGeneratedBy"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Influence -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Influence">
+        <rdfs:label>Influence</rdfs:label>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-influence</n>
+        <component>derivations</component>
+        <rdfs:comment xml:lang="en">An instance of prov:Influence provides additional descriptions about the binary prov:wasInfluencedBy relation from some influenced Activity, Entity, or Agent to the influencing Activity, Entity, or Agent. For example, :stomach_ache prov:wasInfluencedBy :spoon; prov:qualifiedInfluence [ a prov:Influence; prov:entity :spoon; :foo :bar ] . Because prov:Influence is a broad relation, the more specific relations (Communication, Delegation, End, etc.) should be used when applicable.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Because prov:Influence is a broad relation, its most specific subclasses (e.g. prov:Communication, prov:Delegation, prov:End, prov:Revision, etc.) should be used when applicable.</rdfs:comment>
+        <category>qualified</category>
+        <definition xml:lang="en">Influence is the capacity of an entity, activity, or agent to have an effect on the character, development, or behavior of another by means of usage, start, end, generation, invalidation, communication, derivation, attribution, association, or delegation.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasInfluencedBy"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#InstantaneousEvent -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#InstantaneousEvent">
+        <rdfs:label>InstantaneousEvent</rdfs:label>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#dfn-event</constraints>
+        <component>entities-activities</component>
+        <rdfs:comment xml:lang="en">An instantaneous event, or event for short, happens in the world and marks a change in the world, in its activities and in its entities. The term &#39;event&#39; is commonly used in process algebra with a similar meaning. Events represent communications or interactions; they are assumed to be atomic and instantaneous.</rdfs:comment>
+        <definition xml:lang="en">The PROV data model is implicitly based on a notion of instantaneous events (or just events), that mark transitions in the world. Events include generation, usage, or invalidation of entities, as well as starting or ending of activities. This notion of event is not first-class in the data model, but it is useful for explaining its other concepts and its semantics.</definition>
+        <category>qualified</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Invalidation -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Invalidation">
+        <rdfs:label>Invalidation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#ActivityInfluence"/>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Invalidation</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Invalidation</n>
+        <component>entities-activities</component>
+        <definition>Invalidation is the start of the destruction, cessation, or expiry of an existing entity by an activity. The entity is no longer available for use (or further invalidation) after invalidation. Any generation or usage of an entity precedes its invalidation.</definition>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">An instance of prov:Invalidation provides additional descriptions about the binary prov:wasInvalidatedBy relation from an invalidated prov:Entity to the prov:Activity that invalidated it. For example, :uncracked_egg prov:wasInvalidatedBy :baking; prov:qualifiedInvalidation [ a prov:Invalidation; prov:activity :baking; :foo :bar ].</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasInvalidatedBy"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Location -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Location">
+        <rdfs:label>Location</rdfs:label>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-location</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute</n>
+        <definition xml:lang="en">A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth.</definition>
+        <category>expanded</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#atLocation"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Organization -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Organization">
+        <rdfs:label>Organization</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types</n>
+        <definition>An organization is a social or legal institution such as a company, society, etc.</definition>
+        <category>expanded</category>
+        <component>agents-responsibility</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Person -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Person">
+        <rdfs:label>Person</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types</n>
+        <category>expanded</category>
+        <component>agents-responsibility</component>
+        <definition xml:lang="en">Person agents are people.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Plan -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Plan">
+        <rdfs:label>Plan</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Entity"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association</n>
+        <definition>A plan is an entity that represents a set of actions or steps intended by one or more agents to achieve some goals.</definition>
+        <category>expanded</category>
+        <rdfs:comment xml:lang="en">There exist no prescriptive requirement on the nature of plans, their representation, the actions or steps they consist of, or their intended goals. Since plans may evolve over time, it may become necessary to track their provenance, so plans themselves are entities. Representing the plan explicitly in the provenance can be useful for various tasks: for example, to validate the execution as represented in the provenance record, to manage expectation failures, or to provide explanations.</rdfs:comment>
+        <category>qualified</category>
+        <component>agents-responsibility</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#PrimarySource -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#PrimarySource">
+        <rdfs:label>PrimarySource</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Derivation"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-primary-source</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-original-source</n>
+        <category>qualified</category>
+        <component>derivations</component>
+        <definition xml:lang="en">A primary source for a topic refers to something produced by some agent with direct experience and knowledge about the topic, at the time of the topic&#39;s study, without benefit from hindsight.
+
+Because of the directness of primary sources, they &#39;speak for themselves&#39; in ways that cannot be captured through the filter of secondary sources. As such, it is important for secondary sources to reference those primary sources from which they were derived, so that their reliability can be investigated.
+
+A primary source relation is a particular case of derivation of secondary materials from their primary sources. It is recognized that the determination of primary sources can be up to interpretation, and should be done according to conventions accepted within the application&#39;s domain.</definition>
+        <rdfs:comment xml:lang="en">An instance of prov:PrimarySource provides additional descriptions about the binary prov:hadPrimarySource relation from some secondary prov:Entity to an earlier, primary prov:Entity. For example, :blog prov:hadPrimarySource :newsArticle; prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity :newsArticle; :foo :bar ] .</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#hadPrimarySource"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Quotation -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Quotation">
+        <rdfs:label>Quotation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Derivation"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-quotation</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-quotation</n>
+        <rdfs:comment xml:lang="en">An instance of prov:Quotation provides additional descriptions about the binary prov:wasQuotedFrom relation from some taken prov:Entity from an earlier, larger prov:Entity. For example, :here_is_looking_at_you_kid prov:wasQuotedFrom :casablanca_script; prov:qualifiedQuotation [ a prov:Quotation; prov:entity :casablanca_script; :foo :bar ].</rdfs:comment>
+        <component>derivations</component>
+        <category>qualified</category>
+        <definition xml:lang="en">A quotation is the repeat of (some or all of) an entity, such as text or image, by someone who may or may not be its original author. Quotation is a particular case of derivation.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasQuotedFrom"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Revision -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Revision">
+        <rdfs:label>Revision</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Derivation"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-revision</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Revision</n>
+        <component>derivations</component>
+        <category>qualified</category>
+        <definition xml:lang="en">A revision is a derivation for which the resulting entity is a revised version of some original. The implication here is that the resulting entity contains substantial content from the original. Revision is a particular case of derivation.</definition>
+        <rdfs:comment xml:lang="en">An instance of prov:Revision provides additional descriptions about the binary prov:wasRevisionOf relation from some newer prov:Entity to an earlier prov:Entity. For example, :draft_2 prov:wasRevisionOf :draft_1; prov:qualifiedRevision [ a prov:Revision; prov:entity :draft_1; :foo :bar ].</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasRevisionOf"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Role -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Role">
+        <rdfs:label>Role</rdfs:label>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-role</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute</n>
+        <definition xml:lang="en">A role is the function of an entity or agent with respect to an activity, in the context of a usage, generation, invalidation, association, start, and end.</definition>
+        <category>qualified</category>
+        <component>agents-responsibility</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#hadRole"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#SoftwareAgent -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#SoftwareAgent">
+        <rdfs:label>SoftwareAgent</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#Agent"/>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types</n>
+        <component>agents-responsibility</component>
+        <definition xml:lang="en">A software agent is running software.</definition>
+        <category>expanded</category>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Start -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Start">
+        <rdfs:label>Start</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#EntityInfluence"/>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Start</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Start</n>
+        <component>entities-activities</component>
+        <category>qualified</category>
+        <rdfs:comment xml:lang="en">An instance of prov:Start provides additional descriptions about the binary prov:wasStartedBy relation from some started prov:Activity to an prov:Entity that started it. For example, :foot_race prov:wasStartedBy :bang; prov:qualifiedStart [ a prov:Start; prov:entity :bang; :foo :bar; prov:atTime &#39;2012-03-09T08:05:08-05:00&#39;^^xsd:dateTime ] .</rdfs:comment>
+        <definition xml:lang="en">Start is when an activity is deemed to have been started by an entity, known as trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity&#39;s start. A start may refer to a trigger entity that set off the activity, or to an activity, known as starter, that generated the trigger.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#wasStartedBy"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#Usage -->
+
+    <owl:Class rdf:about="http://www.w3.org/ns/prov#Usage">
+        <rdfs:label>Usage</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#EntityInfluence"/>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/prov#InstantaneousEvent"/>
+        <constraints rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig</constraints>
+        <dm rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Usage</dm>
+        <n rdf:datatype="&xsd;anyURI">http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Usage</n>
+        <rdfs:comment xml:lang="en">An instance of prov:Usage provides additional descriptions about the binary prov:used relation from some prov:Activity to an prov:Entity that it used. For example, :keynote prov:used :podium; prov:qualifiedUsage [ a prov:Usage; prov:entity :podium; :foo :bar ].</rdfs:comment>
+        <definition xml:lang="en">Usage is the beginning of utilizing an entity by an activity. Before usage, the activity had not begun to utilize this entity and could not have been affected by the entity.</definition>
+        <category>qualified</category>
+        <component>entities-activities</component>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+        <unqualifiedForm rdf:resource="http://www.w3.org/ns/prov#used"/>
+    </owl:Class>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/ns/prov#EmptyCollection -->
+
+    <owl:NamedIndividual rdf:about="http://www.w3.org/ns/prov#EmptyCollection">
+        <rdfs:label xml:lang="en">EmptyCollection</rdfs:label>
+        <category>expanded</category>
+        <component>collections</component>
+        <definition xml:lang="en">An empty collection is a collection without members.</definition>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    </owl:NamedIndividual>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.1.0.20069) http://owlapi.sourceforge.net -->
+

--- a/orcid-api-common/src/test/java/org/orcid/api/common/writer/rdf/RDFWriterTest.java
+++ b/orcid-api-common/src/test/java/org/orcid/api/common/writer/rdf/RDFWriterTest.java
@@ -1,0 +1,106 @@
+/**
+ * =============================================================================
+ *
+ * ORCID (R) Open Source
+ * http://orcid.org
+ *
+ * Copyright (c) 2012-2013 ORCID, Inc.
+ * Licensed under an MIT-Style License (MIT)
+ * http://orcid.org/open-source-license
+ *
+ * This copyright and license information (including a link to the full license)
+ * shall be included in its entirety in all copies or substantial portion of
+ * the software.
+ *
+ * =============================================================================
+ */
+package org.orcid.api.common.writer.rdf;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.Test;
+import org.orcid.jaxb.model.message.ContactDetails;
+import org.orcid.jaxb.model.message.CreditName;
+import org.orcid.jaxb.model.message.Email;
+import org.orcid.jaxb.model.message.FamilyName;
+import org.orcid.jaxb.model.message.GivenNames;
+import org.orcid.jaxb.model.message.OrcidBio;
+import org.orcid.jaxb.model.message.OrcidMessage;
+import org.orcid.jaxb.model.message.OrcidProfile;
+import org.orcid.jaxb.model.message.OtherNames;
+import org.orcid.jaxb.model.message.PersonalDetails;
+
+//@RunWith(SpringJUnit4ClassRunner.class)
+//@ContextConfiguration(locations = { "classpath:orcid-t1-web-context.xml" })
+public class RDFWriterTest {
+
+    private RDFMessageBodyWriter rdfWriter = new RDFMessageBodyWriter();
+    
+    private OrcidMessage fakeBio() {
+        OrcidMessage orcidMessage = new OrcidMessage();
+        OrcidProfile orcidProfile1 = new OrcidProfile();
+        orcidProfile1.setOrcidId("http://orcid.example.com/000-1337");
+        orcidProfile1.setOrcid("000-1337");
+        OrcidBio bio = new OrcidBio();
+        orcidProfile1.setOrcidBio(bio);
+        PersonalDetails personal = new PersonalDetails();
+        bio.setPersonalDetails(personal);
+        personal.setFamilyName(new FamilyName("Doe"));
+        personal.setCreditName(new CreditName("John F Doe"));
+        personal.setGivenNames(new GivenNames("John"));
+        personal.setOtherNames(new OtherNames());
+        personal.getOtherNames().addOtherName("Johnny");
+        personal.getOtherNames().addOtherName("Mr Doe");
+
+        bio.setContactDetails(new ContactDetails());
+        bio.getContactDetails().setEmail(Arrays.asList(new Email("john@example.org"), new Email("doe@example.com")));
+
+        
+        orcidMessage.setOrcidProfile(orcidProfile1);
+        return orcidMessage;
+
+    }
+
+    @Test
+    public void writeRdfXML() throws Exception {
+        
+        ByteArrayOutputStream entityStream = new ByteArrayOutputStream(1024);
+
+        rdfWriter.writeTo(fakeBio(), OrcidMessage.class, null, null, new MediaType("application", "rdf+xml"), null, entityStream);
+        
+        String str = entityStream.toString("utf-8");
+        System.out.println(str);
+        assertTrue(str.contains("http://orcid.example.com/000-1337"));
+        assertTrue(str.contains("foaf:name>John F"));
+        assertTrue(str.contains("rdf:about"));
+        assertFalse(str.contains("subClassOf"));
+    }
+
+    @Test
+    public void writeTurte() throws Exception {
+        
+        ByteArrayOutputStream entityStream = new ByteArrayOutputStream(1024);
+        rdfWriter.writeTo(fakeBio(), OrcidMessage.class, null, null, new MediaType("text", "turtle"), null, entityStream);
+        
+        String str = entityStream.toString("utf-8");
+        System.out.println(str);
+        assertTrue(str.contains("<http://orcid.example.com/000-1337>"));
+        assertTrue(str.contains("foaf:Person"));
+        assertTrue(str.contains("foaf:name \"John F"));
+        assertFalse(str.contains("subClassOf"));
+    }
+
+    
+}

--- a/orcid-api-web/src/main/java/org/orcid/api/t2/server/T2OrcidApiServiceImpl.java
+++ b/orcid-api-web/src/main/java/org/orcid/api/t2/server/T2OrcidApiServiceImpl.java
@@ -16,6 +16,7 @@
  */
 package org.orcid.api.t2.server;
 
+import static org.orcid.api.common.OrcidApiConstants.APPLICATION_RDFXML;
 import static org.orcid.api.common.OrcidApiConstants.BIO_PATH;
 import static org.orcid.api.common.OrcidApiConstants.BIO_SEARCH_PATH;
 import static org.orcid.api.common.OrcidApiConstants.EXTERNAL_IDENTIFIER_PATH;
@@ -25,6 +26,8 @@ import static org.orcid.api.common.OrcidApiConstants.PROFILE_DELETE_PATH;
 import static org.orcid.api.common.OrcidApiConstants.PROFILE_GET_PATH;
 import static org.orcid.api.common.OrcidApiConstants.PROFILE_POST_PATH;
 import static org.orcid.api.common.OrcidApiConstants.STATUS_PATH;
+import static org.orcid.api.common.OrcidApiConstants.TEXT_N3;
+import static org.orcid.api.common.OrcidApiConstants.TEXT_TURTLE;
 import static org.orcid.api.common.OrcidApiConstants.VND_ORCID_JSON;
 import static org.orcid.api.common.OrcidApiConstants.VND_ORCID_XML;
 import static org.orcid.api.common.OrcidApiConstants.WEBHOOKS_PATH;
@@ -159,6 +162,40 @@ public class T2OrcidApiServiceImpl implements T2OrcidApiService<Response> {
         return serviceDelegator.findBioDetails(orcid);
     }
 
+    /**
+     * GETs the RDF Turtle representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF Turtle representation of the ORCID record
+     */
+    @Override
+    @GET
+    @Produces(value = { TEXT_N3, TEXT_TURTLE })
+    @Path(BIO_PATH)
+    public Response viewBioDetailsTurtle(@PathParam("orcid") String orcid) {
+        T2_GET_REQUESTS.inc();
+        return serviceDelegator.findBioDetails(orcid);
+    }
+
+    /**
+     * GETs the RDF/XML representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF/XML representation of the ORCID record
+     */
+    @Override
+    @GET
+    @Produces(value = { APPLICATION_RDFXML })
+    @Path(BIO_PATH)
+    public Response viewBioDetailsRdf(@PathParam("orcid") String orcid) {
+        T2_GET_REQUESTS.inc();
+        return serviceDelegator.findBioDetails(orcid);
+    }
+    
     /**
      * GETs the HTML representation of the ORCID external identifiers
      * 

--- a/orcid-api-web/src/test/java/org/orcid/api/t2/integration/T2OrcidApiClientImpl.java
+++ b/orcid-api-web/src/test/java/org/orcid/api/t2/integration/T2OrcidApiClientImpl.java
@@ -250,6 +250,32 @@ public class T2OrcidApiClientImpl implements T2OrcidApiService<ClientResponse> {
     }
 
     /**
+     * GETs the RDF/XML representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF/XML representation of the ORCID record
+     */
+    @Override
+    public ClientResponse viewBioDetailsRdf(@PathParam("orcid") String orcid) {
+        return orcidClientHelper.getClientResponse(UriBuilder.fromPath(BIO_PATH_NO_REGEX).build(orcid), APPLICATION_RDFXML);
+    }
+
+    /**
+     * GETs the RDF Turtle representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF Turtle representation of the ORCID record
+     */
+    @Override
+    public ClientResponse viewBioDetailsTurtle(@PathParam("orcid") String orcid) {
+        return orcidClientHelper.getClientResponse(UriBuilder.fromPath(BIO_PATH_NO_REGEX).build(orcid), TEXT_TURTLE);
+    }
+    
+    /**
      * GETs the HTML representation of the ORCID external identifiers
      * 
      * @param orcid

--- a/orcid-pub-web/pom.xml
+++ b/orcid-pub-web/pom.xml
@@ -32,6 +32,7 @@
             <artifactId>orcid-api-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>orcid-utils</artifactId>

--- a/orcid-pub-web/src/main/java/org/orcid/api/t1/server/T1OrcidApiServiceImpl.java
+++ b/orcid-pub-web/src/main/java/org/orcid/api/t1/server/T1OrcidApiServiceImpl.java
@@ -16,13 +16,22 @@
  */
 package org.orcid.api.t1.server;
 
-import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.Counter;
+import static org.orcid.api.common.OrcidApiConstants.APPLICATION_RDFXML;
+import static org.orcid.api.common.OrcidApiConstants.BIO_PATH;
+import static org.orcid.api.common.OrcidApiConstants.BIO_SEARCH_PATH;
+import static org.orcid.api.common.OrcidApiConstants.EXTERNAL_IDENTIFIER_PATH;
+import static org.orcid.api.common.OrcidApiConstants.ORCID_JSON;
+import static org.orcid.api.common.OrcidApiConstants.ORCID_XML;
+import static org.orcid.api.common.OrcidApiConstants.PROFILE_GET_PATH;
+import static org.orcid.api.common.OrcidApiConstants.STATUS_PATH;
+import static org.orcid.api.common.OrcidApiConstants.TEXT_N3;
+import static org.orcid.api.common.OrcidApiConstants.TEXT_TURTLE;
+import static org.orcid.api.common.OrcidApiConstants.VND_ORCID_JSON;
+import static org.orcid.api.common.OrcidApiConstants.VND_ORCID_XML;
+import static org.orcid.api.common.OrcidApiConstants.WORKS_PATH;
 
-import org.orcid.api.common.OrcidApiService;
-import org.orcid.api.common.delegator.OrcidApiServiceDelegator;
-import org.orcid.jaxb.model.message.OrcidMessage;
-import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Resource;
 import javax.ws.rs.GET;
@@ -33,10 +42,14 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.util.List;
-import java.util.Map;
 
-import static org.orcid.api.common.OrcidApiConstants.*;
+import org.orcid.api.common.OrcidApiService;
+import org.orcid.api.common.delegator.OrcidApiServiceDelegator;
+import org.orcid.jaxb.model.message.OrcidMessage;
+import org.springframework.stereotype.Component;
+
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Counter;
 
 /**
  * Copyright 2011-2012 ORCID
@@ -107,6 +120,40 @@ public class T1OrcidApiServiceImpl implements OrcidApiService<Response> {
     @Produces(value = { VND_ORCID_XML, ORCID_XML, MediaType.APPLICATION_XML })
     @Path(BIO_PATH)
     public Response viewBioDetailsXml(@PathParam("orcid") String orcid) {
+        T1_GET_REQUESTS.inc();
+        return serviceDelegator.findBioDetails(orcid);
+    }
+    
+    /**
+     * GETs the RDF/XML representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF/XML representation of the ORCID record
+     */
+    @Override
+    @GET
+    @Produces(value = { APPLICATION_RDFXML })
+    @Path(BIO_PATH)
+    public Response viewBioDetailsRdf(@PathParam("orcid") String orcid) {
+        T1_GET_REQUESTS.inc();
+        return serviceDelegator.findBioDetails(orcid);
+    }
+
+
+    /**
+     * GETs the RDF Turtle representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF Turtle representation of the ORCID record
+     */
+    @GET
+    @Produces(value = { TEXT_N3, TEXT_TURTLE })
+    @Path(BIO_PATH)
+    public Response viewBioDetailsTurtle(@PathParam("orcid") String orcid) {
         T1_GET_REQUESTS.inc();
         return serviceDelegator.findBioDetails(orcid);
     }

--- a/orcid-pub-web/src/test/java/org/orcid/api/t1/integration/T1OrcidApiClientImpl.java
+++ b/orcid-pub-web/src/test/java/org/orcid/api/t1/integration/T1OrcidApiClientImpl.java
@@ -72,6 +72,32 @@ public class T1OrcidApiClientImpl implements OrcidApiService<ClientResponse> {
     public ClientResponse viewBioDetailsXml(@PathParam("orcid") String orcid) {
         return orcidClientHelper.getClientResponse(UriBuilder.fromPath(BIO_PATH_NO_REGEX).build(orcid), VND_ORCID_XML);
     }
+    
+    /**
+     * GETs the RDF/XML representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF/XML representation of the ORCID record
+     */
+    @Override
+    public ClientResponse viewBioDetailsRdf(@PathParam("orcid") String orcid) {
+        return orcidClientHelper.getClientResponse(UriBuilder.fromPath(BIO_PATH_NO_REGEX).build(orcid), APPLICATION_RDFXML);
+    }
+
+    /**
+     * GETs the RDF Turtle representation of the ORCID record containing only the
+     * Biography details
+     * 
+     * @param orcid
+     *            the ORCID that corresponds to the user's record
+     * @return the RDF Turtle representation of the ORCID record
+     */
+    @Override
+    public ClientResponse viewBioDetailsTurtle(@PathParam("orcid") String orcid) {
+        return orcidClientHelper.getClientResponse(UriBuilder.fromPath(BIO_PATH_NO_REGEX).build(orcid), TEXT_TURTLE);
+    }
 
     /**
      * GETs the JSON representation of the ORCID record containing only the

--- a/pom.xml
+++ b/pom.xml
@@ -923,6 +923,11 @@ the software.
                 <version>2.13.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-core</artifactId>
+                <version>2.10.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
presents a simple FOAF profile for REST requests. Implemented by adding
org.orcid.api.common.writer.rdf.RDFMessageBodyWriter
and modified org.orcid.api.common.OrcidApiService<T>
to allow text/turtle and application/rdf-xml for viewBioDetailsRdf
by simply translating the XML JAXB bean into RDF. Thus existing
visibility checks etc. should work.

No write support from RDF is planned as it could get tricky if the RDF
contained additional statements that would have to be either thrown away
or stored somewhere per ORCID.

The implementations of OrcidApiService have been modified in both
orcid-pub-web and orcid-api-web -

TODO: Do we really need various methods like viewBioDetailsRdf and
viewBioDetailsJson, or just change them to have multiple @Produces ?

The remaining REST services have not yet been RDFized, doing this for
orcid-works requires some thoughts as to what existing vocabularies
and terms should be used - for instance BIBO ontology or simply
dcterms:bibliographicReferences etc.

Example of RDF document:

```
c:\Users\stain>curl -H "Accept: text/turtle" http://localhost:8080/orcid-pub-web/0000-0002-0222-5559
@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
@prefix prov:    <http://www.w3.org/ns/prov#> .
@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
@prefix pav:     <http://purl.org/pav/> .
@prefix owl:     <http://www.w3.org/2002/07/owl#> .
@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

<http://localhost:8080/orcid-web/0000-0002-0222-5559/orcid-profile>
      a       foaf:PersonalProfileDocument , foaf:OnlineAccount ;
      rdfs:label "0000-0002-0222-5559" ;
      pav:createdBy <http://localhost:8080/orcid-web/0000-0002-0222-5559> ;
      pav:createdOn "2013-05-24T16:14:43.885+01:00"^^xsd:dateTime ;
      pav:createdWith <http://orcid.org> ;
      pav:lastUpdateOn "2013-05-25T20:32:37.295+01:00"^^xsd:dateTime ;
      prov:generatedAtTime
              "2013-05-25T20:32:37.295+01:00"^^xsd:dateTime ;
      prov:wasAttributedTo
              <http://localhost:8080/orcid-web/0000-0002-0222-5559> ;
      foaf:accountName "0000-0002-0222-5559" ;
      foaf:accountServiceHomepage
              <http://orcid.org> ;
      foaf:maker <http://localhost:8080/orcid-web/0000-0002-0222-5559> ;
      foaf:primaryTopic <http://localhost:8080/orcid-web/0000-0002-0222-5559> .

<http://localhost:8080/orcid-web/0000-0002-0222-5559>
      a       foaf:Person , prov:Person ;
      rdfs:label "Johnnye Does" ;
      foaf:account <http://localhost:8080/orcid-web/0000-0002-0222-5559/orcid-profile> ;
      foaf:familyName "Doe" ;
      foaf:givenName "John" ;
      foaf:mbox <mailto:oldemail@example.com> , <mailto:otheremail@example.com> , <mailto:johndoe@example.com> ;
      foaf:name "Johnnye Does" ;
      foaf:page <http://homepage.example.com/> , <http://work.example.org/> ;
      foaf:plan """I am a very interesting person
with several lines
of biography""" ;
      foaf:publications <http://localhost:8080/orcid-pub-web/0000-0002-0222-5559/orcid-works> .
```

This corresponds to the XML:

```
c:\Users\stain>curl -H "Accept: application/xml" http://localhost:8080/orcid-pub-web/0000-0002-0222-5559
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<orcid-message xmlns="http://www.orcid.org/ns/orcid">
    <message-version>1.0.14</message-version>
    <orcid-profile type="user">
        <orcid>0000-0002-0222-5559</orcid>
        <orcid-id>http://localhost:8080/orcid-web/0000-0002-0222-5559</orcid-id>
        <orcid-history>
            <creation-method>website</creation-method>
            <submission-date>2013-05-24T16:14:43.885+01:00</submission-date>
            <last-modified-date>2013-05-25T20:32:37.295+01:00</last-modified-date>
            <claimed>true</claimed>
        </orcid-history>
        <orcid-bio>
            <personal-details>
                <given-names>John</given-names>
                <family-name>Doe</family-name>
                <credit-name>Johnnye Does</credit-name>
                <other-names>
                    <other-name>Old Johnny</other-name>
                </other-names>
            </personal-details>
            <biography>I am a very interesting person&#xD;
with several lines&#xD;
of biography</biography>
            <researcher-urls>
                <researcher-url>
                    <url-name></url-name>
                    <url>http://homepage.example.com/</url>
                </researcher-url>
                <researcher-url>
                    <url-name>Other</url-name>
                    <url>http://work.example.org/</url>
                </researcher-url>
            </researcher-urls>
            <contact-details>
                <email primary="false" current="true" verified="false" source="0000-0002-0222-5559">otheremail@example.com</email>
                <email primary="false" current="true" verified="false" source="0000-0002-0222-5559">oldemail@example.com</email>
                <email primary="true" current="true" verified="false">johndoe@example.com</email>
            </contact-details>
            <keywords>
                <keyword>some keywords, entered, here</keyword>
            </keywords>
            <affiliations/>
        </orcid-bio>
    </orcid-profile>
</orcid-message>
orcid.org/0000-0001-9842-9718
```
# RDF notes

Vocabularies:
- foaf:   http://xmlns.com/foaf/0.1/
- pav:    http://purl.org/pav/
- prov:   http://www.w3.org/ns/prov#

An ORCID (e.g. http://orcid.org/0000-0001-9842-9718 ) is presented as a
[http://xmlns.com/foaf/spec/#term_Person](foaf:Person), with
foaf:givenName, foaf:familyName, foaf:mbox, etc.

The ORCID identifier represents the person (and not his record) and
can be used directly in Linked Data for attribution and provenance.

The ORCID record is identified as
http://orcid.org/0000-0001-9842-9718/orcid-profile - in the REST
interface both of these URIs return the same RDF (and XML), but the
distinction is that the second identifies the ORCID record at orcid.org.

Thus creation date of the record,
[purl.org/pav/html#http://purl.org/pav/createdOn](pav:createdOn), is when
the user registered on ORCID (the submission-date in XML), and if the
record was created on the website, then the person is also listed as the
pav:createdBy, foaf:maker and prov:wasAttributedTo.

If the ORCID has been claimed, then this will be a
foaf:PersonalProfileDocument - this is only the case if the user has
actually claimed (and presumably curated) the ORCID record, even if it
was imported through the API.

See https://github.com/stain/ORCID-Source/tree/rdf for individual
commits.

Squashed commit of the following:

commit 1c8c57634d7f4f9fb1c3fcec5c018a962c10cd41
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Tue May 28 13:48:04 2013 +0100

```
RDF: dates for ORCID record modifications
```

commit 1a89cbb0946c12737f108f0d51638e918a6489e5
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Tue May 28 12:41:38 2013 +0100

```
provenance of ORCID account

(when was it last modified?)
```

commit ed2db405975df414abd9f2610ddd0b26ea7dd764
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Tue May 28 11:04:18 2013 +0100

```
RDF: publication link to XML repr rather than HTML
```

commit 1a91ed53ad75c8a7b8d179b13153f91bee6619ac
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Tue May 28 11:02:06 2013 +0100

```
RDF: Error representation (with relative URI). Publications.
```

commit 8744ea973f0351813f6545b1c6c336bf4bb7a107
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Sun May 26 11:37:34 2013 +0100

```
load pav and prov ontologies for provenance
```

commit 06057ab9b0230d9fdff843ac83bc9090df251faf
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Sat May 25 20:35:13 2013 +0100

```
Refactored methods per section of XML bean
```

commit 22c405d6b5603fdab7628413ffa6a973e7a0bebf
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 17:57:40 2013 +0100

```
orcid as foaf account
```

commit 490760fa344d473cf90cf1eaa7036c267b6eb51d
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 17:02:58 2013 +0100

```
Don't forget foaf:Person!
```

commit b6f91eb3629e7175a3643198c478a64a6f435e70
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 17:00:53 2013 +0100

```
Load FOAF separately and add as import (avoids printing all of foaf!)
```

commit cbfd2fc305800f991255717b5d49682f4a8a1eb1
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 16:47:29 2013 +0100

```
Tests for RDFMessageBodyWriter
```

commit db9db1a931bca2ddf0ab295f0de812ef55295fd1
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 16:47:11 2013 +0100

```
FOAF ontology
Downloaded from http://xmlns.com/foaf/0.1/ as application/rdf+xml
```

commit 4bab8c07b04629a8c16d3c06ae90f55792b19682
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 16:46:43 2013 +0100

```
Media Type done correctly
```

commit 01bd12546ac52bbeedf7f83344deb0527c4db2ae
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 16:26:03 2013 +0100

```
Removed orcid-api-rdf dependency
```

commit 226c9d6ab7d4ac5479d671f244fe49e715134185
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 16:24:49 2013 +0100

```
Remove silly debug exception :)
```

commit d08fac9ab358707c9a843be6a1c0b94cae48be40
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 16:24:29 2013 +0100

```
Moved RDFMessageBody to orcid-api-common
```

commit 6373e21f5b9cd5dd29b4a8e62b38a2cb6b46174c
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 14:02:34 2013 +0100

```
RDF: Charset versions of text/turtle and text/n3 separate
```

commit 3c5223952cc88498c14ba4024fdffab1307dbe19
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 14:02:06 2013 +0100

```
Load FOAF locally, and only once
```

commit f13be2f0b8f5c07ccbb17c1687111fb945ba6da5
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Fri May 24 10:37:40 2013 +0100

```
Include basedir and relativePath
```

commit 228a7ac6a2cd91b46576c80a958c8ab3e74c80a8
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 22:15:57 2013 +0100

```
Turtle support?
```

commit a6065516328e1d36990c0d81530500cbe9f12b3b
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 22:11:13 2013 +0100

```
Moved RDF writer to orcid-api-rdf so it can be maintained more loosely
```

commit 558a1d7e5f28d2a3fa1a9c7fa4a0e43db672dbb6
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 21:49:35 2013 +0100

```
get URL for orcID not orcIDID
```

commit 3fa8e0e8422ae2a5c3453011132d5232e0c1b7f3
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 21:46:47 2013 +0100

```
nullchecks
```

commit 3691fa396aec024481d5a6390b36192954f0855d
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 21:30:42 2013 +0100

```
Moved RDF transformation to RDFMessageBodyWriter
```

commit 720106262ff782193ccd6ca6ff5c05ae350dad85
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 20:21:51 2013 +0100

```
Jena-based RDF wrapper
```

commit b5faeea48e8ca839f2eb368cad9d8de357365d9d
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 19:32:34 2013 +0100

```
Clone of HTML Writer
```

commit 695b55d6f47367da6c6953c261866d6241b42106
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 19:32:20 2013 +0100

```
Ignore RDF test for now, so build passest
```

commit 682ea05d96d912f5990455cc7205c148a7af7cc8
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Thu May 23 19:31:54 2013 +0100

```
Temporarily Break HTML Writer - is it used? :)
```

commit aee172131dc89cf8cb2eb83492583539aa9f1827
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Wed May 22 11:26:51 2013 +0100

```
RDF: Test for RDF/XML entity
```

commit cf1fc194e0f72ad2669b1a2c63432467b874ad6c
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Wed May 22 10:22:40 2013 +0100

```
RDF: Remove unused methods in RDFTest
```

commit 115d4c39643efa82109634198ceb185131ed78b8
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Wed May 22 10:17:50 2013 +0100

```
RDF: Skeleton viewBioDetailsRdf and viewBioDetailsTurtle
```

commit 63673c86704a57f273bbee3c306e9fffb54fcee3
Author: Stian Soiland-Reyes stian@soiland-reyes.com
Date:   Wed May 22 10:03:00 2013 +0100

```
Clone T1OrcidApiServiceImplMetricsTest to test RDF
```
