### PR TITLE
Fixing an NPE for users that install the statistics for the firts time

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/StatisticsManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/StatisticsManagerImpl.java
@@ -115,8 +115,8 @@ public class StatisticsManagerImpl implements StatisticsManager {
      * */
     @Cacheable("statistics")
     public String getLiveIds(Locale locale) {
-        StatisticValuesEntity entity = getLatestStatistics(StatisticsEnum.KEY_LIVE_IDS.value());
-        double amount = Double.parseDouble(String.valueOf(entity.getStatisticValue()));        
+        StatisticValuesEntity entity = getLatestStatistics(StatisticsEnum.KEY_LIVE_IDS.value());        
+        double amount = (entity == null)? 0 : Double.parseDouble(String.valueOf(entity.getStatisticValue()));        
         DecimalFormat formatter = new DecimalFormat(messageSource.getMessage("public-layout.number_format",null, locale));        
         return formatter.format(amount);
     }


### PR DESCRIPTION
When the statistics database is empty, a NPE error occurs.
