### PR TITLE
Make trash icon always visible

### DIFF
--- a/orcid-web/src/main/resources/freemarker/current_works_list.ftl
+++ b/orcid-web/src/main/resources/freemarker/current_works_list.ftl
@@ -23,7 +23,7 @@
         <h3 class="work-title"><b>${(work.title)!}</b><#if (work.subtitle)??>: <span class="work-subtitle">${(work.subtitle)!""}</span></#if><#if (work.year)??> <#if (work.month)?? && work.month?has_content><@orcid.month work.month />-</#if>${work.year}</#if></h3>
         <label class="work-delete-lbl">
             <div class="delete-group">
-            	<a href="#" class="icon-trash grey delete-work" title="${springMacroRequestContext.getMessage("current_works_list.delete")}"></a>
+            	<a href="#" class="icon-trash orcid-icon-trash grey delete-work" title="${springMacroRequestContext.getMessage("current_works_list.delete")}"></a>
                 <span class="alert hide form-change-alert deleted-alert">
                     <a href="#" class="confirm-link">${springMacroRequestContext.getMessage("current_works_list.confirmrequiressave")}</a> |
                     <a href="#" class="deny-link">${springMacroRequestContext.getMessage("current_works_list.Abandon")}</a></span>

--- a/orcid-web/src/main/resources/freemarker/manage.ftl
+++ b/orcid-web/src/main/resources/freemarker/manage.ftl
@@ -69,7 +69,7 @@
 	   							      <span ng-show="email.verified">${springMacroRequestContext.getMessage("manage.email.verified")}</span>		
 		   						  </td>
 		   						  <td class="padRgt">
-		   						  	<a href="" class="icon-trash grey" ng-show="email.primary == false" ng-click="confirmDeleteEmail($index)"></a>
+		   						  	<a href="" class="icon-trash orcid-icon-trash grey" ng-show="email.primary == false" ng-click="confirmDeleteEmail($index)"></a>
 		   						  </td>
 		   						  <td class="padRgt">
 		   						  	<@orcid.privacyToggle "email.visibility" "setPrivacy($index, 'PUBLIC', $event)" "setPrivacy($index, 'LIMITED', $event)" "setPrivacy($index, 'PRIVATE', $event)" />
@@ -251,7 +251,7 @@
                                             </#list>
                                         </#if>
                                     </td width="35%">                                    
-                                    <td width="5%"><button class="btn btn-link" onclick="orcidGA.gaPush(['_trackEvent', 'Disengagement', 'Revoke_Access', 'OAuth ${applicationSummary.applicationName.content}']);"><i class="icon-trash grey" title="${springMacroRequestContext.getMessage("manage.revokeaccess")}"></i></button></td>
+                                    <td width="5%"><button class="btn btn-link" onclick="orcidGA.gaPush(['_trackEvent', 'Disengagement', 'Revoke_Access', 'OAuth ${applicationSummary.applicationName.content}']);"><i class="icon-trash orcid-icon-trash grey" title="${springMacroRequestContext.getMessage("manage.revokeaccess")}"></i></button></td>
                                 </form>
                             </tr>
                         </#list>

--- a/orcid-web/src/main/resources/freemarker/manage_bio_settings.ftl
+++ b/orcid-web/src/main/resources/freemarker/manage_bio_settings.ftl
@@ -125,7 +125,7 @@
                       		<#else> 
                       		    ${savedResearcherUrl.urlName.content} (<a href="${savedResearcherUrl.url.value}">${savedResearcherUrl.url.value}</a>)
                       		</#if>
-                      		<a href="" class="icon-trash grey delete-url" ng-show="email.primary == false" ng-click="deleteEmail($index)" title="remove url"></a>
+                      		<a href="" class="icon-trash orcid-icon-trash grey delete-url" ng-show="email.primary == false" ng-click="deleteEmail($index)" title="remove url"></a>
                       		</p>     		    
                     </#list>
              	</#if>

--- a/orcid-web/src/main/resources/freemarker/works_update.ftl
+++ b/orcid-web/src/main/resources/freemarker/works_update.ftl
@@ -61,7 +61,7 @@
                                             <h4>${(work.title)!}</h4>
                                             <label class="work-delete-lbl hide">
                                                 <div class="delete-group">
-                                                    <a href="#" class="icon-trash grey delete-work" title="${springMacroRequestContext.getMessage("current_works_list.delete")}"></a>
+                                                    <a href="#" class="icon-trash orcid-icon-trash grey delete-work" title="${springMacroRequestContext.getMessage("current_works_list.delete")}"></a>
                                                     <span class="alert hide form-change-alert deleted-alert">
                                                         <a href="#" class="confirm-link">${springMacroRequestContext.getMessage("current_works_list.confirmrequiressave")} </a> |
                                                         <a href="#" class="deny-link">${springMacroRequestContext.getMessage("current_works_list.Abandon")}</a></span>

--- a/orcid-web/src/main/resources/freemarker/workspace.ftl
+++ b/orcid-web/src/main/resources/freemarker/workspace.ftl
@@ -80,7 +80,7 @@
 		        			<p ng-show="externalIdentifier.externalIdUrl"><a ng-href="{{externalIdentifier.externalIdUrl.value}}">{{externalIdentifier.externalIdCommonName.content}} {{externalIdentifier.externalIdReference.content}}</a></p>
 		     			</td>
 			   			<td class="padRgt">
-			   				<p><a href ng-click="deleteExternalIdentifier($index)" class="icon-trash grey"></a></p>
+			   				<p><a href ng-click="deleteExternalIdentifier($index)" class="icon-trash orcid-icon-trash grey"></a></p>
 			   			</td>		        		
 		        	</tr>
 		        </table>

--- a/orcid-web/src/main/resources/freemarker/workspace_works_body_list.ftl
+++ b/orcid-web/src/main/resources/freemarker/workspace_works_body_list.ftl
@@ -32,7 +32,7 @@
 	 
 	<ul ng-hide="!works.length" class="workspace-publications workspace-body-list bottom-margin-medium" ng-cloak>        
             <li class="bottom-margin-small" ng-repeat='work in works'>            	
-                <div class="pull-right" style="right: 145px; top: 20px; width: 15px;"><a href ng-click="deleteWork($index)" class="icon-trash grey"></a></div>
+                <div class="pull-right" style="right: 145px; top: 20px; width: 15px;"><a href ng-click="deleteWork($index)" class="icon-trash orcid-icon-trash grey"></a></div>
 				<div style="width: 530px;">
                 <h3 class="work-title">
                 	<strong ng-bind="work.workTitle.title.value"></strong><span class="work-subtitle" ng-show="work.workTitle.subtitle.value" ng-bind-html-unsafe="':&nbsp;'.concat(work.workTitle.subtitle.value)"></span>

--- a/orcid-web/src/main/webapp/static/css/orcid.css
+++ b/orcid-web/src/main/webapp/static/css/orcid.css
@@ -2270,3 +2270,8 @@ a.btn-primary:hover {
 	margin: 30px 0 0;
 	font-size: 12px;
 }
+
+
+.orcid-icon-trash {
+	background-color: white;
+}


### PR DESCRIPTION
Put white background behind trash icon, so that is always clearly visible even when there is a long chemical formula in a work title.

https://trello.com/c/1dJpQ2mJ/93-long-titles-obscure-the-trash-icon
