### PR TITLE
Removed custom solr response writer from persistence unit tests, because...

### DIFF
--- a/orcid-persistence/src/test/resources/solr/profile/conf/solrconfig.xml
+++ b/orcid-persistence/src/test/resources/solr/profile/conf/solrconfig.xml
@@ -980,9 +980,6 @@
 		<int name="xsltCacheLifetimeSeconds">5</int>
 	</queryResponseWriter>
 	
-	<queryResponseWriter name="orcidProfile" class="org.orcid.solr.writer.OrcidProfileResponseWriter">
-	</queryResponseWriter>
-
 	<!-- Query Parsers http://wiki.apache.org/solr/SolrQuerySyntax Multiple 
 		QParserPlugins can be registered by name, and then used in either the "defType" 
 		param for the QueryComponent (used by SearchHandler) or in LocalParams -->


### PR DESCRIPTION
... not easily available in dependencies.