### PR TITLE
Fix missing number in notifcations email

### DIFF
--- a/orcid-core/src/main/resources/org/orcid/core/template/digest_email_html_en.ftl
+++ b/orcid-core/src/main/resources/org/orcid/core/template/digest_email_html_en.ftl
@@ -37,7 +37,7 @@
                 <ul style="font-family: arial, helvetica, sans-serif; font-size: 15px; color: #666666; margin-left: 0;">
                     <#compress>
                     <#if amendedMessageCount gt 0><li>[${amendedMessageCount}] <#if amendedMessageCount == 1>notification<#else>notifications</#if> from ORCID member organizations that added or updated information on your record</li></#if>
-                    <#if addActivitiesMessageCount gt 0><li>[{$addActivitiesMessageCount}] <#if addActivitiesMessageCount == 1>Request<#else>Requests</#if> to add or update your ORCID record</li></#if>
+                    <#if addActivitiesMessageCount gt 0><li>[${addActivitiesMessageCount}] <#if addActivitiesMessageCount == 1>Request<#else>Requests</#if> to add or update your ORCID record</li></#if>
                     <#if orcidMessageCount gt 0><li>[${orcidMessageCount}] <#if orcidMessageCount == 1>notification<#else>notifications</#if> from ORCID</li></#if>
                     </#compress>
                 </ul>

--- a/orcid-web/src/main/resources/freemarker/notification/add_activities_notification_en.ftl
+++ b/orcid-web/src/main/resources/freemarker/notification/add_activities_notification_en.ftl
@@ -28,7 +28,7 @@
 </style>
 <body data-baseurl="<@spring.url '/'/>">
 <div>
-    ${notification.source.sourceName} has ${notification.activities.activities?size}
+    ${notification.source.sourceName.content} has ${notification.activities.activities?size}
     <#if notification.activities.activities?size == 1>
         activity
     <#else>

--- a/orcid-web/src/main/resources/freemarker/notification/amended_notification_en.ftl
+++ b/orcid-web/src/main/resources/freemarker/notification/amended_notification_en.ftl
@@ -26,7 +26,7 @@
                 Dear ${emailName},
             </p>
             <p style="font-family: arial, helvetica, sans-serif; font-size: 15px; color: #666666;">
-                Thought you'd like to know... ${notification.source.sourceName} has updated your ORCID record.
+                Thought you'd like to know... ${notification.source.sourceName.content} has updated your ORCID record.
             </p>            
             <p style="font-family: arial, helvetica, sans-serif; font-size: 15px; color: #666666; white-space: pre;">
 Kind Regards,

--- a/orcid-web/src/main/resources/freemarker/notifications.ftl
+++ b/orcid-web/src/main/resources/freemarker/notifications.ftl
@@ -46,7 +46,7 @@
 	                <tr ng-repeat-start="notification in notifications" ng-class="{unread: !notification.readDate, archived: notification.archivedDate}">
 	                    <td ng-click="toggleDisplayBody(notification.putCode)">
 	                        <i class="glyphicon-chevron-down glyphicon x0" ng-class="{'glyphicon-chevron-right':!displayBody[notification.putCode]}"></i>
-	                        <span ng-show="notification.source" ng-cloak>{{notification.source.sourceName}}</span><span ng-hide="notification.source" ng-cloak>ORCID</span>
+	                        <span ng-show="notification.source" ng-cloak>{{notification.source.sourceName.content}}</span><span ng-hide="notification.source" ng-cloak>ORCID</span>
 	                    </td>
 	                    <td ng-click="toggleDisplayBody(notification.putCode)"><span ng-cloak>{{notification.subject}}</span></td>
 	                    <td ng-click="toggleDisplayBody(notification.putCode)"><span ng-cloak>{{notification.createdDate|humanDate}}</span></td>


### PR DESCRIPTION
https://trello.com/c/A4VGY1sR/1894-messaging-addactivitiesmessagecount-isn-t-showing-a-number-in-the-email-message