### PR TITLE
Changed so that 'given permission by' entities are not saved to the DB

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/Jaxb2JpaAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/Jaxb2JpaAdapterImpl.java
@@ -631,7 +631,6 @@ public class Jaxb2JpaAdapterImpl implements Jaxb2JpaAdapter {
 
     private void setDelegations(ProfileEntity profileEntity, Delegation delegation) {
         profileEntity.setGivenPermissionTo(getGivenPermissionsTo(profileEntity, delegation));
-        profileEntity.setGivenPermissionBy(getGivenPermissionsBy(profileEntity, delegation));
     }
 
     private void setContactDetails(ProfileEntity profileEntity, ContactDetails contactDetails) {
@@ -855,32 +854,6 @@ public class Jaxb2JpaAdapterImpl implements Jaxb2JpaAdapter {
                     givenPermissionToEntities.add(givenPermissionToEntity);
                 }
                 return givenPermissionToEntities;
-            }
-        }
-        return null;
-    }
-
-    private Set<GivenPermissionByEntity> getGivenPermissionsBy(ProfileEntity profileEntity, Delegation delegation) {
-        if (delegation != null) {
-            GivenPermissionBy givenPermissionBy = delegation.getGivenPermissionBy();
-            if (givenPermissionBy != null && givenPermissionBy.getDelegationDetails() != null && !givenPermissionBy.getDelegationDetails().isEmpty()) {
-                Set<GivenPermissionByEntity> givenPermissionByEntities = new HashSet<GivenPermissionByEntity>();
-                for (DelegationDetails delegationDetails : givenPermissionBy.getDelegationDetails()) {
-                    GivenPermissionByEntity givenPermissionByEntity = new GivenPermissionByEntity();
-                    DelegateSummary profileSummary = delegationDetails.getDelegateSummary();
-                    ProfileSummaryEntity profileSummaryEntity = new ProfileSummaryEntity(profileSummary.getOrcidIdentifier().getPath());
-                    profileSummaryEntity.setCreditName(profileSummary.getCreditName().getContent());
-                    givenPermissionByEntity.setGiver(profileSummaryEntity);
-                    givenPermissionByEntity.setReceiver(profileEntity.getId());
-                    ApprovalDate approvalDate = delegationDetails.getApprovalDate();
-                    if (approvalDate == null) {
-                        givenPermissionByEntity.setApprovalDate(new Date());
-                    } else {
-                        givenPermissionByEntity.setApprovalDate(DateUtils.convertToDate(approvalDate.getValue()));
-                    }
-                    givenPermissionByEntities.add(givenPermissionByEntity);
-                }
-                return givenPermissionByEntities;
             }
         }
         return null;

--- a/orcid-core/src/test/java/org/orcid/core/adapter/JpaJaxbEntityAdapterToProfileEntityTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/JpaJaxbEntityAdapterToProfileEntityTest.java
@@ -224,11 +224,7 @@ public class JpaJaxbEntityAdapterToProfileEntityTest extends DBUnitTest {
         GivenPermissionToEntity retrievedGivenPermissionToEntity = profileEntity.getGivenPermissionTo().iterator().next();
         assertEquals("1111-1111-1111-1115", retrievedGivenPermissionToEntity.getReceiver().getId());
         assertEquals(DateUtils.convertToDate("2012-11-10T13:18:51"), retrievedGivenPermissionToEntity.getApprovalDate());
-        assertNotNull(profileEntity.getGivenPermissionBy());
-        assertEquals(1, profileEntity.getGivenPermissionBy().size());
-        GivenPermissionByEntity retrievedGivenPermissionByEntity = profileEntity.getGivenPermissionBy().iterator().next();
-        assertEquals("2222-2222-2222-2229", retrievedGivenPermissionByEntity.getGiver().getId());
-        assertEquals(DateUtils.convertToDate("2012-12-22T08:16:22"), retrievedGivenPermissionByEntity.getApprovalDate());
+        assertNull(profileEntity.getGivenPermissionBy());
 
         adapter.toOrcidProfile(retrievedProfileEntity);
     }


### PR DESCRIPTION
Changed so that 'given permission by' entities are not saved to the DB
when saving the profile (they are the mirror image of the 'given
permission to' entities in the givers' profiles, so don't need to be
saved here).
