### PR TITLE
Moved BibTeX processing from OrcidWork into Work

### DIFF
--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/OrcidWork.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/OrcidWork.java
@@ -32,13 +32,6 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.apache.commons.lang.StringUtils;
-import org.jbibtex.ParseException;
-import org.orcid.utils.BibtexUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.util.HtmlUtils;
-
 /**
  * <p>
  * Java class for anonymous complex type.
@@ -78,8 +71,6 @@ import org.springframework.web.util.HtmlUtils;
 @XmlRootElement(name = "orcid-work")
 public class OrcidWork implements VisibilityType, Serializable {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(OrcidWork.class);
-    
     private static final long serialVersionUID = 1L;
     @XmlElement(name = "work-title")
     protected WorkTitle workTitle;
@@ -102,8 +93,6 @@ public class OrcidWork implements VisibilityType, Serializable {
     protected String putCode;
     @XmlAttribute
     protected Visibility visibility;
-    @XmlAttribute
-    protected String citationForDisplay;
 
     /**
      * Gets the value of the putCode property.
@@ -421,27 +410,5 @@ public class OrcidWork implements VisibilityType, Serializable {
             return false;
         return true;
     }
-    
-    /**
-     * Return the Bibtex work citations in a readable format.
-     * @return the bibtex citation converted into a readable string
-     * */
-    public String getCitationForDisplay() {
-        if (this.workCitation != null && this.workCitation.citation != null && CitationType.BIBTEX.value().toLowerCase().equals(this.workCitation.workCitationType.value().toLowerCase())) {
-            try {
-                String result = BibtexUtils.toCitation(HtmlUtils.htmlUnescape(this.workCitation.citation));                               
-                return result;
-            } catch (ParseException e) {
-                LOGGER.info("Invalid BibTeX. Sending back as a string");
-            }
-        }
-        if (this.workCitation != null && StringUtils.isNotBlank(this.workCitation.citation)) {
-            return this.workCitation.citation;
-        }
-        return null;
-    }
-    
-    public void setCitationForDisplay(String citation) {
-        this.citationForDisplay = citation;
-    }
+
 }

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/WorkspaceController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/WorkspaceController.java
@@ -38,7 +38,6 @@ import org.orcid.jaxb.model.message.OrcidWork;
 import org.orcid.jaxb.model.message.OrcidWorks;
 import org.orcid.jaxb.model.message.SourceOrcid;
 import org.orcid.persistence.adapter.Jpa2JaxbAdapter;
-import org.orcid.persistence.jpa.entities.ProfileWorkEntity;
 import org.orcid.pojo.ThirdPartyRedirect;
 import org.orcid.pojo.Work;
 import org.springframework.stereotype.Controller;
@@ -223,17 +222,17 @@ public class WorkspaceController extends BaseWorkspaceController {
      * */
     @SuppressWarnings("unchecked")
     @RequestMapping(value = "/work.json", method = RequestMethod.GET)
-    public @ResponseBody List<OrcidWork> getWorkJson(HttpServletRequest request, @RequestParam(value = "workIds") String workIdsStr) {
-        ArrayList<OrcidWork> workList = new ArrayList<OrcidWork>();
-        OrcidWork work = null;
+    public @ResponseBody List<Work> getWorkJson(HttpServletRequest request, @RequestParam(value = "workIds") String workIdsStr) {
+        List<Work> workList = new ArrayList<>();
+        Work work = null;
         String[] workIds = workIdsStr.split(",");
         
         if(workIds != null){
-            HashMap<String,OrcidWork> worksMap = (HashMap<String,OrcidWork>)request.getSession().getAttribute(WORKS_MAP);
+            HashMap<String,Work> worksMap = (HashMap<String,Work>)request.getSession().getAttribute(WORKS_MAP);
             // this should never happen, but just in case.
             if (worksMap == null) {
                 createWorksIdList(request);
-                worksMap = (HashMap<String,OrcidWork>)request.getSession().getAttribute(WORKS_MAP);
+                worksMap = (HashMap<String,Work>)request.getSession().getAttribute(WORKS_MAP);
             }
             for (String workId: workIds) {
                 work = worksMap.get(workId);
@@ -268,7 +267,7 @@ public class WorkspaceController extends BaseWorkspaceController {
         List<String> workIds = new ArrayList<String>();
         if (orcidWorks != null) {
             for(OrcidWork work : orcidWorks.getOrcidWork()) {
-                worksMap.put(work.getPutCode(), work);
+                worksMap.put(work.getPutCode(), new Work(work));
                 workIds.add(work.getPutCode());
             }
             request.getSession().setAttribute(WORKS_MAP, worksMap);

--- a/orcid-web/src/main/java/org/orcid/pojo/Work.java
+++ b/orcid-web/src/main/java/org/orcid/pojo/Work.java
@@ -19,19 +19,33 @@ package org.orcid.pojo;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlAttribute;
+
+import org.apache.commons.lang.StringUtils;
+import org.jbibtex.ParseException;
+import org.orcid.jaxb.model.message.CitationType;
 import org.orcid.jaxb.model.message.OrcidWork;
 import org.orcid.pojo.ajaxForm.ErrorsInterface;
+import org.orcid.utils.BibtexUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.util.HtmlUtils;
 
 public class Work extends OrcidWork implements ErrorsInterface {
     private static final long serialVersionUID = 1L;
 
     private List<String> errors = new ArrayList<String>();
 
-    public Work () {
-        
-    }
+    private static Logger LOGGER = LoggerFactory.getLogger(Work.class);
     
-    public Work(OrcidWork orcidWork){
+    @XmlAttribute
+    protected String citationForDisplay;
+
+    public Work() {
+
+    }
+
+    public Work(OrcidWork orcidWork) {
         this.setPublicationDate(orcidWork.getPublicationDate());
         this.setPutCode(orcidWork.getPutCode());
         this.setShortDescription(orcidWork.getShortDescription());
@@ -44,7 +58,32 @@ public class Work extends OrcidWork implements ErrorsInterface {
         this.setWorkTitle(orcidWork.getWorkTitle());
         this.setWorkType(orcidWork.getWorkType());
     }
-    
+
+    /**
+     * Return the Bibtex work citations in a readable format.
+     * 
+     * @return the bibtex citation converted into a readable string
+     * */
+    public String getCitationForDisplay() {
+        if (this.workCitation != null && this.workCitation.getCitation() != null
+                && CitationType.BIBTEX.value().toLowerCase().equals(this.workCitation.getWorkCitationType().value().toLowerCase())) {
+            try {
+                String result = BibtexUtils.toCitation(HtmlUtils.htmlUnescape(this.workCitation.getCitation()));
+                return result;
+            } catch (ParseException e) {
+                LOGGER.info("Invalid BibTeX. Sending back as a string");
+            }
+        }
+        if (this.workCitation != null && StringUtils.isNotBlank(this.workCitation.getCitation())) {
+            return this.workCitation.getCitation();
+        }
+        return null;
+    }
+
+    public void setCitationForDisplay(String citation) {
+        this.citationForDisplay = citation;
+    }
+
     public List<String> getErrors() {
         return errors;
     }


### PR DESCRIPTION
Moved BibTeX processing from OrcidWork into Work, to avoid processing when doing visibility filtering (and hence bogging down the scheduler).
