### PR TITLE
Added persist* to list of DAO methods that trigger profile last modified update.

### DIFF
--- a/orcid-persistence/src/main/java/org/orcid/persistence/aop/ProfileLastModifiedAspect.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/aop/ProfileLastModifiedAspect.java
@@ -49,7 +49,8 @@ public class ProfileLastModifiedAspect implements PriorityOrdered {
     //@formatter:off
     private static final String POINTCUT_DEFINITION_BASE = "(execution(* org.orcid.persistence.dao.*.remove*(..))"
             + "|| execution(* org.orcid.persistence.dao.*.delete*(..))" + "|| execution(* org.orcid.persistence.dao.*.update*(..))"
-            + "|| execution(* org.orcid.persistence.dao.*.merge*(..))" + "|| execution(* org.orcid.persistence.dao.*.add*(..)))"
+            + "|| execution(* org.orcid.persistence.dao.*.merge*(..))" + "|| execution(* org.orcid.persistence.dao.*.add*(..))"
+            + "|| execution(* org.orcid.persistence.dao.*.persist*(..)))"
             + "&& !@annotation(org.orcid.persistence.aop.ExcludeFromProfileLastModifiedUpdate)" + "&& !within(org.orcid.persistence.dao.impl.ProfileDaoImpl)"
             + "&& !within(org.orcid.persistence.dao.impl.WebhookDaoImpl)";
 


### PR DESCRIPTION
Fixes https://trello.com/c/vRYFYi5b/497-freshly-added-client-authorisations-to-not-show-up-until-user-refreshes-profile.
