### PR TITLE
Upgraded to latest postgres driver.

### DIFF
--- a/orcid-audit/pom.xml
+++ b/orcid-audit/pom.xml
@@ -71,7 +71,7 @@
 
         <!-- Database -->
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>

--- a/orcid-persistence/pom.xml
+++ b/orcid-persistence/pom.xml
@@ -112,7 +112,7 @@
 
         <!-- Database -->
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -740,9 +740,9 @@ the software.
 
             <!-- Database -->
             <dependency>
-                <groupId>postgresql</groupId>
+                <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>9.1-901.jdbc4</version>
+                <version>9.3-1101-jdbc41</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.java-persistence</groupId>


### PR DESCRIPTION
Noticed that we are using a oldish postgres driver, while working on the json work ext ids. Using the old driver doesn't cause any problems as far as I know, but thought it might be better to push up to the latest anyway?
