### PR TITLE
Add RIS as a valid citation type.

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/version/impl/OrcidMessageVersionConverterImplV1_0_22ToV1_0_23.java
+++ b/orcid-core/src/main/java/org/orcid/core/version/impl/OrcidMessageVersionConverterImplV1_0_22ToV1_0_23.java
@@ -16,11 +16,14 @@
  */
 package org.orcid.core.version.impl;
 
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.orcid.core.version.OrcidMessageVersionConverter;
 import org.orcid.jaxb.model.message.Affiliation;
 import org.orcid.jaxb.model.message.AffiliationType;
 import org.orcid.jaxb.model.message.Affiliations;
+import org.orcid.jaxb.model.message.CitationType;
 import org.orcid.jaxb.model.message.OrcidActivities;
 import org.orcid.jaxb.model.message.OrcidMessage;
 import org.orcid.jaxb.model.message.OrcidProfile;
@@ -55,8 +58,26 @@ public class OrcidMessageVersionConverterImplV1_0_22ToV1_0_23 implements OrcidMe
             return null;
         }
         orcidMessage.setMessageVersion(FROM_VERSION);
-
+        
+        OrcidProfile orcidProfile = orcidMessage.getOrcidProfile();
+        
+        if (orcidProfile != null) {
+            OrcidActivities orcidActivities = orcidProfile.getOrcidActivities();
+            if (orcidActivities != null && orcidActivities.getOrcidWorks() != null) {
+                List<OrcidWork> works = orcidActivities.getOrcidWorks().getOrcidWork();
+                for (OrcidWork orcidWork: works) {
+                    if (orcidWork.getWorkCitation() != null && orcidWork.getWorkCitation().getWorkCitationType() != null) {
+                        CitationType workCitationType =  orcidWork.getWorkCitation().getWorkCitationType();
+                        if (workCitationType.equals(CitationType.RIS)) {
+                            orcidWork.getWorkCitation().setWorkCitationType(CitationType.FORMATTED_UNSPECIFIED);
+                        }
+                    }
+                }
+            }
+        }
         return orcidMessage;
+        
+        
     }
 
     @Override

--- a/orcid-core/src/main/resources/i18n/messages_en.properties
+++ b/orcid-core/src/main/resources/i18n/messages_en.properties
@@ -1012,6 +1012,7 @@ org.orcid.jaxb.model.message.CitationType.formatted-ieee=IEEE
 org.orcid.jaxb.model.message.CitationType.formatted-mla=MLA
 org.orcid.jaxb.model.message.CitationType.formatted-vancouver=VANCOUVER
 org.orcid.jaxb.model.message.CitationType.formatted-chicago=CHICAGO
+org.orcid.jaxb.model.message.CitationType.ris=RIS
 
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.empty=What type of external ID?
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.other-id=Other identifier type

--- a/orcid-core/src/main/resources/i18n/messages_es.properties
+++ b/orcid-core/src/main/resources/i18n/messages_es.properties
@@ -1174,6 +1174,7 @@ org.orcid.jaxb.model.message.CitationType.formatted-ieee=IEEE
 org.orcid.jaxb.model.message.CitationType.formatted-mla=MLA
 org.orcid.jaxb.model.message.CitationType.formatted-vancouver=VANCOUVER
 org.orcid.jaxb.model.message.CitationType.formatted-chicago=CHICAGO
+org.orcid.jaxb.model.message.CitationType.ris=RIS
 
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.empty=¿Qué tipo de ID externo?
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.other-id=Otro tipo de identificador

--- a/orcid-core/src/main/resources/i18n/messages_fr.properties
+++ b/orcid-core/src/main/resources/i18n/messages_fr.properties
@@ -1193,6 +1193,7 @@ org.orcid.jaxb.model.message.CitationType.formatted-ieee=IEEE
 org.orcid.jaxb.model.message.CitationType.formatted-mla=MLA
 org.orcid.jaxb.model.message.CitationType.formatted-vancouver=VANCOUVER
 org.orcid.jaxb.model.message.CitationType.formatted-chicago=CHICAGO
+org.orcid.jaxb.model.message.CitationType.ris=RIS
 
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.empty=Quel type d'identifiant externe?
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.other-id=Autre type d'identificateur

--- a/orcid-core/src/main/resources/i18n/messages_orc.properties
+++ b/orcid-core/src/main/resources/i18n/messages_orc.properties
@@ -1196,6 +1196,7 @@ org.orcid.jaxb.model.message.CitationType.formatted-ieee=EIII
 org.orcid.jaxb.model.message.CitationType.formatted-mla=NHA
 org.orcid.jaxb.model.message.CitationType.formatted-vancouver=VAMQOUVIR
 org.orcid.jaxb.model.message.CitationType.formatted-chicago=QLEQAGO
+org.orcid.jaxb.model.message.CitationType.ris=RIS
 
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.empty=Wlat typi of ixtirmah EJ?
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.other-id=Otlir ejimtefeir typi

--- a/orcid-core/src/main/resources/i18n/messages_zh_CN.properties
+++ b/orcid-core/src/main/resources/i18n/messages_zh_CN.properties
@@ -1172,6 +1172,7 @@ org.orcid.jaxb.model.message.CitationType.formatted-ieee=IEEE
 org.orcid.jaxb.model.message.CitationType.formatted-mla=MLA
 org.orcid.jaxb.model.message.CitationType.formatted-vancouver=温哥华
 org.orcid.jaxb.model.message.CitationType.formatted-chicago=芝加哥
+org.orcid.jaxb.model.message.CitationType.ris=RIS
 
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.empty=什么类型的外部 ID？
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.other-id=其他标识符类型

--- a/orcid-core/src/main/resources/i18n/messages_zh_TW.properties
+++ b/orcid-core/src/main/resources/i18n/messages_zh_TW.properties
@@ -1164,6 +1164,7 @@ org.orcid.jaxb.model.message.CitationType.formatted-ieee=IEEE
 org.orcid.jaxb.model.message.CitationType.formatted-mla=MLA
 org.orcid.jaxb.model.message.CitationType.formatted-vancouver=溫哥華
 org.orcid.jaxb.model.message.CitationType.formatted-chicago=芝加哥
+org.orcid.jaxb.model.message.CitationType.ris=RIS
 
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.empty=什麼類型的外部 ID？
 org.orcid.jaxb.model.message.WorkExternalIdentifierType.other-id=其他識別碼類型

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/CitationType.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/CitationType.java
@@ -59,7 +59,9 @@ public enum CitationType {
     FORMATTED_IEEE("formatted-ieee"), @XmlEnumValue("formatted-mla")
     FORMATTED_MLA("formatted-mla"), @XmlEnumValue("formatted-vancouver")
     FORMATTED_VANCOUVER("formatted-vancouver"), @XmlEnumValue("formatted-chicago")
-    FORMATTED_CHICAGO("formatted-chicago");
+    FORMATTED_CHICAGO("formatted-chicago"),
+    @XmlEnumValue("ris") RIS("ris");
+    
     private final String value;
 
     CitationType(String v) {

--- a/orcid-model/src/main/resources/orcid-message-1.0.23.xsd
+++ b/orcid-model/src/main/resources/orcid-message-1.0.23.xsd
@@ -1563,6 +1563,7 @@
             <xs:enumeration value="formatted-mla"/>
             <xs:enumeration value="formatted-vancouver"/>
             <xs:enumeration value="formatted-chicago"/>
+            <xs:enumeration value="ris"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="iso-3166-country">

--- a/orcid-model/src/main/resources/orcid-message-1.1.0.md
+++ b/orcid-model/src/main/resources/orcid-message-1.1.0.md
@@ -4,3 +4,4 @@
 * Added work subtypes
 * It is still possible to add works with the old types if you use an older message version
 * Added provisional country code for Kosovo
+* RIS as a citation type 

--- a/orcid-model/src/main/resources/orcid-message-1.1.0.xsd
+++ b/orcid-model/src/main/resources/orcid-message-1.1.0.xsd
@@ -1659,6 +1659,7 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="formatted-unspecified" />
 			<xs:enumeration value="bibtex" />
+			<xs:enumeration value="ris" />
 			<xs:enumeration value="formatted-apa" />
 			<xs:enumeration value="formatted-harvard" />
 			<xs:enumeration value="formatted-ieee" />

--- a/orcid-web/src/main/webapp/static/css/orcid.css
+++ b/orcid-web/src/main/webapp/static/css/orcid.css
@@ -2445,3 +2445,7 @@ a.btn-primary:hover {
 .tt-is-under-cursor .tt-query  {
 	color: red;
 }
+
+.citation-raw {
+	white-space: pre-wrap
+}

--- a/orcid-web/src/main/webapp/static/css/orcid.resp.css
+++ b/orcid-web/src/main/webapp/static/css/orcid.resp.css
@@ -3754,6 +3754,8 @@ ul.personal-inf-display li{
 	.container{
 		max-width:960px;
 	}
-	
-	
+}
+
+.citation-raw {
+	white-space: pre-wrap
 }


### PR DESCRIPTION
One issue we'll have with this is clients using old versions of the API will see the citation type as "formatted-unspecified".

I wouldn't encourage the use of RIS until we get API clients to upgrade to orcid message 1.0.23 and higher.
