### PR TITLE
Back out initial minor changes to remove <orcid> from <orcid-profile>.

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/version/impl/OrcidMessageVersionConverterImplV1_0_15ToV1_0_16.java
+++ b/orcid-core/src/main/java/org/orcid/core/version/impl/OrcidMessageVersionConverterImplV1_0_15ToV1_0_16.java
@@ -17,11 +17,7 @@
 package org.orcid.core.version.impl;
 
 import org.orcid.core.version.OrcidMessageVersionConverter;
-import org.orcid.jaxb.model.message.Orcid;
 import org.orcid.jaxb.model.message.OrcidMessage;
-import org.orcid.jaxb.model.message.OrcidProfile;
-import org.orcid.jaxb.model.message.OrcidSearchResult;
-import org.orcid.jaxb.model.message.OrcidSearchResults;
 
 /**
  * 
@@ -58,23 +54,7 @@ public class OrcidMessageVersionConverterImplV1_0_15ToV1_0_16 implements OrcidMe
             return null;
         }
         orcidMessage.setMessageVersion(TARGET_VERSION);
-        upgradeProfile(orcidMessage.getOrcidProfile());
-        upgradeSearchResults(orcidMessage.getOrcidSearchResults());
         return orcidMessage;
-    }
-
-    private void upgradeSearchResults(OrcidSearchResults orcidSearchResults) {
-        if (orcidSearchResults != null) {
-            for (OrcidSearchResult searchResult : orcidSearchResults.getOrcidSearchResult()) {
-                upgradeProfile(searchResult.getOrcidProfile());
-            }
-        }
-    }
-
-    private void upgradeProfile(OrcidProfile orcidProfile) {
-        if (orcidProfile != null) {
-            orcidProfile.setOrcid((Orcid) null);
-        }
     }
 
 }

--- a/orcid-core/src/test/java/org/orcid/core/version/OrcidMessageVersionConverterChainTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/version/OrcidMessageVersionConverterChainTest.java
@@ -18,7 +18,6 @@ package org.orcid.core.version;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -46,7 +45,7 @@ public class OrcidMessageVersionConverterChainTest extends BaseTest {
         OrcidMessage newMessage = orcidMessageVersionConverterChain.upgradeMessage(oldMessage, "1.0.16");
         assertNotNull(newMessage);
         assertEquals("1.0.16", newMessage.getMessageVersion());
-        assertNull(newMessage.getOrcidProfile().getOrcid());
+        assertEquals("4444-4444-4444-4446", newMessage.getOrcidProfile().getOrcid().getValue());
         assertEquals("http://orcid.org/4444-4444-4444-4446", newMessage.getOrcidProfile().getOrcidId());
     }
 

--- a/orcid-core/src/test/java/org/orcid/core/version/impl/OrcidMessageVersionConverterV1_0_15ToV1_0_16ImplTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/version/impl/OrcidMessageVersionConverterV1_0_15ToV1_0_16ImplTest.java
@@ -41,7 +41,7 @@ public class OrcidMessageVersionConverterV1_0_15ToV1_0_16ImplTest {
         OrcidMessage newMessage = converter.upgradeMessage(oldMessage);
         assertNotNull(newMessage);
         assertEquals("1.0.16", newMessage.getMessageVersion());
-        assertNull(newMessage.getOrcidProfile().getOrcid());
+        assertEquals("4444-4444-4444-4446", newMessage.getOrcidProfile().getOrcid().getValue());
         assertEquals("http://orcid.org/4444-4444-4444-4446", newMessage.getOrcidProfile().getOrcidId());
     }
 


### PR DESCRIPTION
Need these changes, if we are going to keep orcid-profile/orcid in v1.0.16.
