### PR TITLE
Fixed language selector in delegation mode

### DIFF
--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/HomeController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/HomeController.java
@@ -84,7 +84,7 @@ public class HomeController extends BaseController {
     public @ResponseBody
     org.orcid.pojo.Local langJson(HttpServletRequest request, @RequestParam(value = "lang", required = false) String lang) throws NoSuchRequestHandlingMethodException {
         if (lang != null) {
-            String orcid = getCurrentUserOrcid();
+            String orcid = getRealUserOrcid();
             if (orcid != null) {
                 OrcidProfile existingProfile = orcidProfileManager.retrieveOrcidProfile(orcid);
                 org.orcid.jaxb.model.message.Locale locale = existingProfile.getOrcidPreferences().getLocale();


### PR DESCRIPTION
Fixed so that when you are in delegation mode and you use the language selector, your record is be updated with the language preference (not that of the person you have switched to).
