### PR TITLE
Typo fix: Removing an extra space in the orcid-search url

### DIFF
--- a/orcid-web/src/main/resources/freemarker/layout/public-layout.ftl
+++ b/orcid-web/src/main/resources/freemarker/layout/public-layout.ftl
@@ -80,7 +80,7 @@
 						<button type="submit" class="search-button">
 							<i class="icon-orcid-search"></i>
 						</button>
-						<a href="<@spring.url " /orcid-search/search" />"
+						<a href="<@spring.url "/orcid-search/search" />"
 						class="settings-button" title="<@orcid.msg
 						'public-layout.search.advanced'/>"><i class="glyphicon glyphicon-cog"></i></a>
 					</div>


### PR DESCRIPTION
An extra space is present in row 83. It couses the web browser to encode the space in to the url and leads to a 404 Not Found error.