### PR TITLE
Now the title comparison ignore cases, so, AC will be after ab. Before t...

### DIFF
--- a/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/WorkEntity.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/WorkEntity.java
@@ -224,7 +224,7 @@ public class WorkEntity extends BaseEntity<Long> implements Comparable<WorkEntit
         if (title == null) {
             return -1;
         }
-        return title.compareTo(other.getTitle());
+        return title.compareToIgnoreCase(other.getTitle());
     }
 
     private int compareIds(WorkEntity other) {


### PR DESCRIPTION
...his change, the app ordered firts the upper case, and then the lower case titles
