### PR TITLE
Fixed problem in Firefox when selecting a disambiguated organization

### DIFF
--- a/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
+++ b/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
@@ -1192,6 +1192,7 @@ function AffiliationCtrl($scope, $compile, affiliationsSrvc){
 	};
 	
 	$scope.selectAffiliation = function(datum) {
+		$scope.editAffiliation.affiliationName.value = datum.value;
 		$scope.editAffiliation.city.value = datum.city;
 		$scope.editAffiliation.region.value = datum.region;
 		$scope.editAffiliation.country.value = datum.country;
@@ -1265,7 +1266,7 @@ function AffiliationCtrl($scope, $compile, affiliationsSrvc){
 		}).fail(function(){
 			// something bad is happening!
 			$scope.addingAffiliation = false;
-	    	console.log("error fetching affiliations");
+	    	console.log("error adding affiliations");
 		});
 	};
 	


### PR DESCRIPTION
Fixed problem in Firefox, when selecting a disambiguated organization only the characters typed by the user were included in the name of the resulting org (rather than the full org name).
