### PR TITLE
Updated to use OrcidProfile.orcidIdentifier throughout

### DIFF
--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/rdf/RDFMessageBodyWriter.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/rdf/RDFMessageBodyWriter.java
@@ -286,7 +286,7 @@ public class RDFMessageBodyWriter implements MessageBodyWriter<OrcidMessage> {
             webSite = m.createIndividual(baseUri, null);
             account.addProperty(foafAccountServiceHomepage, webSite);
         }
-        String orcId = orcidProfile.getOrcid().getValue();
+        String orcId = orcidProfile.getOrcidIdentifier().getPath();
         account.addProperty(foafAccountName, orcId);
         account.addLabel(orcId, null);
 

--- a/orcid-api-web/src/main/java/org/orcid/api/t2/server/delegator/impl/T2OrcidApiServiceDelegatorImpl.java
+++ b/orcid-api-web/src/main/java/org/orcid/api/t2/server/delegator/impl/T2OrcidApiServiceDelegatorImpl.java
@@ -22,7 +22,6 @@ import static org.orcid.api.common.OrcidApiConstants.PROFILE_GET_PATH;
 import static org.orcid.api.common.OrcidApiConstants.STATUS_OK_MESSAGE;
 import static org.orcid.api.common.OrcidApiConstants.WORKS_PATH;
 
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -82,7 +81,7 @@ import org.springframework.stereotype.Component;
  * <p/>
  * The delegator for the tier 2 API.
  * <p/>
- * The T2 delegator is responsible for the validation, retrieving results and 
+ * The T2 delegator is responsible for the validation, retrieving results and
  * passing of objects to be from the core
  * 
  * @author Declan Newman (declan) Date: 07/03/2012
@@ -204,10 +203,11 @@ public class T2OrcidApiServiceDelegatorImpl extends OrcidApiServiceDelegatorImpl
         OrcidProfile profile = orcidProfileManager.retrieveClaimedOrcidWorks(orcid);
         return getOrcidMessageResponse(profile, orcid);
     }
-    
+
     /**
      * finds and returns the {@link org.orcid.jaxb.model.message.OrcidMessage}
-     * wrapped in a {@link javax.xml.ws.Response} with only the affiliation details
+     * wrapped in a {@link javax.xml.ws.Response} with only the affiliation
+     * details
      * 
      * @param orcid
      *            the ORCID to be used to identify the record
@@ -360,8 +360,8 @@ public class T2OrcidApiServiceDelegatorImpl extends OrcidApiServiceDelegatorImpl
     }
 
     private Response getCreatedResponse(UriInfo uriInfo, String requested, OrcidProfile profile) {
-        if (profile != null && profile.getOrcid() != null) {
-            return getCreatedResponse(uriInfo, requested, profile.getOrcid().getValue());
+        if (profile != null && profile.getOrcidIdentifier() != null) {
+            return getCreatedResponse(uriInfo, requested, profile.getOrcidIdentifier().getPath());
         } else {
             throw new OrcidNotFoundException("Cannot find ORCID");
         }
@@ -407,8 +407,8 @@ public class T2OrcidApiServiceDelegatorImpl extends OrcidApiServiceDelegatorImpl
                 OrcidSearchResult filteredSearchResult = new OrcidSearchResult();
                 filteredSearchResult.setRelevancyScore(searchResult.getRelevancyScore());
                 OrcidProfile filteredProfile = new OrcidProfile();
-                String retrievedOrcid = searchResult.getOrcidProfile().getOrcid().getValue();
-                filteredProfile.setOrcid(retrievedOrcid);
+                String retrievedOrcid = searchResult.getOrcidProfile().getOrcidIdentifier().getPath();
+                filteredProfile.setOrcidIdentifier(retrievedOrcid);
                 filteredProfile.setOrcidBio(searchResult.getOrcidProfile().getOrcidBio());
                 filteredSearchResult.setOrcidProfile(filteredProfile);
                 filteredResults.add(filteredSearchResult);
@@ -571,7 +571,7 @@ public class T2OrcidApiServiceDelegatorImpl extends OrcidApiServiceDelegatorImpl
             throw new OrcidBadRequestException("Cannot update ORCID");
         }
     }
-    
+
     @Override
     @AccessControl(requiredScope = ScopePathType.FUNDING_CREATE)
     public Response addFunding(UriInfo uriInfo, String orcid, OrcidMessage orcidMessage) {

--- a/orcid-api-web/src/main/java/org/orcid/api/t2/server/delegator/impl/T2OrcidApiServiceVersionedDelegatorImpl.java
+++ b/orcid-api-web/src/main/java/org/orcid/api/t2/server/delegator/impl/T2OrcidApiServiceVersionedDelegatorImpl.java
@@ -152,7 +152,7 @@ public class T2OrcidApiServiceVersionedDelegatorImpl implements T2OrcidApiServic
         Response response = t2OrcidApiServiceDelegator.findAffiliationsDetailsFromPublicCache(orcid);
         return downgradeAndValidateResponse(response);
     }
-    
+
     @Override
     public Response findFundingDetails(String orcid) {
         Response response = t2OrcidApiServiceDelegator.findFundingDetails(orcid);
@@ -164,7 +164,7 @@ public class T2OrcidApiServiceVersionedDelegatorImpl implements T2OrcidApiServic
         Response response = t2OrcidApiServiceDelegator.findFundingDetailsFromPublicCache(orcid);
         return downgradeAndValidateResponse(response);
     }
-    
+
     @Override
     public Response findWorksDetails(String orcid) {
         Response response = t2OrcidApiServiceDelegator.findWorksDetails(orcid);
@@ -271,8 +271,8 @@ public class T2OrcidApiServiceVersionedDelegatorImpl implements T2OrcidApiServic
      *             if the account is deprecated
      * */
     private void checkDeprecation(OrcidMessage orcidMessage) {
-        if (orcidMessage != null && orcidMessage.getOrcidProfile() != null && orcidMessage.getOrcidProfile().getOrcid() != null) {
-            String orcid = orcidMessage.getOrcidProfile().getOrcid().getValue();
+        if (orcidMessage != null && orcidMessage.getOrcidProfile() != null && orcidMessage.getOrcidProfile().getOrcidIdentifier() != null) {
+            String orcid = orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath();
             String primaryOrcid = this.profileDao.retrievePrimaryAccountOrcid(orcid);
             if (primaryOrcid != null) {
                 // TODO: Internationalize these messages
@@ -294,7 +294,7 @@ public class T2OrcidApiServiceVersionedDelegatorImpl implements T2OrcidApiServic
         if (orcidMessage != null && orcidMessage.getOrcidProfile() != null && orcidMessage.getOrcidProfile().getOrcidDeprecated() != null) {
             // TODO: Internationalize these messages
             throw new DeprecatedException("This account is deprecated. Please refer to account:"
-                    + orcidMessage.getOrcidProfile().getOrcidDeprecated().getPrimaryRecord().getOrcid().getValue());
+                    + orcidMessage.getOrcidProfile().getOrcidDeprecated().getPrimaryRecord().getOrcidIdentifier().getPath());
         }
 
         return response;
@@ -344,7 +344,7 @@ public class T2OrcidApiServiceVersionedDelegatorImpl implements T2OrcidApiServic
             throw new OrcidNotFoundException("Affiliations are not supported in this version of the API");
         }
     }
-    
+
     @Override
     public Response addFunding(UriInfo uriInfo, String orcid, OrcidMessage orcidMessage) {
         validateIncomingMessage(orcidMessage);

--- a/orcid-api-web/src/test/java/org/orcid/api/t2/integration/T2OrcidOAuthApiClientIntegrationTest.java
+++ b/orcid-api-web/src/test/java/org/orcid/api/t2/integration/T2OrcidOAuthApiClientIntegrationTest.java
@@ -292,10 +292,10 @@ public class T2OrcidOAuthApiClientIntegrationTest extends BaseT2OrcidOAuthApiCli
         // make sure read scope is still there
         assertTrue(orcidOauth2TokenDetail.getScope().contains("read"));
     }
-    
+
     /*
      * this is to test a ClientCreditalScope Scope that is older then 1 hour
-     * isn't removed 
+     * isn't removed
      */
     @Test
     public void testClientCreditalScopeIsntRemove() throws Exception {
@@ -303,7 +303,8 @@ public class T2OrcidOAuthApiClientIntegrationTest extends BaseT2OrcidOAuthApiCli
         createNewOrcidUsingAccessToken();
         OrcidOauth2TokenDetail orcidOauth2TokenDetail = orcidOauthTokenDetailService.findNonDisabledByTokenValue(accessToken);
 
-        // modify the access token to look like a user granted token and make it a day old
+        // modify the access token to look like a user granted token and make it
+        // a day old
         Date d = new Date();
         d.setTime(d.getTime() - 24 * 60 * 60 * 1000);
         orcidOauth2TokenDetail.setDateCreated(d);
@@ -315,11 +316,11 @@ public class T2OrcidOAuthApiClientIntegrationTest extends BaseT2OrcidOAuthApiCli
         // test creating a record works with token
         OrcidMessage message = orcidClientDataHelper.createFromXML(OrcidClientDataHelper.ORCID_INTERNAL_NO_SPONSOR_XML);
         ClientResponse clientResponse = oauthT2Client.createProfileXML(message, accessToken);
-        assertEquals(201,clientResponse.getStatus());
+        assertEquals(201, clientResponse.getStatus());
         MultivaluedMap<String, String> map = clientResponse.getHeaders();
         List<String> locList = map.get("Location");
         assertTrue(locList.get(0).contains("/orcid-profile"));
-        
+
         // test trying use UserGrantToken
         OrcidWorks orcidWorks = message.getOrcidProfile().retrieveOrcidWorks();
         orcidWorks = new OrcidWorks();
@@ -328,15 +329,13 @@ public class T2OrcidOAuthApiClientIntegrationTest extends BaseT2OrcidOAuthApiCli
         orcidWorks.getOrcidWork().add(orcidWork);
         message.getOrcidProfile().setOrcidWorks(orcidWorks);
         assertClientResponse403SecurityProblem(oauthT2Client.addWorksXml(orcid, message, accessToken));
-        
+
         // test ClientCreditalScope isn't removed
         orcidOauth2TokenDetail = orcidOauthTokenDetailService.findNonDisabledByTokenValue(accessToken);
         assertTrue(orcidOauth2TokenDetail.getScope().contains("/orcid-profile/create"));
         // test make sure UserGrantScope is removed
         assertTrue(!orcidOauth2TokenDetail.getScope().contains("/orcid-works/create"));
     }
-
-    
 
     @Test
     public void testTokenWithBlankScope() throws Exception {
@@ -485,7 +484,7 @@ public class T2OrcidOAuthApiClientIntegrationTest extends BaseT2OrcidOAuthApiCli
 
             createNewOrcidUsingAccessToken();
             OrcidMessage sponsorMessage = orcidClientDataHelper.createSponsor();
-            sponsorOrcid = sponsorMessage.getOrcidProfile().getOrcid().getValue();
+            sponsorOrcid = sponsorMessage.getOrcidProfile().getOrcidIdentifier().getPath();
 
             // get the bio details of the actual
             createAccessTokenFromCredentials();

--- a/orcid-api-web/src/test/java/org/orcid/api/t2/server/delegator/T2OrcidApiServiceDelegatorTest.java
+++ b/orcid-api-web/src/test/java/org/orcid/api/t2/server/delegator/T2OrcidApiServiceDelegatorTest.java
@@ -145,7 +145,7 @@ public class T2OrcidApiServiceDelegatorTest extends DBUnitTest {
         assertNotNull(readResponse);
         assertEquals(HttpStatus.SC_OK, readResponse.getStatus());
         OrcidMessage retrievedMessage = (OrcidMessage) readResponse.getEntity();
-        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcidIdentifier().getPath());
         assertEquals("S. Milligan", retrievedMessage.getOrcidProfile().getOrcidBio().getPersonalDetails().getCreditName().getContent());
     }
 
@@ -168,7 +168,7 @@ public class T2OrcidApiServiceDelegatorTest extends DBUnitTest {
         assertNotNull(readResponse);
         assertEquals(HttpStatus.SC_OK, readResponse.getStatus());
         OrcidMessage retrievedMessage = (OrcidMessage) readResponse.getEntity();
-        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcidIdentifier().getPath());
         assertEquals("Test credit name", retrievedMessage.getOrcidProfile().getOrcidBio().getPersonalDetails().getCreditName().getContent());
     }
 
@@ -193,7 +193,7 @@ public class T2OrcidApiServiceDelegatorTest extends DBUnitTest {
         assertNotNull(readResponse);
         assertEquals(HttpStatus.SC_OK, readResponse.getStatus());
         OrcidMessage retrievedMessage = (OrcidMessage) readResponse.getEntity();
-        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcidIdentifier().getPath());
         GivenNames givenNames = retrievedMessage.getOrcidProfile().getOrcidBio().getPersonalDetails().getGivenNames();
         assertNotNull(givenNames);
         assertEquals("Reserved For Claim", givenNames.getContent());

--- a/orcid-api-web/src/test/java/org/orcid/api/t2/server/delegator/T2OrcidApiServiceVersionedDelegatorTest.java
+++ b/orcid-api-web/src/test/java/org/orcid/api/t2/server/delegator/T2OrcidApiServiceVersionedDelegatorTest.java
@@ -69,7 +69,6 @@ import org.orcid.test.DBUnitTest;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.oauth2.provider.AuthorizationRequest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -173,7 +172,7 @@ public class T2OrcidApiServiceVersionedDelegatorTest extends DBUnitTest {
         assertNotNull(readResponse);
         assertEquals(HttpStatus.SC_OK, readResponse.getStatus());
         OrcidMessage retrievedMessage = (OrcidMessage) readResponse.getEntity();
-        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcidIdentifier().getPath());
         assertEquals("S. Milligan", retrievedMessage.getOrcidProfile().getOrcidBio().getPersonalDetails().getCreditName().getContent());
     }
 
@@ -196,7 +195,7 @@ public class T2OrcidApiServiceVersionedDelegatorTest extends DBUnitTest {
         assertNotNull(readResponse);
         assertEquals(HttpStatus.SC_OK, readResponse.getStatus());
         OrcidMessage retrievedMessage = (OrcidMessage) readResponse.getEntity();
-        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcidIdentifier().getPath());
         assertEquals("Test credit name", retrievedMessage.getOrcidProfile().getOrcidBio().getPersonalDetails().getCreditName().getContent());
     }
 
@@ -243,7 +242,7 @@ public class T2OrcidApiServiceVersionedDelegatorTest extends DBUnitTest {
         assertNotNull(readResponse);
         assertEquals(HttpStatus.SC_OK, readResponse.getStatus());
         OrcidMessage retrievedMessage = (OrcidMessage) readResponse.getEntity();
-        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(orcid, retrievedMessage.getOrcidProfile().getOrcidIdentifier().getPath());
         GivenNames givenNames = retrievedMessage.getOrcidProfile().getOrcidBio().getPersonalDetails().getGivenNames();
         assertNotNull(givenNames);
         assertEquals("Reserved For Claim", givenNames.getContent());

--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/Jaxb2JpaAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/Jaxb2JpaAdapterImpl.java
@@ -62,22 +62,22 @@ import org.orcid.jaxb.model.message.ExternalIdUrl;
 import org.orcid.jaxb.model.message.ExternalIdentifier;
 import org.orcid.jaxb.model.message.ExternalIdentifiers;
 import org.orcid.jaxb.model.message.FamilyName;
+import org.orcid.jaxb.model.message.Funding;
+import org.orcid.jaxb.model.message.FundingContributors;
+import org.orcid.jaxb.model.message.FundingExternalIdentifier;
+import org.orcid.jaxb.model.message.FundingExternalIdentifiers;
+import org.orcid.jaxb.model.message.FundingList;
+import org.orcid.jaxb.model.message.FundingTitle;
 import org.orcid.jaxb.model.message.FuzzyDate;
 import org.orcid.jaxb.model.message.GivenNames;
 import org.orcid.jaxb.model.message.GivenPermissionBy;
 import org.orcid.jaxb.model.message.GivenPermissionTo;
-import org.orcid.jaxb.model.message.FundingContributors;
-import org.orcid.jaxb.model.message.FundingExternalIdentifier;
-import org.orcid.jaxb.model.message.FundingTitle;
 import org.orcid.jaxb.model.message.Iso3166Country;
 import org.orcid.jaxb.model.message.Keyword;
 import org.orcid.jaxb.model.message.Keywords;
 import org.orcid.jaxb.model.message.Locale;
 import org.orcid.jaxb.model.message.OrcidActivities;
 import org.orcid.jaxb.model.message.OrcidBio;
-import org.orcid.jaxb.model.message.Funding;
-import org.orcid.jaxb.model.message.FundingExternalIdentifiers;
-import org.orcid.jaxb.model.message.FundingList;
 import org.orcid.jaxb.model.message.OrcidHistory;
 import org.orcid.jaxb.model.message.OrcidInternal;
 import org.orcid.jaxb.model.message.OrcidPatent;
@@ -113,9 +113,9 @@ import org.orcid.persistence.dao.OrgDisambiguatedDao;
 import org.orcid.persistence.jpa.entities.EmailEntity;
 import org.orcid.persistence.jpa.entities.EndDateEntity;
 import org.orcid.persistence.jpa.entities.ExternalIdentifierEntity;
+import org.orcid.persistence.jpa.entities.FundingExternalIdentifierEntity;
 import org.orcid.persistence.jpa.entities.GivenPermissionByEntity;
 import org.orcid.persistence.jpa.entities.GivenPermissionToEntity;
-import org.orcid.persistence.jpa.entities.FundingExternalIdentifierEntity;
 import org.orcid.persistence.jpa.entities.OrgAffiliationRelationEntity;
 import org.orcid.persistence.jpa.entities.OrgEntity;
 import org.orcid.persistence.jpa.entities.OtherNameEntity;
@@ -162,7 +162,7 @@ public class Jaxb2JpaAdapterImpl implements Jaxb2JpaAdapter {
         ProfileEntity profileEntity = existingProfileEntity == null ? new ProfileEntity() : existingProfileEntity;
 
         // if orcid-id exist us it
-        String orcidString = profile.getOrcid().getValue();
+        String orcidString = profile.getOrcidIdentifier().getPath();
         if (profile.retrieveOrcidUriAsString() != null && !profile.retrieveOrcidUriAsString().isEmpty()) {
             orcidString = OrcidStringUtils.getOrcidNumber(profile.retrieveOrcidUriAsString());
         }
@@ -918,7 +918,7 @@ public class Jaxb2JpaAdapterImpl implements Jaxb2JpaAdapter {
                     GivenPermissionToEntity givenPermissionToEntity = new GivenPermissionToEntity();
                     givenPermissionToEntity.setGiver(profileEntity.getId());
                     DelegateSummary profileSummary = delegationDetails.getDelegateSummary();
-                    ProfileSummaryEntity profileSummaryEntity = new ProfileSummaryEntity(profileSummary.getOrcid().getValue());
+                    ProfileSummaryEntity profileSummaryEntity = new ProfileSummaryEntity(profileSummary.getOrcidIdentifier().getPath());
                     profileSummaryEntity.setCreditName(profileSummary.getCreditName() != null ? profileSummary.getCreditName().getContent() : null);
                     givenPermissionToEntity.setReceiver(profileSummaryEntity);
                     ApprovalDate approvalDate = delegationDetails.getApprovalDate();
@@ -943,7 +943,7 @@ public class Jaxb2JpaAdapterImpl implements Jaxb2JpaAdapter {
                 for (DelegationDetails delegationDetails : givenPermissionBy.getDelegationDetails()) {
                     GivenPermissionByEntity givenPermissionByEntity = new GivenPermissionByEntity();
                     DelegateSummary profileSummary = delegationDetails.getDelegateSummary();
-                    ProfileSummaryEntity profileSummaryEntity = new ProfileSummaryEntity(profileSummary.getOrcid().getValue());
+                    ProfileSummaryEntity profileSummaryEntity = new ProfileSummaryEntity(profileSummary.getOrcidIdentifier().getPath());
                     profileSummaryEntity.setCreditName(profileSummary.getCreditName().getContent());
                     givenPermissionByEntity.setGiver(profileSummaryEntity);
                     givenPermissionByEntity.setReceiver(profileEntity.getId());

--- a/orcid-core/src/main/java/org/orcid/core/cli/OrcidBatchLoad.java
+++ b/orcid-core/src/main/java/org/orcid/core/cli/OrcidBatchLoad.java
@@ -19,6 +19,7 @@ package org.orcid.core.cli;
 import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.Date;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
@@ -113,7 +114,7 @@ public class OrcidBatchLoad {
     private void assignPersistenceFields(OrcidProfile profile) {
         // set the transient fields that the encrypters need
         profile.setPassword("password");
-        // profile.setOrcid();
+        // profile.setOrcidIdentifier();
         profile.setSecurityQuestionAnswer("securityQuestionAnswer");
         profile.setVerificationCode("1111");
 

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidClientGroupManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidClientGroupManagerImpl.java
@@ -204,7 +204,7 @@ public class OrcidClientGroupManagerImpl implements OrcidClientGroupManager {
         if (groupOrcid == null) {
             OrcidProfile groupProfile = createGroupProfile(orcidClientGroup);
             groupProfile = orcidProfileManager.createOrcidProfile(groupProfile);
-            groupOrcid = groupProfile.getOrcid().getValue();
+            groupOrcid = groupProfile.getOrcidIdentifier().getPath();
             orcidClientGroup.setGroupOrcid(groupOrcid);
         }
 
@@ -257,7 +257,7 @@ public class OrcidClientGroupManagerImpl implements OrcidClientGroupManager {
         clientProfile = orcidProfileManager.createOrcidProfile(clientProfile);
         // Now the client profile has been created, use the profile DAO
         // to link it to the group.
-        ProfileEntity clientProfileEntity = profileDao.find(clientProfile.getOrcid().getValue());
+        ProfileEntity clientProfileEntity = profileDao.find(clientProfile.getOrcidIdentifier().getPath());
         clientProfileEntity.setGroupOrcid(groupOrcid);
         profileDao.merge(clientProfileEntity);
         // And link the client to the copy of the profile cached in
@@ -271,7 +271,7 @@ public class OrcidClientGroupManagerImpl implements OrcidClientGroupManager {
         }
         clientProfileEntities.add(clientProfileEntity);
         // Use the client details service to create the client details
-        ClientDetailsEntity clientDetailsEntity = createClientDetails(clientProfile.getOrcid().getValue(), client, client.getType());
+        ClientDetailsEntity clientDetailsEntity = createClientDetails(clientProfile.getOrcidIdentifier().getPath(), client, client.getType());
         // And put the client details into the copy of the profile
         // entity cached in memory by Hibernate.
         clientProfileEntity.setClientDetails(clientDetailsEntity);
@@ -394,14 +394,14 @@ public class OrcidClientGroupManagerImpl implements OrcidClientGroupManager {
             clientProfile = orcidProfileManager.createOrcidProfile(clientProfile);
             // Now the client profile has been created, use the profile DAO
             // to link it to the group.
-            ProfileEntity clientProfileEntity = profileDao.find(clientProfile.getOrcid().getValue());
+            ProfileEntity clientProfileEntity = profileDao.find(clientProfile.getOrcidIdentifier().getPath());
             clientProfileEntity.setGroupOrcid(groupOrcid);
             profileDao.merge(clientProfileEntity);
             // And link the client to the copy of the profile cached in
             // memory by Hibernate
             clientProfileEntities.add(clientProfileEntity);
             // Use the client details service to create the client details
-            ClientDetailsEntity clientDetailsEntity = createClientDetails(clientProfile.getOrcid().getValue(), client, clientType);
+            ClientDetailsEntity clientDetailsEntity = createClientDetails(clientProfile.getOrcidIdentifier().getPath(), client, clientType);
             // And put the client details into the copy of the profile
             // entity cached in memory by Hibernate.
             clientProfileEntity.setClientDetails(clientDetailsEntity);
@@ -458,7 +458,7 @@ public class OrcidClientGroupManagerImpl implements OrcidClientGroupManager {
         Map<String, ClientRedirectUriEntity> clientRedirectUriEntitiesMap = ClientRedirectUriEntity.mapByUri(clientRedirectUriEntities);
         clientRedirectUriEntities.clear();
         Set<RedirectUri> redirectUrisToAdd = new HashSet<RedirectUri>();
-        redirectUrisToAdd.addAll(client.getRedirectUris().getRedirectUri());        
+        redirectUrisToAdd.addAll(client.getRedirectUris().getRedirectUri());
         for (RedirectUri redirectUri : redirectUrisToAdd) {
             if (clientRedirectUriEntitiesMap.containsKey(redirectUri.getValue())) {
                 clientRedirectUriEntities.add(clientRedirectUriEntitiesMap.get(redirectUri.getValue()));

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidIndexManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidIndexManagerImpl.java
@@ -80,13 +80,13 @@ public class OrcidIndexManagerImpl implements OrcidIndexManager {
 		OrcidProfile filteredProfile = filteredMessage.getOrcidProfile();
 
 		OrcidSolrDocument profileIndexDocument = new OrcidSolrDocument();
-		profileIndexDocument.setOrcid(filteredProfile.getOrcid().getValue());
+		profileIndexDocument.setOrcid(filteredProfile.getOrcidIdentifier().getPath());
 
 		OrcidDeprecated orcidDeprecated = filteredProfile.getOrcidDeprecated();
 		if (orcidDeprecated != null) {
 			profileIndexDocument.setPrimaryRecord(orcidDeprecated
 					.getPrimaryRecord() != null ? orcidDeprecated
-					.getPrimaryRecord().getOrcid().getValue() : null);
+					.getPrimaryRecord().getOrcidIdentifier().getPath() : null);
 		}
 
 		OrcidBio orcidBio = filteredProfile.getOrcidBio();
@@ -345,7 +345,7 @@ public class OrcidIndexManagerImpl implements OrcidIndexManager {
 
 	@Override
 	public void deleteOrcidProfile(OrcidProfile orcidProfile) {
-		deleteOrcidProfile(orcidProfile.getOrcid().getValue());
+		deleteOrcidProfile(orcidProfile.getOrcidIdentifier().getPath());
 
 	}
 

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidProfileManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidProfileManagerImpl.java
@@ -260,7 +260,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile createOrcidProfile(OrcidProfile orcidProfile) {
-        if (orcidProfile.getOrcid() == null) {
+        if (orcidProfile.getOrcidIdentifier() == null) {
             orcidProfile.setOrcidIdentifier(orcidGenerationManager.createNewOrcid());
         }
 
@@ -291,7 +291,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Transactional
     public OrcidProfile updateOrcidProfile(OrcidProfile orcidProfile) {
         String amenderOrcid = sourceManager.retrieveSourceOrcid();
-        ProfileEntity existingProfileEntity = profileDao.find(orcidProfile.getOrcid().getValue());
+        ProfileEntity existingProfileEntity = profileDao.find(orcidProfile.getOrcidIdentifier().getPath());
         if (existingProfileEntity != null) {
             profileDao.removeChildrenWithGeneratedIds(existingProfileEntity);
             setWorkPrivacy(orcidProfile, existingProfileEntity.getWorkVisibilityDefault());
@@ -672,7 +672,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
 
     private OrcidProfile createReservedForClaimOrcidProfile(String orcid, OrcidDeprecated deprecatedInfo, LastModifiedDate lastModifiedDate) {
         OrcidProfile op = new OrcidProfile();
-        op.setOrcid(orcid);
+        op.setOrcidIdentifier(orcid);
 
         if (deprecatedInfo != null)
             op.setOrcidDeprecated(deprecatedInfo);
@@ -768,7 +768,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile updateOrcidWorks(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
 
         if (existingProfile == null) {
             return null;
@@ -787,7 +787,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile addExternalIdentifiers(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
 
         if (existingProfile != null && existingProfile.getOrcidBio() != null) {
             OrcidBio orcidBio = existingProfile.getOrcidBio();
@@ -822,7 +822,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile updateOrcidBio(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
         if (existingProfile == null) {
             return null;
         }
@@ -835,7 +835,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile updatePersonalInformation(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
 
         if (existingProfile == null) {
             return null;
@@ -849,7 +849,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile updateOrcidHistory(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
 
         if (existingProfile == null) {
             return null;
@@ -862,7 +862,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile updateAffiliations(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
         if (existingProfile == null) {
             return null;
         }
@@ -892,7 +892,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile updateFundings(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
         if (existingProfile == null) {
             return null;
         }
@@ -922,7 +922,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public void updatePasswordInformation(OrcidProfile updatedOrcidProfile) {
-        String orcid = updatedOrcidProfile.getOrcid().getValue();
+        String orcid = updatedOrcidProfile.getOrcidIdentifier().getPath();
         String hashedPassword = hash(updatedOrcidProfile.getPassword());
         profileDao.updateEncryptedPassword(orcid, hashedPassword);
         OrcidProfile cachedProfile = getOrcidProfileFromCache(orcid);
@@ -952,7 +952,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
 
     @Override
     public void updateSecurityQuestionInformation(OrcidProfile updatedOrcidProfile) {
-        String orcid = updatedOrcidProfile.getOrcid().getValue();
+        String orcid = updatedOrcidProfile.getOrcidIdentifier().getPath();
         SecurityQuestionId securityQuestionId = updatedOrcidProfile.getOrcidInternal().getSecurityDetails().getSecurityQuestionId();
         Integer questionId = null;
         if (securityQuestionId != null) {
@@ -975,7 +975,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile updatePreferences(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
         if (existingProfile == null) {
             return null;
         }
@@ -987,7 +987,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile updateOrcidPreferences(OrcidProfile updatedOrcidProfile) {
-        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcid().getValue());
+        OrcidProfile existingProfile = retrieveOrcidProfile(updatedOrcidProfile.getOrcidIdentifier().getPath());
         if (existingProfile == null) {
             return null;
         }
@@ -1186,7 +1186,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
         minimalBio.setBiography(new Biography());
         minimalBio.setExternalIdentifiers(new ExternalIdentifiers());
         blankedOrcidProfile.setOrcidBio(minimalBio);
-        blankedOrcidProfile.setOrcid(existingOrcidProfile.getOrcid().getValue());
+        blankedOrcidProfile.setOrcidIdentifier(existingOrcidProfile.getOrcidIdentifier().getPath());
 
         return this.updateOrcidProfile(blankedOrcidProfile);
     }
@@ -1259,7 +1259,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public void addAffiliations(OrcidProfile updatedOrcidProfile) {
-        String orcid = updatedOrcidProfile.getOrcid().getValue();
+        String orcid = updatedOrcidProfile.getOrcidIdentifier().getPath();
         OrcidProfile existingProfile = retrieveOrcidProfile(orcid);
         if (existingProfile == null) {
             throw new IllegalArgumentException("No record found for " + orcid);
@@ -1287,7 +1287,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public void addFundings(OrcidProfile updatedOrcidProfile) {
-        String orcid = updatedOrcidProfile.getOrcid().getValue();
+        String orcid = updatedOrcidProfile.getOrcidIdentifier().getPath();
         OrcidProfile existingProfile = retrieveOrcidProfile(orcid);
         if (existingProfile == null) {
             throw new IllegalArgumentException("No record found for " + orcid);
@@ -1482,7 +1482,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     @Override
     @Transactional
     public OrcidProfile addDelegates(OrcidProfile updatedOrcidProfile) {
-        String orcid = updatedOrcidProfile.getOrcid().getValue();
+        String orcid = updatedOrcidProfile.getOrcidIdentifier().getPath();
         OrcidProfile existingProfile = retrieveOrcidProfile(orcid);
         if (existingProfile == null) {
             return null;
@@ -1829,7 +1829,7 @@ public class OrcidProfileManagerImpl implements OrcidProfileManager {
     }
 
     private void putInCache(OrcidProfile orcidProfile) {
-        putInCache(orcidProfile.getOrcid().getValue(), orcidProfile);
+        putInCache(orcidProfile.getOrcidIdentifier().getPath(), orcidProfile);
     }
 
     private void putInCache(String orcid, OrcidProfile orcidProfile) {

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/ProfileEntityManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/ProfileEntityManagerImpl.java
@@ -108,7 +108,7 @@ public class ProfileEntityManagerImpl implements ProfileEntityManager {
         profile.setOtherNamesVisibility(orcidProfile.getOrcidBio().getPersonalDetails().getOtherNames().getVisibility());
         profile.setCreditNameVisibility(orcidProfile.getOrcidBio().getPersonalDetails().getCreditName().getVisibility());
         profile.setProfileAddressVisibility(orcidProfile.getOrcidBio().getContactDetails().getAddress().getCountry().getVisibility());
-        profile.setId(orcidProfile.getOrcid().getValue());
+        profile.setId(orcidProfile.getOrcidIdentifier().getPath());
         return profile;
     }
     

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/RegistrationManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/RegistrationManagerImpl.java
@@ -90,7 +90,7 @@ public class RegistrationManagerImpl implements RegistrationManager {
 
     @Override
     public void verifyRegistration(OrcidProfile orcidProfile, URI baseUri) {
-        LOGGER.debug("Verifying registration: {}", orcidProfile.getOrcid().getValue());
+        LOGGER.debug("Verifying registration: {}", orcidProfile.getOrcidIdentifier().getPath());
         OrcidHistory orcidHistory = orcidProfile.getOrcidHistory();
         if (orcidHistory == null) {
             orcidHistory = new OrcidHistory();
@@ -105,9 +105,9 @@ public class RegistrationManagerImpl implements RegistrationManager {
 
     @Override
     public void resetUserPassword(String toEmail, OrcidProfile orcidProfile, URI baseUri) {
-        LOGGER.debug("Resetting password for Orcid: {}", orcidProfile.getOrcid().getValue());
+        LOGGER.debug("Resetting password for Orcid: {}", orcidProfile.getOrcidIdentifier().getPath());
         if (!orcidProfile.getOrcidHistory().isClaimed()) {
-            LOGGER.debug("Profile is not claimed so re-sending claim email instead of password reset: {}", orcidProfile.getOrcid().getValue());
+            LOGGER.debug("Profile is not claimed so re-sending claim email instead of password reset: {}", orcidProfile.getOrcidIdentifier().getPath());
             notificationManager.sendApiRecordCreationEmail(toEmail,orcidProfile);
         } else {
             notificationManager.sendPasswordResetEmail(toEmail, orcidProfile, baseUri);
@@ -130,7 +130,7 @@ public class RegistrationManagerImpl implements RegistrationManager {
     public OrcidProfile createMinimalRegistration(OrcidProfile orcidProfile) {
         OrcidProfile minimalProfile = orcidProfileManager.createOrcidProfile(orcidProfile);
         orcidProfileManager.processProfilePendingIndexingInTransaction(orcidProfile.getOrcidIdentifier().getPath());
-        LOGGER.debug("Created minimal orcid and assigned id of {}", orcidProfile.getOrcid().getValue());
+        LOGGER.debug("Created minimal orcid and assigned id of {}", orcidProfile.getOrcidIdentifier().getPath());
         return minimalProfile;
     }
 

--- a/orcid-core/src/main/java/org/orcid/core/profileEvent/CrossRefEmail.java
+++ b/orcid-core/src/main/java/org/orcid/core/profileEvent/CrossRefEmail.java
@@ -87,7 +87,7 @@ public class CrossRefEmail implements ProfileEvent {
                     LOG.debug("SendEventEmail exception", e);
                 }
                 templateParams.put("verificationUrl", verificationUrl);
-                templateParams.put("orcid", orcidProfile.getOrcid().getValue());
+                templateParams.put("orcid", orcidProfile.getOrcidIdentifier().getPath());
                 templateParams.put("baseUri", orcidUrlManager.getBaseUrl());
                 String text = templateManager.processTemplate("verification_email_w_crossref.ftl", templateParams);
                 String html = templateManager.processTemplate("verification_email_w_crossref_html.ftl", templateParams);

--- a/orcid-core/src/test/java/org/orcid/core/adapter/JpaJaxbEntityAdapterToOrcidProfileTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/JpaJaxbEntityAdapterToOrcidProfileTest.java
@@ -198,7 +198,7 @@ public class JpaJaxbEntityAdapterToOrcidProfileTest extends DBUnitTest {
         assertNotNull(orcidProfile.getOrcidDeprecated().getPrimaryRecord());
         assertNotNull(orcidProfile.getOrcidDeprecated().getPrimaryRecord().getOrcid());
         assertNotNull(orcidProfile.getOrcidDeprecated().getPrimaryRecord().getOrcidId());
-        assertEquals("4444-4444-4444-4441", orcidProfile.getOrcidDeprecated().getPrimaryRecord().getOrcid().getValue());
+        assertEquals("4444-4444-4444-4441", orcidProfile.getOrcidDeprecated().getPrimaryRecord().getOrcidIdentifier().getPath());
         assertTrue(orcidProfile.getOrcidDeprecated().getPrimaryRecord().getOrcidId().getValue().endsWith("/4444-4444-4444-4441"));
         validateAgainstSchema(new OrcidMessage(orcidProfile));
     }
@@ -215,7 +215,7 @@ public class JpaJaxbEntityAdapterToOrcidProfileTest extends DBUnitTest {
         assertNotNull(orcidProfile.retrieveOrcidWorks());
         checkOrcidWorks(orcidProfile.retrieveOrcidWorks());
         checkOrcidFundings(orcidProfile.retrieveFundings());
-        assertEquals("4444-4444-4444-4443", orcidProfile.getOrcid().getValue());
+        assertEquals("4444-4444-4444-4443", orcidProfile.getOrcidIdentifier().getPath());
 
         assertNotNull(orcidProfile.getOrcidInternal());
         checkOrcidInternal(orcidProfile.getOrcidInternal());
@@ -389,11 +389,11 @@ public class JpaJaxbEntityAdapterToOrcidProfileTest extends DBUnitTest {
         assertNotNull(delegation);
         assertEquals(1, delegation.getGivenPermissionTo().getDelegationDetails().size());
         DelegationDetails givenPermssionToDetails = delegation.getGivenPermissionTo().getDelegationDetails().iterator().next();
-        assertEquals("4444-4444-4444-4446", givenPermssionToDetails.getDelegateSummary().getOrcid().getValue());
+        assertEquals("4444-4444-4444-4446", givenPermssionToDetails.getDelegateSummary().getOrcidIdentifier().getPath());
         assertTrue(givenPermssionToDetails.getApprovalDate().getValue().toXMLFormat().startsWith("2011-10-17T16:59:32.000"));
         assertEquals(1, delegation.getGivenPermissionBy().getDelegationDetails().size());
         DelegationDetails givenPermissionByDetails = delegation.getGivenPermissionBy().getDelegationDetails().iterator().next();
-        assertEquals("4444-4444-4444-4441", givenPermissionByDetails.getDelegateSummary().getOrcid().getValue());
+        assertEquals("4444-4444-4444-4441", givenPermissionByDetails.getDelegateSummary().getOrcidIdentifier().getPath());
         assertTrue(givenPermissionByDetails.getApprovalDate().getValue().toXMLFormat().startsWith("2011-08-24T11:28:16.000"));
     }
 

--- a/orcid-core/src/test/java/org/orcid/core/adapter/JpaJaxbEntityAdapterToProfileEntityTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/JpaJaxbEntityAdapterToProfileEntityTest.java
@@ -126,7 +126,7 @@ public class JpaJaxbEntityAdapterToProfileEntityTest extends DBUnitTest {
         assertNotNull(profileEntity);
         profileDao.persist(profileEntity);
 
-        ProfileEntity retrievedProfileEntity = profileDao.find(orcidMessage.getOrcidProfile().getOrcid().getValue());
+        ProfileEntity retrievedProfileEntity = profileDao.find(orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
         assertNotNull(retrievedProfileEntity);
         assertEquals("Josiah", retrievedProfileEntity.getGivenNames());
 
@@ -241,7 +241,7 @@ public class JpaJaxbEntityAdapterToProfileEntityTest extends DBUnitTest {
         assertNotNull(profileEntity);
         profileDao.persist(profileEntity);
 
-        ProfileEntity retrievedProfileEntity = profileDao.find(orcidMessage.getOrcidProfile().getOrcid().getValue());
+        ProfileEntity retrievedProfileEntity = profileDao.find(orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
         assertNotNull(retrievedProfileEntity);
         assertEquals("Josiah", retrievedProfileEntity.getGivenNames());
         assertEquals("abc123", retrievedProfileEntity.getEncryptedPassword());

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidIndexManagerImplTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidIndexManagerImplTest.java
@@ -265,7 +265,7 @@ public class OrcidIndexManagerImplTest extends BaseTest {
      */
     private OrcidProfile getOrcidProfileMandatoryOnly() {
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid("5678");
+        orcidProfile.setOrcidIdentifier("5678");
         OrcidBio orcidBio = new OrcidBio();
         orcidProfile.setOrcidBio(orcidBio);
         ContactDetails contactDetails = new ContactDetails();
@@ -405,7 +405,7 @@ public class OrcidIndexManagerImplTest extends BaseTest {
 
     private OrcidProfile getStandardOrcid() {
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid("1234");
+        orcidProfile.setOrcidIdentifier("1234");
 
         OrcidBio orcidBio = new OrcidBio();
         ContactDetails contactDetails = new ContactDetails();

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidIndexManagerTypeMatcherTestFactory.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidIndexManagerTypeMatcherTestFactory.java
@@ -40,7 +40,7 @@ class OrcidIndexManagerTypeMatcherTestFactory {
 
             @Override
             public boolean matchesSafely(OrcidProfile orcidProfile) {
-                if (!"4444-4444-4444-4447".equals(orcidProfile.getOrcid().getValue())) {
+                if (!"4444-4444-4444-4447".equals(orcidProfile.getOrcidIdentifier().getPath())) {
                     return false;
                 }
 

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidMultiThreadedIndexingTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidMultiThreadedIndexingTest.java
@@ -48,7 +48,7 @@ public class OrcidMultiThreadedIndexingTest extends OrcidProfileManagerBaseTest 
         subjectDao.merge(new SubjectEntity("Dance"));
 
         OrcidProfile delegateProfile = new OrcidProfile();
-        delegateProfile.setOrcid(DELEGATE_ORCID);
+        delegateProfile.setOrcidIdentifier(DELEGATE_ORCID);
         OrcidBio delegateBio = new OrcidBio();
         delegateProfile.setOrcidBio(delegateBio);
         PersonalDetails delegatePersonalDetails = new PersonalDetails();
@@ -57,7 +57,7 @@ public class OrcidMultiThreadedIndexingTest extends OrcidProfileManagerBaseTest 
         orcidProfileManager.createOrcidProfile(delegateProfile);
 
         OrcidProfile applicationProfile = new OrcidProfile();
-        applicationProfile.setOrcid(APPLICATION_ORCID);
+        applicationProfile.setOrcidIdentifier(APPLICATION_ORCID);
         OrcidBio applicationBio = new OrcidBio();
         applicationProfile.setOrcidBio(applicationBio);
         PersonalDetails applicationPersonalDetails = new PersonalDetails();

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerBaseTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerBaseTest.java
@@ -129,7 +129,7 @@ public class OrcidProfileManagerBaseTest extends BaseTest {
         OrcidProfile profile2 = new OrcidProfile();
         profile2.setPassword("password");
         profile2.setVerificationCode("1234");
-        profile2.setOrcid(TEST_ORCID);
+        profile2.setOrcidIdentifier(TEST_ORCID);
         OrcidBio bio = new OrcidBio();
         ContactDetails contactDetails = new ContactDetails();
         contactDetails.addOrReplacePrimaryEmail(new Email("will@orcid.org"));

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerImplTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerImplTest.java
@@ -58,10 +58,10 @@ import org.orcid.jaxb.model.message.ExternalIdentifier;
 import org.orcid.jaxb.model.message.ExternalIdentifiers;
 import org.orcid.jaxb.model.message.GivenPermissionTo;
 import org.orcid.jaxb.model.message.Iso3166Country;
-import org.orcid.jaxb.model.message.Orcid;
 import org.orcid.jaxb.model.message.OrcidActivities;
 import org.orcid.jaxb.model.message.OrcidBio;
 import org.orcid.jaxb.model.message.OrcidHistory;
+import org.orcid.jaxb.model.message.OrcidIdentifier;
 import org.orcid.jaxb.model.message.OrcidInternal;
 import org.orcid.jaxb.model.message.OrcidProfile;
 import org.orcid.jaxb.model.message.OrcidWork;
@@ -157,7 +157,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         subjectDao.merge(new SubjectEntity("Dance"));
 
         OrcidProfile delegateProfile = new OrcidProfile();
-        delegateProfile.setOrcid(DELEGATE_ORCID);
+        delegateProfile.setOrcidIdentifier(DELEGATE_ORCID);
         OrcidBio delegateBio = new OrcidBio();
         delegateProfile.setOrcidBio(delegateBio);
         PersonalDetails delegatePersonalDetails = new PersonalDetails();
@@ -166,7 +166,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         orcidProfileManager.createOrcidProfile(delegateProfile);
 
         OrcidProfile applicationProfile = new OrcidProfile();
-        applicationProfile.setOrcid(APPLICATION_ORCID);
+        applicationProfile.setOrcidIdentifier(APPLICATION_ORCID);
         OrcidBio applicationBio = new OrcidBio();
         applicationProfile.setOrcidBio(applicationBio);
         PersonalDetails applicationPersonalDetails = new PersonalDetails();
@@ -175,8 +175,8 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         orcidProfileManager.createOrcidProfile(applicationProfile);
 
         ClientDetailsEntity clientDetails = new ClientDetailsEntity();
-        clientDetails.setId(applicationProfile.getOrcid().getValue());
-        ProfileEntity applicationProfileEntity = profileDao.find(applicationProfile.getOrcid().getValue());
+        clientDetails.setId(applicationProfile.getOrcidIdentifier().getPath());
+        ProfileEntity applicationProfileEntity = profileDao.find(applicationProfile.getOrcidIdentifier().getPath());
         profileDao.refresh(applicationProfileEntity);
         clientDetails.setProfileEntity(applicationProfileEntity);
         clientDetailsDao.merge(clientDetails);
@@ -184,11 +184,11 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         OrcidOauth2TokenDetail token = new OrcidOauth2TokenDetail();
         token.setTokenValue("1234");
         token.setClientDetailsEntity(clientDetails);
-        token.setProfile(profileDao.find(delegateProfile.getOrcid().getValue()));
+        token.setProfile(profileDao.find(delegateProfile.getOrcidIdentifier().getPath()));
         token.setScope(StringUtils.join(new String[] { ScopePathType.ORCID_BIO_READ_LIMITED.value(), ScopePathType.ORCID_BIO_UPDATE.value() }, " "));
         SortedSet<OrcidOauth2TokenDetail> tokens = new TreeSet<>();
         tokens.add(token);
-        ProfileEntity delegateProfileEntity = profileDao.find(delegateProfile.getOrcid().getValue());
+        ProfileEntity delegateProfileEntity = profileDao.find(delegateProfile.getOrcidIdentifier().getPath());
         delegateProfileEntity.setTokenDetails(tokens);
         profileDao.merge(delegateProfileEntity);
 
@@ -318,7 +318,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         assertEquals(1, profile1.getOrcidBio().getApplications().getApplicationSummary().size());
 
         OrcidProfile profile2 = createBasicProfile();
-        profile2.setOrcid(DELEGATE_ORCID);
+        profile2.setOrcidIdentifier(DELEGATE_ORCID);
 
         orcidProfileManager.updateOrcidProfile(profile2);
 
@@ -826,7 +826,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         assertEquals("random answer", encryptionManager.decryptForInternalUse(derivedProfile.getSecurityQuestionAnswer()));
         assertEquals("1234", encryptionManager.decryptForInternalUse(derivedProfile.getVerificationCode()));
 
-        OrcidProfile retrievedProfile = orcidProfileManager.retrieveOrcidProfile(derivedProfile.getOrcid().getValue());
+        OrcidProfile retrievedProfile = orcidProfileManager.retrieveOrcidProfile(derivedProfile.getOrcidIdentifier().getPath());
         assertTrue(encryptionManager.hashMatches("password", derivedProfile.getPassword()));
         assertEquals("random answer", retrievedProfile.getSecurityQuestionAnswer());
         assertEquals("1234", retrievedProfile.getVerificationCode());
@@ -841,7 +841,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         assertEquals(Visibility.PRIVATE, profile1.getOrcidInternal().getPreferences().getWorkVisibilityDefault().getValue());
 
         OrcidProfile profile2 = new OrcidProfile();
-        profile2.setOrcid(TEST_ORCID);
+        profile2.setOrcidIdentifier(TEST_ORCID);
         OrcidInternal internal = new OrcidInternal();
         profile2.setOrcidInternal(internal);
         Preferences preferences = new Preferences();
@@ -866,7 +866,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         orcidProfileManager.createOrcidProfile(profile1);
 
         OrcidProfile profile2 = new OrcidProfile();
-        profile2.setOrcid(TEST_ORCID);
+        profile2.setOrcidIdentifier(TEST_ORCID);
         OrcidBio orcidBio = new OrcidBio();
         orcidBio.setPersonalDetails(new PersonalDetails());
 
@@ -942,7 +942,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
 
         String otherOrcid = "4444-4444-4444-4448";
         OrcidProfile profile2 = createBasicProfile();
-        profile2.setOrcid(otherOrcid);
+        profile2.setOrcidIdentifier(otherOrcid);
         List<Email> emailList2 = profile2.getOrcidBio().getContactDetails().getEmail();
         emailList2.clear();
         emailList2.add(new Email("another@semantico.com"));
@@ -966,7 +966,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         orcidProfileManager.createOrcidProfile(profile1);
 
         OrcidProfile profile2 = new OrcidProfile();
-        profile2.setOrcid(TEST_ORCID);
+        profile2.setOrcidIdentifier(TEST_ORCID);
         OrcidBio orcidBio = new OrcidBio();
         profile2.setOrcidBio(orcidBio);
         Delegation delegation = new Delegation();
@@ -975,7 +975,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         delegation.setGivenPermissionTo(givenPermissionTo);
         DelegationDetails delegationDetails = new DelegationDetails();
         delegationDetails.setApprovalDate(new ApprovalDate(DateUtils.convertToXMLGregorianCalendar("2011-03-14T02:34:16")));
-        DelegateSummary delegateSummary = new DelegateSummary(new Orcid(DELEGATE_ORCID));
+        DelegateSummary delegateSummary = new DelegateSummary(new OrcidIdentifier(DELEGATE_ORCID));
         delegationDetails.setDelegateSummary(delegateSummary);
         givenPermissionTo.getDelegationDetails().add(delegationDetails);
         orcidProfileManager.addDelegates(profile2);
@@ -988,7 +988,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         DelegationDetails retrievedDelegationDetails = retrievedGivenPermissionTo.getDelegationDetails().get(0);
         DelegateSummary retrievedDelegateSummary = retrievedDelegationDetails.getDelegateSummary();
         assertNotNull(retrievedDelegateSummary);
-        assertEquals(DELEGATE_ORCID, retrievedDelegateSummary.getOrcid().getValue());
+        assertEquals(DELEGATE_ORCID, retrievedDelegateSummary.getOrcidIdentifier().getPath());
         assertEquals("H. Shearer", retrievedDelegateSummary.getCreditName().getContent());
         assertEquals(DateUtils.convertToDate("2011-03-14T02:34:16"), DateUtils.convertToDate(retrievedDelegationDetails.getApprovalDate().getValue()));
         verify(notificationManager, times(1)).sendNotificationToAddedDelegate(any(OrcidProfile.class), any(List.class));
@@ -1005,7 +1005,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         delegation.setGivenPermissionTo(givenPermissionTo);
         DelegationDetails delegationDetails = new DelegationDetails();
         delegationDetails.setApprovalDate(new ApprovalDate(DateUtils.convertToXMLGregorianCalendar("2011-03-14T02:34:16")));
-        DelegateSummary profileSummary = new DelegateSummary(new Orcid(DELEGATE_ORCID));
+        DelegateSummary profileSummary = new DelegateSummary(new OrcidIdentifier(DELEGATE_ORCID));
         delegationDetails.setDelegateSummary(profileSummary);
         givenPermissionTo.getDelegationDetails().add(delegationDetails);
         orcidProfileManager.createOrcidProfile(profile1);
@@ -1025,7 +1025,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         assertEquals("random answer", profile1.getSecurityQuestionAnswer());
         orcidProfileManager.createOrcidProfile(profile1);
 
-        OrcidProfile retrievedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcid().getValue());
+        OrcidProfile retrievedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcidIdentifier().getPath());
 
         String hashedPasswordValue = retrievedProfile.getPassword();
         assertTrue("Should have hashed password", 108 == hashedPasswordValue.length() && !"password".equals(hashedPasswordValue));
@@ -1036,7 +1036,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
 
         orcidProfileManager.updatePasswordInformation(retrievedProfile);
 
-        OrcidProfile updatedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcid().getValue());
+        OrcidProfile updatedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcidIdentifier().getPath());
 
         String updatedPassword = updatedProfile.getPassword();
         assertEquals("Password should be hashed", 108, updatedPassword.length());
@@ -1054,7 +1054,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         assertEquals("random answer", profile1.getSecurityQuestionAnswer());
         orcidProfileManager.createOrcidProfile(profile1);
 
-        OrcidProfile retrievedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcid().getValue());
+        OrcidProfile retrievedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcidIdentifier().getPath());
 
         String hashedPasswordValue = retrievedProfile.getPassword();
         assertTrue("Should have hashed password", 108 == hashedPasswordValue.length() && !"password".equals(hashedPasswordValue));
@@ -1065,7 +1065,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
 
         orcidProfileManager.updateSecurityQuestionInformation(retrievedProfile);
 
-        OrcidProfile updatedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcid().getValue());
+        OrcidProfile updatedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcidIdentifier().getPath());
 
         assertTrue("Password should not have changed", hashedPasswordValue.equals(updatedProfile.getPassword()));
         assertEquals("Should have security question", 3, updatedProfile.getOrcidInternal().getSecurityDetails().getSecurityQuestionId().getValue());
@@ -1107,7 +1107,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
 
         orcidProfileManager.deactivateOrcidProfile(profile1);
 
-        OrcidProfile retrievedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcid().getValue());
+        OrcidProfile retrievedProfile = orcidProfileManager.retrieveOrcidProfile(profile1.getOrcidIdentifier().getPath());
         assertTrue(retrievedProfile.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().isEmpty());
         assertNull(retrievedProfile.getOrcidBio().getBiography());
     }

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidSearchManagerImplTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidSearchManagerImplTest.java
@@ -118,7 +118,7 @@ public class OrcidSearchManagerImplTest extends BaseTest {
         assertTrue(new Float(37.2).compareTo(result.getRelevancyScore().getValue()) == 0);
 
         OrcidProfile retrievedProfile = result.getOrcidProfile();
-        assertEquals("5678", retrievedProfile.getOrcid().getValue());
+        assertEquals("5678", retrievedProfile.getOrcidIdentifier().getPath());
         OrcidBio orcidBio = retrievedProfile.getOrcidBio();
         assertEquals("Logan", orcidBio.getPersonalDetails().getFamilyName().getContent());
         assertEquals("Donald Edward", orcidBio.getPersonalDetails().getGivenNames().getContent());
@@ -183,7 +183,7 @@ public class OrcidSearchManagerImplTest extends BaseTest {
 
         OrcidSearchResult result = retrievedOrcidMessage.getOrcidSearchResults().getOrcidSearchResult().get(0);
         OrcidProfile retrievedProfile = result.getOrcidProfile();
-        assertEquals("5678", retrievedProfile.getOrcid().getValue());
+        assertEquals("5678", retrievedProfile.getOrcidIdentifier().getPath());
         OrcidBio orcidBio = retrievedProfile.getOrcidBio();
         assertEquals("Logan", orcidBio.getPersonalDetails().getFamilyName().getContent());
         assertEquals("Donald Edward", orcidBio.getPersonalDetails().getGivenNames().getContent());
@@ -213,12 +213,12 @@ public class OrcidSearchManagerImplTest extends BaseTest {
         assertTrue(retrievedOrcidMessage.getOrcidSearchResults() != null && retrievedOrcidMessage.getOrcidSearchResults().getOrcidSearchResult().size() == 1);
         OrcidSearchResult searchResult = retrievedOrcidMessage.getOrcidSearchResults().getOrcidSearchResult().get(0);
         OrcidProfile profileReturnedFromSearch = searchResult.getOrcidProfile();
-        assertEquals("5678", profileReturnedFromSearch.getOrcid().getValue());
+        assertEquals("5678", profileReturnedFromSearch.getOrcidIdentifier().getPath());
     }
 
     private OrcidProfile getOrcidProfile5678MandatoryOnly() {
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid("5678");
+        orcidProfile.setOrcidIdentifier("5678");
         OrcidBio orcidBio = new OrcidBio();
         PersonalDetails personalDetails = new PersonalDetails();
         personalDetails.setFamilyName(new FamilyName("Logan"));
@@ -231,7 +231,7 @@ public class OrcidSearchManagerImplTest extends BaseTest {
 
     private OrcidProfile getOrcidProfile6789MandatoryOnly() {
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid("6789");
+        orcidProfile.setOrcidIdentifier("6789");
         OrcidBio orcidBio = new OrcidBio();
         orcidProfile.setOrcidBio(orcidBio);
         ContactDetails contactDetails = new ContactDetails();
@@ -266,7 +266,7 @@ public class OrcidSearchManagerImplTest extends BaseTest {
 
         OrcidSearchResult result = retrievedOrcidMessage.getOrcidSearchResults().getOrcidSearchResult().get(0);
         OrcidProfile retrievedProfile = result.getOrcidProfile();
-        assertEquals("5678", retrievedProfile.getOrcid().getValue());
+        assertEquals("5678", retrievedProfile.getOrcidIdentifier().getPath());
         OrcidBio orcidBio = retrievedProfile.getOrcidBio();
         assertEquals("Logan", orcidBio.getPersonalDetails().getFamilyName().getContent());
         assertEquals("Donald Edward", orcidBio.getPersonalDetails().getGivenNames().getContent());
@@ -275,7 +275,7 @@ public class OrcidSearchManagerImplTest extends BaseTest {
         OrcidSearchResult result2 = retrievedOrcidMessage.getOrcidSearchResults().getOrcidSearchResult().get(1);
 
         OrcidProfile retrievedProfile2 = result2.getOrcidProfile();
-        assertEquals("6789", retrievedProfile2.getOrcid().getValue());
+        assertEquals("6789", retrievedProfile2.getOrcidIdentifier().getPath());
         OrcidBio orcidBio2 = retrievedProfile2.getOrcidBio();
         assertEquals("Thomson", orcidBio2.getPersonalDetails().getFamilyName().getContent());
         assertEquals("Homer J", orcidBio2.getPersonalDetails().getGivenNames().getContent());
@@ -308,7 +308,7 @@ public class OrcidSearchManagerImplTest extends BaseTest {
 
     private OrcidProfile getOrcidProfileAllIndexFieldsPopulated() {
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid("5678");
+        orcidProfile.setOrcidIdentifier("5678");
 
         OrcidBio orcidBio = new OrcidBio();
         PersonalDetails personalDetails = new PersonalDetails();

--- a/orcid-core/src/test/java/org/orcid/core/manager/impl/RegistrationManagerImplTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/impl/RegistrationManagerImplTest.java
@@ -56,7 +56,7 @@ public class RegistrationManagerImplTest {
     public void testVerifyRegistration() throws Exception {
         assertTrue(RegistrationManagerImpl.REGISTRATIONS_VERIFIED_COUNTER.count() == 0);
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid("xyz");
+        orcidProfile.setOrcidIdentifier("xyz");
         registrationManagerImpl.verifyRegistration(orcidProfile, new URI(""));
         assertTrue(RegistrationManagerImpl.REGISTRATIONS_VERIFIED_COUNTER.count() == 1);
     }
@@ -64,7 +64,7 @@ public class RegistrationManagerImplTest {
     @Test
     public void testVerifyRegistrationNotIncrementedOnException() throws Exception {
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid("xyz");
+        orcidProfile.setOrcidIdentifier("xyz");
         doThrow(new RuntimeException()).when(orcidProfileManager).updateOrcidHistory(orcidProfile);
         assertTrue(RegistrationManagerImpl.REGISTRATIONS_VERIFIED_COUNTER.count() == 0);
 

--- a/orcid-core/src/test/java/org/orcid/core/oauth/service/OrcidAuthorizationCodeServiceTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/oauth/service/OrcidAuthorizationCodeServiceTest.java
@@ -106,7 +106,7 @@ public class OrcidAuthorizationCodeServiceTest extends DBUnitTest {
         authorizationRequest.setAuthorities(grantedAuthorities);
         authorizationRequest.setResourceIds(resourceIds);
         OrcidProfile profile = new OrcidProfile();
-        profile.setOrcid(new Orcid("4444-4444-4444-4445"));
+        profile.setOrcidIdentifier("4444-4444-4444-4445");
         OrcidProfileUserDetails details = new OrcidProfileUserDetails("4444-4444-4444-4445", "test123@semantico.com", "encrypted_password", OrcidType.USER);
         Authentication userAuthentication = new UsernamePasswordAuthenticationToken(details, "password");
 

--- a/orcid-core/src/test/java/org/orcid/core/security/DefaultPermissionCheckerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/security/DefaultPermissionCheckerTest.java
@@ -87,7 +87,7 @@ public class DefaultPermissionCheckerTest extends DBUnitTest {
         OAuth2Authentication oAuth2Authentication = new OrcidOAuth2Authentication(request, oauth2UserAuthentication, "made-up-token");
         ScopePathType requiredScope = ScopePathType.ORCID_BIO_EXTERNAL_IDENTIFIERS_CREATE;
         OrcidMessage orcidMessage = getOrcidMessage();
-        String messageOrcid = orcidMessage.getOrcidProfile().getOrcid().getValue();
+        String messageOrcid = orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath();
         defaultPermissionChecker.checkPermissions(oAuth2Authentication, requiredScope, messageOrcid, orcidMessage);
     }
 
@@ -105,7 +105,7 @@ public class DefaultPermissionCheckerTest extends DBUnitTest {
         OAuth2Authentication oAuth2Authentication = new OrcidOAuth2Authentication(request, oauth2UserAuthentication, "made-up-token");
         ScopePathType requiredScope = ScopePathType.ORCID_BIO_EXTERNAL_IDENTIFIERS_CREATE;
         OrcidMessage orcidMessage = getOrcidMessage();
-        String messageOrcid = orcidMessage.getOrcidProfile().getOrcid().getValue();
+        String messageOrcid = orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath();
         defaultPermissionChecker.checkPermissions(oAuth2Authentication, requiredScope, messageOrcid, orcidMessage);
     }
 

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/DelegateSummary.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/DelegateSummary.java
@@ -54,7 +54,7 @@ import java.io.Serializable;
  * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType( propOrder = { "orcid", "orcidIdentifier", "creditName" })
+@XmlType(propOrder = { "orcid", "orcidIdentifier", "creditName" })
 @XmlRootElement(name = "delegate-summary")
 public class DelegateSummary implements Serializable {
 
@@ -73,8 +73,10 @@ public class DelegateSummary implements Serializable {
         super();
     }
 
+    @Deprecated
     public DelegateSummary(Orcid orcid) {
         this.orcid = orcid;
+        this.orcidIdentifier = new OrcidIdentifier(orcid.getValue());
     }
 
     public DelegateSummary(OrcidIdentifier orcidIdentifier) {
@@ -87,14 +89,9 @@ public class DelegateSummary implements Serializable {
      * @return possible object is {@link Orcid }
      * 
      */
+    @Deprecated
     public Orcid getOrcid() {
-        if (orcid != null) {
-            return orcid;
-        }
-        if (orcidIdentifier != null) {
-            return new Orcid(orcidIdentifier.getPath());
-        }
-        return null;
+        return orcid;
     }
 
     /**
@@ -104,6 +101,7 @@ public class DelegateSummary implements Serializable {
      *            allowed object is {@link Orcid }
      * 
      */
+    @Deprecated
     public void setOrcid(Orcid value) {
         this.orcid = value;
     }

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/OrcidProfile.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/OrcidProfile.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang.StringUtils;
 import org.orcid.jaxb.model.clientgroup.ClientType;
 import org.orcid.jaxb.model.clientgroup.GroupType;
 import org.orcid.utils.DateUtils;
+import org.orcid.utils.NullUtils;
 import org.orcid.utils.ReleaseNameUtils;
 
 /**
@@ -71,9 +72,11 @@ public class OrcidProfile implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    @Deprecated
     protected Orcid orcid;
 
     // Legacy
+    @Deprecated
     @XmlElement(name = "orcid-id")
     protected String orcidId;
 
@@ -126,17 +129,9 @@ public class OrcidProfile implements Serializable {
      * @return possible object is {@link Orcid }
      * 
      */
+    @Deprecated
     public Orcid getOrcid() {
-        if (orcid != null) {
-            return orcid;
-        }
-        if (orcidIdentifier != null) {
-            String path = orcidIdentifier.getPath();
-            if (path != null) {
-                return new Orcid(path);
-            }
-        }
-        return null;
+        return orcid;
     }
 
     /**
@@ -146,10 +141,12 @@ public class OrcidProfile implements Serializable {
      *            allowed object is {@link Orcid }
      * 
      */
+    @Deprecated
     public void setOrcid(Orcid value) {
         this.orcid = value;
     }
 
+    @Deprecated
     public void setOrcid(String value) {
         if (value == null) {
             this.orcid = null;
@@ -496,7 +493,11 @@ public class OrcidProfile implements Serializable {
     }
 
     public static String createCacheKey(OrcidProfile profile) {
-        return createCacheKey(profile.getOrcidIdentifier().getPath(), profile.getOrcidHistory().getLastModifiedDate().getValue().toXMLFormat(), profile.getReleaseName());
+        OrcidHistory orcidHistory = profile.getOrcidHistory();
+        OrcidIdentifier orcidIdentifier = profile.getOrcidIdentifier();
+        String xmlFormatLastModifiedDate = (orcidHistory != null && orcidHistory.getLastModifiedDate() != null) ? orcidHistory.getLastModifiedDate().getValue()
+                .toXMLFormat() : "no-last-modified";
+        return createCacheKey(orcidIdentifier != null ? orcidIdentifier.getPath() : "no-orcid-identifier", xmlFormatLastModifiedDate, profile.getReleaseName());
     }
 
     public static String createCacheKey(String path, Date lastModifiedDate) {
@@ -504,7 +505,7 @@ public class OrcidProfile implements Serializable {
     }
 
     public static String createCacheKey(String path, String xmlFormatLastModifiedDate, String releaseName) {
-        return StringUtils.join(new String[] { path, xmlFormatLastModifiedDate, releaseName });
+        return StringUtils.join(new String[] { path, xmlFormatLastModifiedDate, releaseName }, "_");
     }
 
     public void downgradeToBioOnly() {

--- a/orcid-model/src/test/java/org/orcid/entities/MarshallingTest.java
+++ b/orcid-model/src/test/java/org/orcid/entities/MarshallingTest.java
@@ -53,7 +53,7 @@ public class MarshallingTest {
         assertNotNull(orcidMessage);
         OrcidProfile orcidProfile = orcidMessage.getOrcidProfile();
         assertNotNull(orcidProfile);
-        assertEquals("4444-4444-4444-4446", orcidProfile.getOrcid().getValue());
+        assertEquals("4444-4444-4444-4446", orcidProfile.getOrcidIdentifier().getPath());
         OrcidActivities orcidActivities = orcidProfile.getOrcidActivities();
         assertNotNull(orcidActivities);
         assertEquals(4, orcidActivities.getAffiliations().getAffiliation().size());

--- a/orcid-pub-web/src/test/java/org/orcid/api/t1/integration/T1OrcidApiClientIntegrationTest.java
+++ b/orcid-pub-web/src/test/java/org/orcid/api/t1/integration/T1OrcidApiClientIntegrationTest.java
@@ -70,7 +70,7 @@ public class T1OrcidApiClientIntegrationTest {
         assertEquals(OrcidApiConstants.VND_ORCID_XML, clientResponse.getType().toString());
         OrcidMessage orcidMessage = clientResponse.getEntity(OrcidMessage.class);
         assertNotNull(orcidMessage);
-        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class T1OrcidApiClientIntegrationTest {
         assertEquals(OrcidApiConstants.VND_ORCID_JSON, clientResponse.getType().toString());
         OrcidMessage orcidMessage = clientResponse.getEntity(OrcidMessage.class);
         assertNotNull(orcidMessage);
-        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
     }
 
     @Test
@@ -101,7 +101,7 @@ public class T1OrcidApiClientIntegrationTest {
         assertEquals(OrcidApiConstants.VND_ORCID_XML, clientResponse.getType().toString());
         OrcidMessage orcidMessage = clientResponse.getEntity(OrcidMessage.class);
         assertNotNull(orcidMessage);
-        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class T1OrcidApiClientIntegrationTest {
         assertEquals(OrcidApiConstants.VND_ORCID_JSON, clientResponse.getType().toString());
         OrcidMessage orcidMessage = clientResponse.getEntity(OrcidMessage.class);
         assertNotNull(orcidMessage);
-        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class T1OrcidApiClientIntegrationTest {
         assertEquals(OrcidApiConstants.VND_ORCID_XML, clientResponse.getType().toString());
         OrcidMessage orcidMessage = clientResponse.getEntity(OrcidMessage.class);
         assertNotNull(orcidMessage);
-        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
     }
 
     @Test
@@ -143,7 +143,7 @@ public class T1OrcidApiClientIntegrationTest {
         assertEquals(OrcidApiConstants.VND_ORCID_JSON, clientResponse.getType().toString());
         OrcidMessage orcidMessage = clientResponse.getEntity(OrcidMessage.class);
         assertNotNull(orcidMessage);
-        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
     }
 
     @Test
@@ -163,7 +163,7 @@ public class T1OrcidApiClientIntegrationTest {
         assertEquals(OrcidApiConstants.VND_ORCID_XML, clientResponse.getType().toString());
         OrcidMessage orcidMessage = clientResponse.getEntity(OrcidMessage.class);
         assertNotNull(orcidMessage);
-        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class T1OrcidApiClientIntegrationTest {
         assertEquals(OrcidApiConstants.VND_ORCID_JSON, clientResponse.getType().toString());
         OrcidMessage orcidMessage = clientResponse.getEntity(OrcidMessage.class);
         assertNotNull(orcidMessage);
-        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcid().getValue());
+        assertEquals(ORCID, orcidMessage.getOrcidProfile().getOrcidIdentifier().getPath());
     }
 
 }

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/AffiliationsController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/AffiliationsController.java
@@ -107,7 +107,7 @@ public class AffiliationsController extends BaseWorkspaceController {
                 }
             }
             currentProfile.getOrcidActivities().setAffiliations(affiliations);
-            orgRelationAffiliationDao.removeOrgAffiliationRelation(currentProfile.getOrcid().getValue(), affiliation.getPutCode().getValue());
+            orgRelationAffiliationDao.removeOrgAffiliationRelation(currentProfile.getOrcidIdentifier().getPath(), affiliation.getPutCode().getValue());
         }
 
         return affiliation;
@@ -282,7 +282,7 @@ public class AffiliationsController extends BaseWorkspaceController {
                     // same affiliation
                     if (orcidAffiliation.getPutCode().equals(affiliation.getPutCode().getValue())) {
                         // Update the privacy of the affiliation
-                        orgRelationAffiliationDao.updateOrgAffiliationRelation(currentProfile.getOrcid().getValue(), affiliation.getPutCode().getValue(), affiliation
+                        orgRelationAffiliationDao.updateOrgAffiliationRelation(currentProfile.getOrcidIdentifier().getPath(), affiliation.getPutCode().getValue(), affiliation
                                 .getVisibility().getVisibility());
                     }
                 }

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/FundingsController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/FundingsController.java
@@ -196,7 +196,7 @@ public class FundingsController extends BaseWorkspaceController {
 			}
 			fundings.setFundings(fundingList);
 			currentProfile.getOrcidActivities().setFundings(fundings);
-			profileFundingDao.removeProfileFunding(currentProfile.getOrcid().getValue(), funding.getPutCode().getValue());
+			profileFundingDao.removeProfileFunding(currentProfile.getOrcidIdentifier().getPath(), funding.getPutCode().getValue());
 		}
 		return deletedFunding;
 	}
@@ -441,7 +441,7 @@ public class FundingsController extends BaseWorkspaceController {
                 for (Funding funding : fundings) {
                     if (funding.getPutCode().equals(fundingForm.getPutCode().getValue())) {
                         // Update the privacy of the funding
-                    	profileFundingDao.updateProfileFunding(currentProfile.getOrcid().getValue(), fundingForm.getPutCode().getValue(), fundingForm.getVisibility().getVisibility());
+                    	profileFundingDao.updateProfileFunding(currentProfile.getOrcidIdentifier().getPath(), fundingForm.getPutCode().getValue(), fundingForm.getVisibility().getVisibility());
                     }
                 }
             }

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/GroupAdministratorController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/GroupAdministratorController.java
@@ -66,11 +66,11 @@ public class GroupAdministratorController extends BaseWorkspaceController {
         OrcidProfile profile = getEffectiveProfile();
         
         if(profile.getType() == null || !profile.getType().equals(OrcidType.GROUP)){        	
-        	LOGGER.warn("Trying to access manage-clients page with user {} which is not a group", profile.getOrcid().getValue());
+        	LOGGER.warn("Trying to access manage-clients page with user {} which is not a group", profile.getOrcidIdentifier().getPath());
         	return new ModelAndView("redirect:/my-orcid");
         }
         
-        OrcidClientGroup group = orcidClientGroupManager.retrieveOrcidClientGroup(profile.getOrcid().getValue());
+        OrcidClientGroup group = orcidClientGroupManager.retrieveOrcidClientGroup(profile.getOrcidIdentifier().getPath());
         mav.addObject("group", group);   
         switch(profile.getGroupType()){
         case BASIC:
@@ -181,10 +181,10 @@ public class GroupAdministratorController extends BaseWorkspaceController {
         
         if(client.getErrors().size() == 0) {
             OrcidProfile profile = getEffectiveProfile();
-            String groupOrcid = profile.getOrcid().getValue();
+            String groupOrcid = profile.getOrcidIdentifier().getPath();
             
             if(profile.getType() == null || !profile.getType().equals(OrcidType.GROUP)){
-            	LOGGER.warn("Trying to create client with non group user {}", profile.getOrcid().getValue());
+            	LOGGER.warn("Trying to create client with non group user {}", profile.getOrcidIdentifier().getPath());
             	throw new OrcidClientGroupManagementException("Your account is not allowed to do this operation.");
             }
             
@@ -226,10 +226,10 @@ public class GroupAdministratorController extends BaseWorkspaceController {
         
         if(client.getErrors().size() == 0) {
             OrcidProfile profile = getEffectiveProfile();
-        	String groupOrcid = profile.getOrcid().getValue();
+        	String groupOrcid = profile.getOrcidIdentifier().getPath();
             
             if(profile.getType() == null || !profile.getType().equals(OrcidType.GROUP)){
-            	LOGGER.warn("Trying to edit client with non group user {}", profile.getOrcid().getValue());
+            	LOGGER.warn("Trying to edit client with non group user {}", profile.getOrcidIdentifier().getPath());
             	throw new OrcidClientGroupManagementException("Your account is not allowed to do this operation.");
             }
             
@@ -252,10 +252,10 @@ public class GroupAdministratorController extends BaseWorkspaceController {
     @Produces(value = { MediaType.APPLICATION_JSON })
     public @ResponseBody List<Client> getClients(){
         OrcidProfile profile = getEffectiveProfile();
-        String groupOrcid = profile.getOrcid().getValue();
+        String groupOrcid = profile.getOrcidIdentifier().getPath();
         
         if(profile.getType() == null || !profile.getType().equals(OrcidType.GROUP)){
-                LOGGER.warn("Trying to get clients of non group user {}", profile.getOrcid().getValue());
+                LOGGER.warn("Trying to get clients of non group user {}", profile.getOrcidIdentifier().getPath());
                 throw new OrcidClientGroupManagementException("Your account is not allowed to do this operation.");
         }
         

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/ManageProfileController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/ManageProfileController.java
@@ -213,14 +213,14 @@ public class ManageProfileController extends BaseWorkspaceController {
         OrcidProfile orcidProfile = getEffectiveProfile();
         List<String> orcidsToExclude = new ArrayList<String>();
         // Exclude myself
-        orcidsToExclude.add(orcidProfile.getOrcid().getValue());
+        orcidsToExclude.add(orcidProfile.getOrcidIdentifier().getPath());
         // Exclude profiles I've already delegated to
         Delegation delegation = orcidProfile.getOrcidBio().getDelegation();
         if (delegation != null) {
             GivenPermissionTo givenPermissionTo = delegation.getGivenPermissionTo();
             if (givenPermissionTo != null) {
                 for (DelegationDetails delegationDetails : givenPermissionTo.getDelegationDetails()) {
-                    orcidsToExclude.add(delegationDetails.getDelegateSummary().getOrcid().getValue());
+                    orcidsToExclude.add(delegationDetails.getDelegateSummary().getOrcidIdentifier().getPath());
                 }
             }
         }
@@ -324,7 +324,7 @@ public class ManageProfileController extends BaseWorkspaceController {
             GivenPermissionBy givenPermissionBy = delegation.getGivenPermissionBy();
             if (givenPermissionBy != null) {
                 for (DelegationDetails delegationDetails : givenPermissionBy.getDelegationDetails()) {
-                    if (delegationDetails.getDelegateSummary().getOrcid().getValue().equals(giverOrcid)) {
+                    if (delegationDetails.getDelegateSummary().getOrcidIdentifier().getPath().equals(giverOrcid)) {
                         return true;
                     }
                 }
@@ -351,7 +351,7 @@ public class ManageProfileController extends BaseWorkspaceController {
         // TODO - placeholder just to test the retrieve etc..replace with only
         // fields that we will populate
         // password fields are never populated
-        OrcidProfile unecryptedProfile = orcidProfileManager.retrieveOrcidProfile(profile.getOrcid().getValue());
+        OrcidProfile unecryptedProfile = orcidProfileManager.retrieveOrcidProfile(profile.getOrcidIdentifier().getPath());
         ManagePasswordOptionsForm managePasswordOptionsForm = new ManagePasswordOptionsForm();
         managePasswordOptionsForm.setVerificationNumber(unecryptedProfile.getVerificationCode());
         managePasswordOptionsForm.setSecurityQuestionAnswer(unecryptedProfile.getSecurityQuestionAnswer());
@@ -667,7 +667,7 @@ public class ManageProfileController extends BaseWorkspaceController {
                 emails.add(email);
                 currentProfile.getOrcidBio().getContactDetails().setEmail(emails);
                 email.setSource(getRealUserOrcid());
-                emailManager.addEmail(currentProfile.getOrcid().getValue(), email);
+                emailManager.addEmail(currentProfile.getOrcidIdentifier().getPath(), email);
 
                 // send verifcation email for new address
                 URI baseUri = OrcidWebUtils.getServerUriWithContextPath(request);
@@ -717,7 +717,7 @@ public class ManageProfileController extends BaseWorkspaceController {
                 }
             }
             currentProfile.getOrcidBio().getContactDetails().setEmail(emails);
-            emailManager.removeEmail(currentProfile.getOrcid().getValue(), email.getValue());
+            emailManager.removeEmail(currentProfile.getOrcidIdentifier().getPath(), email.getValue());
         }
         return email;
     }
@@ -755,7 +755,7 @@ public class ManageProfileController extends BaseWorkspaceController {
         emails.setErrors(allErrors);
         if (allErrors.size() == 0) {
             currentProfile.getOrcidBio().getContactDetails().setEmail((List<Email>) (Object) emails.getEmails());
-            emailManager.updateEmails(currentProfile.getOrcid().getValue(), currentProfile.getOrcidBio().getContactDetails().getEmail());
+            emailManager.updateEmails(currentProfile.getOrcidIdentifier().getPath(), currentProfile.getOrcidBio().getContactDetails().getEmail());
             if (newPrime != null && !newPrime.getValue().equalsIgnoreCase(oldPrime.getValue())) {
                 URI baseUri = OrcidWebUtils.getServerUriWithContextPath(request);
                 notificationManager.sendEmailAddressChangedNotification(currentProfile, new Email(oldPrime.getValue()), baseUri);
@@ -807,7 +807,7 @@ public class ManageProfileController extends BaseWorkspaceController {
         // Update profile on database
         profileEntityManager.updateProfile(profile);
 
-        String orcid = profile.getOrcid().getValue();
+        String orcid = profile.getOrcidIdentifier().getPath();
 
         // Update other names on database
         OtherNames otherNames = profile.getOrcidBio().getPersonalDetails().getOtherNames();

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/PublicProfileController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/PublicProfileController.java
@@ -98,7 +98,7 @@ public class PublicProfileController extends BaseWorkspaceController {
         HashMap<String, Funding> fundingMap = new HashMap<String, Funding>();
 
         if (profile.getOrcidDeprecated() != null) {
-            String primaryRecord = profile.getOrcidDeprecated().getPrimaryRecord().getOrcid().getValue();
+            String primaryRecord = profile.getOrcidDeprecated().getPrimaryRecord().getOrcidIdentifier().getPath();
             mav.addObject("deprecated", true);
             mav.addObject("primaryRecord", primaryRecord);
         } else {

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/RegistrationController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/RegistrationController.java
@@ -441,7 +441,7 @@ public class RegistrationController extends BaseController {
                 dr.setGivenNames(op.getOrcidBio().getPersonalDetails().getGivenNames().getContent());
                 dr.setInstitution(null);
             }
-            dr.setOrcid(op.getOrcid().getValue());
+            dr.setOrcid(op.getOrcidIdentifier().getPath());
             drList.add(dr);
         }
 
@@ -532,7 +532,7 @@ public class RegistrationController extends BaseController {
     private void automaticallyLogin(HttpServletRequest request, String password, OrcidProfile orcidProfile) {
         UsernamePasswordAuthenticationToken token = null;
         try {
-            String orcid = orcidProfile.getOrcid().getValue();
+            String orcid = orcidProfile.getOrcidIdentifier().getPath();
             // Force refresh of profile entity to ensure new password value is
             // picked up from DB.
             profileDao.refresh(profileDao.find(orcid));
@@ -903,8 +903,8 @@ public class RegistrationController extends BaseController {
             profileToSave = registrationManager.createMinimalRegistration(profileToSave);
             notificationManager.sendVerificationEmail(profileToSave, uri, profileToSave.getOrcidBio().getContactDetails().retrievePrimaryEmail().getValue());
             request.getSession().setAttribute(ManageProfileController.CHECK_EMAIL_VALIDATED, false);
-            LOGGER.info("Created profile from registration orcid={}, email={}, sessionid={}", new Object[] { profileToSave.getOrcid().getValue(), email, sessionId });
-            token = new UsernamePasswordAuthenticationToken(profileToSave.getOrcid().getValue(), password);
+            LOGGER.info("Created profile from registration orcid={}, email={}, sessionid={}", new Object[] { profileToSave.getOrcidIdentifier().getPath(), email, sessionId });
+            token = new UsernamePasswordAuthenticationToken(profileToSave.getOrcidIdentifier().getPath(), password);
             token.setDetails(new WebAuthenticationDetails(request));
             Authentication authentication = authenticationManager.authenticate(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/WorksController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/WorksController.java
@@ -145,7 +145,7 @@ public class WorksController extends BaseWorkspaceController {
             }
             works.setOrcidWork(workList);
             currentProfile.getOrcidActivities().setOrcidWorks(works);
-            profileWorkManager.removeWork(currentProfile.getOrcid().getValue(), work.getPutCode().getValue());
+            profileWorkManager.removeWork(currentProfile.getOrcidIdentifier().getPath(), work.getPutCode().getValue());
         }
 
         return deletedWork;
@@ -402,7 +402,7 @@ public class WorksController extends BaseWorkspaceController {
             }
 
             // Create profile work relationship
-            profileWorkManager.addProfileWork(currentProfile.getOrcid().getValue(), workEntity.getId(), newOw.getVisibility());
+            profileWorkManager.addProfileWork(currentProfile.getOrcidIdentifier().getPath(), workEntity.getId(), newOw.getVisibility());
 
             // Set the id (put-code) to the new work
             newOw.setPutCode(String.valueOf(workEntity.getId()));
@@ -519,7 +519,7 @@ public class WorksController extends BaseWorkspaceController {
                 WorkContributorEntity workContributorEntity = new WorkContributorEntity();
                 workContributorEntity.setContributorEmail(currentProfile.getOrcidBio().getContactDetails().retrievePrimaryEmail() != null ? currentProfile.getOrcidBio()
                         .getContactDetails().retrievePrimaryEmail().getValue() : null);
-                workContributorEntity.setProfile(new ProfileEntity(currentProfile.getOrcid().getValue()));
+                workContributorEntity.setProfile(new ProfileEntity(currentProfile.getOrcidIdentifier().getPath()));
                 workContributorEntity.setWork(workEntity);
                 workContributorEntity.setCreditName(currentProfile.getOrcidBio().getPersonalDetails().getCreditName() != null ? currentProfile.getOrcidBio()
                         .getPersonalDetails().getCreditName().getContent() : null);
@@ -740,7 +740,7 @@ public class WorksController extends BaseWorkspaceController {
     private List<String> createWorksIdList(HttpServletRequest request) {
         OrcidProfile currentProfile = getEffectiveProfile();
         java.util.Date lastModified = currentProfile.getOrcidHistory().getLastModifiedDate().getValue().toGregorianCalendar().getTime();        
-        List<MinimizedWorkEntity> works = workManager.findWorks(currentProfile.getOrcid().getValue(), lastModified);
+        List<MinimizedWorkEntity> works = workManager.findWorks(currentProfile.getOrcidIdentifier().getPath(), lastModified);
         HashMap<String, Work> worksMap = new HashMap<String, Work>();
         List<String> workIds = new ArrayList<String>();
         if (works != null) {
@@ -775,7 +775,7 @@ public class WorksController extends BaseWorkspaceController {
                     // same work
                     if (orcidWork.getPutCode().equals(ow.getPutCode())) {
                         // Update the privacy of the work
-                        profileWorkManager.updateWork(currentProfile.getOrcid().getValue(), ow.getPutCode(), ow.getVisibility());
+                        profileWorkManager.updateWork(currentProfile.getOrcidIdentifier().getPath(), ow.getPutCode(), ow.getVisibility());
                     }
                 }
             }

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/WorkspaceController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/WorkspaceController.java
@@ -336,7 +336,7 @@ public class WorkspaceController extends BaseWorkspaceController {
             // Update cached profile
             currentProfile.getOrcidBio().setExternalIdentifiers(externalIdentifiers);
             // Remove external identifier
-            externalIdentifierManager.removeExternalIdentifier(currentProfile.getOrcid().getValue(), externalIdentifier.getExternalIdReference().getContent());
+            externalIdentifierManager.removeExternalIdentifier(currentProfile.getOrcidIdentifier().getPath(), externalIdentifier.getExternalIdReference().getContent());
         }
 
         return externalIdentifier;

--- a/orcid-web/src/main/java/org/orcid/frontend/web/forms/AddDelegateForm.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/forms/AddDelegateForm.java
@@ -20,8 +20,8 @@ import org.orcid.jaxb.model.message.DelegateSummary;
 import org.orcid.jaxb.model.message.Delegation;
 import org.orcid.jaxb.model.message.DelegationDetails;
 import org.orcid.jaxb.model.message.GivenPermissionTo;
-import org.orcid.jaxb.model.message.Orcid;
 import org.orcid.jaxb.model.message.OrcidBio;
+import org.orcid.jaxb.model.message.OrcidIdentifier;
 import org.orcid.jaxb.model.message.OrcidProfile;
 
 /**
@@ -43,7 +43,7 @@ public class AddDelegateForm {
 
     public OrcidProfile getOrcidProfile(String orcid) {
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid(orcid);
+        orcidProfile.setOrcidIdentifier(orcid);
         OrcidBio orcidBio = new OrcidBio();
         orcidProfile.setOrcidBio(orcidBio);
         Delegation delegation = new Delegation();
@@ -52,7 +52,7 @@ public class AddDelegateForm {
         delegation.setGivenPermissionTo(givenPermissionTo);
         DelegationDetails delegationDetails = new DelegationDetails();
         givenPermissionTo.getDelegationDetails().add(delegationDetails);
-        DelegateSummary delegateSummary = new DelegateSummary(new Orcid(delegateOrcid));
+        DelegateSummary delegateSummary = new DelegateSummary(new OrcidIdentifier(delegateOrcid));
         delegationDetails.setDelegateSummary(delegateSummary);
         return orcidProfile;
     }

--- a/orcid-web/src/main/java/org/orcid/frontend/web/forms/CrossRefPublicationsForm.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/forms/CrossRefPublicationsForm.java
@@ -47,13 +47,13 @@ public class CrossRefPublicationsForm {
         return orcid;
     }
 
-    public void setOrcid(String orcid) {
+    public void setOrcidIdentifier(String orcid) {
         this.orcid = orcid;
     }
 
     public OrcidProfile getOrcidProfile() {
         OrcidProfile profile = new OrcidProfile();
-        profile.setOrcid(orcid);
+        profile.setOrcidIdentifier(orcid);
         OrcidWorks orcidWorks = new OrcidWorks();
         profile.setOrcidWorks(orcidWorks);
         orcidWorks.getOrcidWork().addAll(getOrcidWorks());

--- a/orcid-web/src/main/java/org/orcid/frontend/web/forms/PersonalInfoForm.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/forms/PersonalInfoForm.java
@@ -106,7 +106,7 @@ public class PersonalInfoForm {
 
     public PersonalInfoForm(OrcidProfile orcidProfile, Map<String, String> availableSubjects) {
         availableRemainingSubjectMap = availableSubjects;
-        orcid = orcidProfile.getOrcid().getValue();
+        orcid = orcidProfile.getOrcidIdentifier().getPath();
 
         OrcidBio orcidBio = orcidProfile.getOrcidBio();
         PersonalDetails personalDetails = null;

--- a/orcid-web/src/main/java/org/orcid/frontend/web/forms/PreferencesForm.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/forms/PreferencesForm.java
@@ -39,7 +39,7 @@ public class PreferencesForm {
     }
 
     public PreferencesForm(OrcidProfile orcidProfile) {
-        orcid = orcidProfile.getOrcid().getValue();
+        orcid = orcidProfile.getOrcidIdentifier().getPath();
 
         OrcidInternal orcidInternal = orcidProfile.getOrcidInternal();
 
@@ -78,7 +78,7 @@ public class PreferencesForm {
 
     public OrcidProfile getOrcidProfile() {
         OrcidProfile orcidProfile = new OrcidProfile();
-        orcidProfile.setOrcid(orcid);
+        orcidProfile.setOrcidIdentifier(orcid);
         OrcidInternal internal = new OrcidInternal();
         orcidProfile.setOrcidInternal(internal);
         Preferences preferences = new Preferences();

--- a/orcid-web/src/main/java/org/orcid/frontend/web/forms/SearchForDelegatesForm.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/forms/SearchForDelegatesForm.java
@@ -40,7 +40,7 @@ public class SearchForDelegatesForm {
         List<SearchForDelegatesResult> results = new ArrayList<SearchForDelegatesResult>();
         for (OrcidSearchResult orcidSearchResult : orcidSearchResults.getOrcidSearchResult()) {
             SearchForDelegatesResult result = new SearchForDelegatesResult();
-            result.setOrcid(orcidSearchResult.getOrcidProfile().getOrcid().getValue());
+            result.setOrcid(orcidSearchResult.getOrcidProfile().getOrcidIdentifier().getPath());
             OrcidBio orcidBio = orcidSearchResult.getOrcidProfile().getOrcidBio();
             result.setCreditName(orcidBio.getPersonalDetails().getCreditName().getContent());
             result.setEmail(orcidBio.getContactDetails().retrievePrimaryEmail().getValue());

--- a/orcid-web/src/main/resources/freemarker/common/html-head.ftl
+++ b/orcid-web/src/main/resources/freemarker/common/html-head.ftl
@@ -47,9 +47,9 @@
         orcidVar.fundingIdsJson = JSON.parse("${fundingIdsJson}");
       </#if>
       <#if (profile)??>
-        orcidVar.orcidId = '${(profile.orcid.value)!}';
+        orcidVar.orcidId = '${(profile.orcidIdentifier.path)!}';
       <#else>
-        orcidVar.orcidId = '${(profile.orcid.value)!}';
+        orcidVar.orcidId = '${(profile.orcidIdentifier.path)!}';
       </#if>
       orcidVar.jsMessages = JSON.parse("${jsMessagesJson}");
     </script>    

--- a/orcid-web/src/main/resources/freemarker/public_profile.ftl
+++ b/orcid-web/src/main/resources/freemarker/public_profile.ftl
@@ -32,7 +32,7 @@
             <div class="oid">
             	<p class="orcid-id-container">		
 	            	<span class="mini-orcid-icon"></span>
-	            	<a href="${baseUriHttp}/${(profile.orcid.value)!}" id="orcid-id" class="orcid-id" title="Click for public view of ORCID iD">${baseUriHttp}/${(profile.orcid.value)!}</a>
+	            	<a href="${baseUriHttp}/${(profile.orcidIdentifier.path)!}" id="orcid-id" class="orcid-id" title="Click for public view of ORCID iD">${baseUriHttp}/${(profile.orcidIdentifier.path)!}</a>
             	<p>
             </div>            
             <#if (profile.orcidBio.personalDetails.otherNames)?? && (profile.orcidBio.personalDetails.otherNames.otherName?size != 0)>

--- a/orcid-web/src/main/resources/freemarker/workspace.ftl
+++ b/orcid-web/src/main/resources/freemarker/workspace.ftl
@@ -52,7 +52,7 @@
             <div class="oid">
             	<p class="orcid-id-container">		
 	            	<span class="mini-orcid-icon"></span>
-	            	<a href="${baseUriHttp}/${(profile.orcid.value)!}" id="orcid-id" class="orcid-id" title="Click for public view of ORCID iD">${baseUriHttp}/${(profile.orcid.value)!}</a>
+	            	<a href="${baseUriHttp}/${(profile.orcidIdentifier.path)!}" id="orcid-id" class="orcid-id" title="Click for public view of ORCID iD">${baseUriHttp}/${(profile.orcidIdentifier.path)!}</a>
             	<p>
             </div>
 	        <#if ((profile.orcidBio.personalDetails.otherNames.otherName)?size != 0)>
@@ -95,7 +95,7 @@
 			</@security.authorize>
 			
 			<p class="hoover-white-fonts">
-	       		<!-- <a href="${baseUriHttp}/${(profile.orcid.value)!}" class="label btn-primary"><@orcid.msg 'workspace.ViewPublicORCIDRecord'/></a> -->	       
+	       		<!-- <a href="${baseUriHttp}/${(profile.orcidIdentifier.path)!}" class="label btn-primary"><@orcid.msg 'workspace.ViewPublicORCIDRecord'/></a> -->	       
 	       		<a href="<@spring.url '/account/manage-bio-settings'/>" id="update-personal-modal-link" class="label btn-primary"><@orcid.msg 'workspace.Update'/></a>
 	        </p>
 			

--- a/orcid-web/src/test/java/org/orcid/frontend/web/controllers/ManageProfileControllerTest.java
+++ b/orcid-web/src/test/java/org/orcid/frontend/web/controllers/ManageProfileControllerTest.java
@@ -283,7 +283,7 @@ public class ManageProfileControllerTest extends BaseControllerTest {
             public boolean matchesSafely(List<DelegationDetails> delegatesAdded) {
                 if (delegatesAdded != null && delegatesAdded.size() == 1) {
                     DelegationDetails delegationDetails = delegatesAdded.get(0);
-                    return "delegateOrcid".equals(delegationDetails.getDelegateSummary().getOrcid().getValue());
+                    return "delegateOrcid".equals(delegationDetails.getDelegateSummary().getOrcidIdentifier().getPath());
                 }
 
                 return false;

--- a/orcid-web/src/test/java/org/orcid/frontend/web/util/BaseControllerTest.java
+++ b/orcid-web/src/test/java/org/orcid/frontend/web/util/BaseControllerTest.java
@@ -71,10 +71,10 @@ public class BaseControllerTest extends DBUnitTest {
 
         OrcidProfileUserDetails details = null;
         if(orcidProfile.getType() != null){        	
-        	details = new OrcidProfileUserDetails(orcidProfile.getOrcid().getValue(), orcidProfile.getOrcidBio().getContactDetails().getEmail()
+        	details = new OrcidProfileUserDetails(orcidProfile.getOrcidIdentifier().getPath(), orcidProfile.getOrcidBio().getContactDetails().getEmail()
                     .get(0).getValue(), orcidProfile.getOrcidInternal().getSecurityDetails().getEncryptedPassword().getContent(), orcidProfile.getType(), orcidProfile.getClientType(), orcidProfile.getGroupType());
         } else {
-        	details = new OrcidProfileUserDetails(orcidProfile.getOrcid().getValue(), orcidProfile.getOrcidBio().getContactDetails().getEmail()
+        	details = new OrcidProfileUserDetails(orcidProfile.getOrcidIdentifier().getPath(), orcidProfile.getOrcidBio().getContactDetails().getEmail()
                     .get(0).getValue(), orcidProfile.getOrcidInternal().getSecurityDetails().getEncryptedPassword().getContent());
         }
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(details, "4444-4444-4444-4446", Arrays.asList(OrcidWebRole.ROLE_USER));


### PR DESCRIPTION
...instead of relying on fallback in OrcidProfile.orcid.
Changed so that OrcidProfile.orcid does not fallback to OrcidProfile.orcidIdentifier (because was causing <orcid> element wrongly to appear in newer API versions).
