### PR TITLE
Login user id additions

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/security/OrcidUserDetailsService.java
+++ b/orcid-core/src/main/java/org/orcid/core/security/OrcidUserDetailsService.java
@@ -46,7 +46,7 @@ public class OrcidUserDetailsService implements UserDetailsService {
     
     @Value("${org.orcid.core.baseUri}")
     private String baseUrl;
-
+    
     /**
      * Locates the user based on the username. In the actual implementation, the
      * search may possibly be case insensitive, or case insensitive depending on
@@ -99,10 +99,16 @@ public class OrcidUserDetailsService implements UserDetailsService {
     private ProfileEntity obtainEntity(String username) {
         ProfileEntity profile = null;
         if(!StringUtils.isEmpty(username)) {
-        	StringBuffer userNameBuffer = new StringBuffer(username);
-	        if (OrcidStringUtils.isValidOrcid(username) || OrcidStringUtils.isValidOrcid(userNameBuffer)) {
-	        	username = userNameBuffer.toString();
+	        if (OrcidStringUtils.isValidOrcid(username)) {
 	            profile = profileDao.find(username);
+	        } else if(OrcidStringUtils.isValidOrcidWithSpaces(username)) {
+	        	username = username.toString().replace(' ', '-');
+	        	profile = profileDao.find(username);
+	        } else if(OrcidStringUtils.isValidOrcidWithoutSpacesWithoutHyphens(username)) {
+	        	String temp = username.replaceAll("(.{4})", "$1-");
+				int length = temp.length();
+				username = temp.substring(0, length -1);
+				profile = profileDao.find(username);
 	        } else if(baseUrl != null && username.contains(new StringBuffer(baseUrl).append("/").toString())) {
 	        	username = OrcidStringUtils.getOrcidNumber(username);
 	        	if(username != null) {

--- a/orcid-core/src/main/java/org/orcid/core/security/OrcidUserDetailsService.java
+++ b/orcid-core/src/main/java/org/orcid/core/security/OrcidUserDetailsService.java
@@ -38,89 +38,101 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public class OrcidUserDetailsService implements UserDetailsService {
 
-    @Resource
-    private ProfileDao profileDao;
+	@Resource
+	private ProfileDao profileDao;
 
-    @Resource
-    private EmailDao emailDao;
-    
-    @Value("${org.orcid.core.baseUri}")
-    private String baseUrl;
-    
-    /**
-     * Locates the user based on the username. In the actual implementation, the
-     * search may possibly be case insensitive, or case insensitive depending on
-     * how the implementation instance is configured. In this case, the
-     * <code>UserDetails</code> object that comes back may have a username that
-     * is of a different case than what was actually requested..
-     * 
-     * @param username
-     *            the username identifying the user whose data is required.
-     * @return a fully populated user record (never <code>null</code>)
-     * @throws org.springframework.security.core.userdetails.UsernameNotFoundException
-     *             if the user could not be found or the user has no
-     *             GrantedAuthority
-     */
-    @Override
-    @Transactional(propagation = Propagation.REQUIRED)
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        ProfileEntity profile = obtainEntity(username);
+	@Resource
+	private EmailDao emailDao;
 
-        if (profile == null) {
-            throw new UsernameNotFoundException("Bad username or password");
-        }
-        if (profile.getPrimaryRecord() != null) {
-            throw new DeprecatedException("orcid.frontend.security.deprecated_with_primary", profile.getPrimaryRecord().getId(), profile.getId());
-        }
-        if (!profile.getClaimed()) {
-            throw new UnclaimedProfileExistsException("orcid.frontend.security.unclaimed_exists");
-        }
-        if (profile.getDeactivationDate() != null) {
-            throw new DisabledException("Account not active, please call helpdesk");
-        }
+	@Value("${org.orcid.core.baseUri}")
+	private String baseUrl;
 
-        String primaryEmail = null;
+	/**
+	 * Locates the user based on the username. In the actual implementation, the
+	 * search may possibly be case insensitive, or case insensitive depending on
+	 * how the implementation instance is configured. In this case, the
+	 * <code>UserDetails</code> object that comes back may have a username that
+	 * is of a different case than what was actually requested..
+	 * 
+	 * @param username
+	 *            the username identifying the user whose data is required.
+	 * @return a fully populated user record (never <code>null</code>)
+	 * @throws org.springframework.security.core.userdetails.UsernameNotFoundException
+	 *             if the user could not be found or the user has no
+	 *             GrantedAuthority
+	 */
+	@Override
+	@Transactional(propagation = Propagation.REQUIRED)
+	public UserDetails loadUserByUsername(String username)
+			throws UsernameNotFoundException {
+		ProfileEntity profile = obtainEntity(username);
 
-        // Clients doesnt have primary email, so, we need to cover that case.
-        if (profile.getPrimaryEmail() != null)
-            primaryEmail = profile.getPrimaryEmail().getId();
+		if (profile == null) {
+			throw new UsernameNotFoundException("Bad username or password");
+		}
+		if (profile.getPrimaryRecord() != null) {
+			throw new DeprecatedException(
+					"orcid.frontend.security.deprecated_with_primary", profile
+							.getPrimaryRecord().getId(), profile.getId());
+		}
+		if (!profile.getClaimed()) {
+			throw new UnclaimedProfileExistsException(
+					"orcid.frontend.security.unclaimed_exists");
+		}
+		if (profile.getDeactivationDate() != null) {
+			throw new DisabledException(
+					"Account not active, please call helpdesk");
+		}
 
-        OrcidProfileUserDetails userDetails = null;
+		String primaryEmail = null;
 
-        if (profile.getOrcidType() != null) {
-            userDetails = new OrcidProfileUserDetails(profile.getId(), primaryEmail, profile.getEncryptedPassword(), profile.getOrcidType(), profile.getGroupType());
-        } else {
-            userDetails = new OrcidProfileUserDetails(profile.getId(), primaryEmail, profile.getEncryptedPassword());
-        }
+		// Clients doesnt have primary email, so, we need to cover that case.
+		if (profile.getPrimaryEmail() != null)
+			primaryEmail = profile.getPrimaryEmail().getId();
 
-        return userDetails;
-    }
+		OrcidProfileUserDetails userDetails = null;
 
-    private ProfileEntity obtainEntity(String username) {
-        ProfileEntity profile = null;
-        if(!StringUtils.isEmpty(username)) {
-	        if (OrcidStringUtils.isValidOrcid(username)) {
-	            profile = profileDao.find(username);
-	        } else if(OrcidStringUtils.isValidOrcidWithSpaces(username)) {
-	        	username = username.toString().replace(' ', '-');
-	        	profile = profileDao.find(username);
-	        } else if(OrcidStringUtils.isValidOrcidWithoutSpacesWithoutHyphens(username)) {
-	        	String temp = username.replaceAll("(.{4})", "$1-");
-				int length = temp.length();
-				username = temp.substring(0, length -1);
+		if (profile.getOrcidType() != null) {
+			userDetails = new OrcidProfileUserDetails(profile.getId(),
+					primaryEmail, profile.getEncryptedPassword(),
+					profile.getOrcidType(), profile.getGroupType());
+		} else {
+			userDetails = new OrcidProfileUserDetails(profile.getId(),
+					primaryEmail, profile.getEncryptedPassword());
+		}
+
+		return userDetails;
+	}
+
+	private ProfileEntity obtainEntity(String username) {
+		ProfileEntity profile = null;
+		if (!StringUtils.isEmpty(username)) {
+			if (OrcidStringUtils.isValidOrcid(username)) {
 				profile = profileDao.find(username);
-	        } else if(baseUrl != null && username.contains(new StringBuffer(baseUrl).append("/").toString())) {
-	        	username = OrcidStringUtils.getOrcidNumber(username);
-	        	if(username != null) {
-	        		profile = profileDao.find(username);
-	        	}
-	        } else {
-	            EmailEntity emailEntity = emailDao.findCaseInsensitive(username);
-	            if (emailEntity != null) {
-	                profile = emailEntity.getProfile();
-	            }
-	        }
-        }
-        return profile;
-    }
+			} else if (OrcidStringUtils.isValidOrcidWithSpaces(username)) {
+				username = username.toString().replace(' ', '-');
+				profile = profileDao.find(username);
+			} else if (OrcidStringUtils
+					.isValidOrcidWithoutSpacesWithoutHyphens(username)) {
+				String temp = username.replaceAll("(.{4})", "$1-");
+				int length = temp.length();
+				username = temp.substring(0, length - 1);
+				profile = profileDao.find(username);
+			} else if (baseUrl != null
+					&& username.contains(new StringBuffer(baseUrl).append("/")
+							.toString())) {
+				username = OrcidStringUtils.getOrcidNumber(username);
+				if (username != null) {
+					profile = profileDao.find(username);
+				}
+			} else {
+				EmailEntity emailEntity = emailDao
+						.findCaseInsensitive(username);
+				if (emailEntity != null) {
+					profile = emailEntity.getProfile();
+				}
+			}
+		}
+		return profile;
+	}
 }

--- a/orcid-integration-test/src/test/java/org/orcid/integration/blackbox/web/SigninTest.java
+++ b/orcid-integration-test/src/test/java/org/orcid/integration/blackbox/web/SigninTest.java
@@ -17,6 +17,7 @@
 package org.orcid.integration.blackbox.web;
 
 import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +45,8 @@ public class SigninTest {
     public String user1UserName;
     @Value("${org.orcid.web.testUser1.password}")
     public String user1Password;
+    @Value("${org.orcid.web.testUser1.orcidId}")
+    public String user1OrcidId;
 
     @Before
     public void before() {
@@ -63,8 +66,25 @@ public class SigninTest {
         signIn(webDriver, user1UserName, user1Password);
         dismissVerifyEmailModal(webDriver);
     }
+    
+    @Test
+    public void signinVariousUsernameFormats() {
+    	String user1FrmtSpaces = user1OrcidId.replace('-', ' ');
+    	verifySignIn(user1FrmtSpaces);
+    	String user1FrmtNoSpNoHyp = user1OrcidId.replace("-", "");
+    	verifySignIn(user1FrmtNoSpNoHyp);
+    	String user1FrmtProfLink = new StringBuffer(baseUri).append("/").append(user1OrcidId).toString();
+    	verifySignIn(user1FrmtProfLink);
+    }
+    
+    private void verifySignIn(String userName) {
+    	webDriver.get(baseUri + "/userStatus.json?logUserOut=true");
+        webDriver.get(baseUri + "/my-orcid");
+        signIn(webDriver, userName, user1Password);
+        dismissVerifyEmailModal(webDriver);
+    }
 
-    // Make this available to other classes
+	// Make this available to other classes
     static public void signIn(WebDriver webDriver, String username, String password) {
         WebElement emailEl = webDriver.findElement(By.xpath("//input[@name='userId']"));
         emailEl.sendKeys(username);

--- a/orcid-utils/src/main/java/org/orcid/utils/OrcidStringUtils.java
+++ b/orcid-utils/src/main/java/org/orcid/utils/OrcidStringUtils.java
@@ -48,21 +48,40 @@ public class OrcidStringUtils {
     private static String DECODED_APOS = "'";
     private static String DECODED_QUOT = "\"";
 
-    private static final Pattern orcidPattern = Pattern.compile("(\\d{4}-){3,}\\d{3}[\\dX]");
+    private static final Pattern orcidPatternNormal = Pattern.compile("(\\d{4}-){3}\\d{3}[\\dX]");
+    private static final Pattern orcidPatternWithSpaces = Pattern.compile("(\\d{4} ){3}\\d{3}[\\dX]");
+    private static final Pattern orcidPatternOnlyDigits = Pattern.compile("(\\d{15}[\\dX])");
     private static final Pattern clientIdPattern = Pattern.compile("APP-[\\dA-Z]{16}");
 
     private static final Document.OutputSettings outputSettings = new Document.OutputSettings().prettyPrint(false).charset("UTF-8").escapeMode(EscapeMode.xhtml);
 
     public static boolean isValidOrcid(String orcid) {
         if (StringUtils.isNotBlank(orcid)) {
-            return orcidPattern.matcher(orcid).matches();
+        	return orcidPatternNormal.matcher(orcid).matches();
         } else {
             return false;
         }
     }
+    
+    public static boolean isValidOrcid(StringBuffer orcid) {
+    	boolean result = false;
+    	if(orcidPatternWithSpaces.matcher(orcid).matches()) {
+    		String temp = orcid.toString().replace(' ', '-');
+			orcid.replace(0, orcid.length(), temp);
+			result = true;
+    	} else if(orcidPatternOnlyDigits.matcher(orcid).matches()) {
+    		String temp = orcid.toString();
+			temp = temp.replaceAll("(.{4})", "$1-");
+			int length = temp.length();
+			temp = temp.substring(0, length -1);
+			orcid.replace(0, orcid.length(), temp);
+			result = true;
+    	}
+    	return result;
+    }
 
     public static String getOrcidNumber(String orcid) {
-        Matcher matcher = orcidPattern.matcher(orcid);
+        Matcher matcher = orcidPatternNormal.matcher(orcid);
         if (matcher.find()) {
             return matcher.group(0);
         }

--- a/orcid-utils/src/main/java/org/orcid/utils/OrcidStringUtils.java
+++ b/orcid-utils/src/main/java/org/orcid/utils/OrcidStringUtils.java
@@ -63,23 +63,22 @@ public class OrcidStringUtils {
         }
     }
     
-    public static boolean isValidOrcid(StringBuffer orcid) {
+    public static boolean isValidOrcidWithSpaces(String orcid) {
     	boolean result = false;
     	if(orcidPatternWithSpaces.matcher(orcid).matches()) {
-    		String temp = orcid.toString().replace(' ', '-');
-			orcid.replace(0, orcid.length(), temp);
-			result = true;
-    	} else if(orcidPatternOnlyDigits.matcher(orcid).matches()) {
-    		String temp = orcid.toString();
-			temp = temp.replaceAll("(.{4})", "$1-");
-			int length = temp.length();
-			temp = temp.substring(0, length -1);
-			orcid.replace(0, orcid.length(), temp);
 			result = true;
     	}
     	return result;
     }
 
+    public static boolean isValidOrcidWithoutSpacesWithoutHyphens(String orcid) {
+    	boolean result = false;
+    	 if(orcidPatternOnlyDigits.matcher(orcid).matches()) {
+ 			result = true;
+     	} 
+    	return result;
+    }
+    
     public static String getOrcidNumber(String orcid) {
         Matcher matcher = orcidPatternNormal.matcher(orcid);
         if (matcher.find()) {

--- a/orcid-utils/src/main/java/org/orcid/utils/OrcidStringUtils.java
+++ b/orcid-utils/src/main/java/org/orcid/utils/OrcidStringUtils.java
@@ -36,113 +36,120 @@ import java.util.regex.Pattern;
  */
 public class OrcidStringUtils {
 
-    private static String LT = "&lt;";
-    private static String GT = "&gt;";
-    private static String AMP = "&amp;";
-    private static String APOS = "&apos;";
-    private static String QUOT = "&quot;";
+	private static String LT = "&lt;";
+	private static String GT = "&gt;";
+	private static String AMP = "&amp;";
+	private static String APOS = "&apos;";
+	private static String QUOT = "&quot;";
 
-    private static String DECODED_LT = "<";
-    private static String DECODED_GT = ">";
-    private static String DECODED_AMP = "&";
-    private static String DECODED_APOS = "'";
-    private static String DECODED_QUOT = "\"";
+	private static String DECODED_LT = "<";
+	private static String DECODED_GT = ">";
+	private static String DECODED_AMP = "&";
+	private static String DECODED_APOS = "'";
+	private static String DECODED_QUOT = "\"";
 
-    private static final Pattern orcidPatternNormal = Pattern.compile("(\\d{4}-){3}\\d{3}[\\dX]");
-    private static final Pattern orcidPatternWithSpaces = Pattern.compile("(\\d{4} ){3}\\d{3}[\\dX]");
-    private static final Pattern orcidPatternOnlyDigits = Pattern.compile("(\\d{15}[\\dX])");
-    private static final Pattern clientIdPattern = Pattern.compile("APP-[\\dA-Z]{16}");
+	private static final Pattern orcidPatternNormal = Pattern
+			.compile("(\\d{4}-){3}\\d{3}[\\dX]");
+	private static final Pattern orcidPatternWithSpaces = Pattern
+			.compile("(\\d{4} ){3}\\d{3}[\\dX]");
+	private static final Pattern orcidPatternOnlyDigits = Pattern
+			.compile("(\\d{15}[\\dX])");
+	private static final Pattern clientIdPattern = Pattern
+			.compile("APP-[\\dA-Z]{16}");
 
-    private static final Document.OutputSettings outputSettings = new Document.OutputSettings().prettyPrint(false).charset("UTF-8").escapeMode(EscapeMode.xhtml);
+	private static final Document.OutputSettings outputSettings = new Document.OutputSettings()
+			.prettyPrint(false).charset("UTF-8").escapeMode(EscapeMode.xhtml);
 
-    public static boolean isValidOrcid(String orcid) {
-        if (StringUtils.isNotBlank(orcid)) {
-        	return orcidPatternNormal.matcher(orcid).matches();
-        } else {
-            return false;
-        }
-    }
-    
-    public static boolean isValidOrcidWithSpaces(String orcid) {
-    	boolean result = false;
-    	if(orcidPatternWithSpaces.matcher(orcid).matches()) {
+	public static boolean isValidOrcid(String orcid) {
+		if (StringUtils.isNotBlank(orcid)) {
+			return orcidPatternNormal.matcher(orcid).matches();
+		} else {
+			return false;
+		}
+	}
+
+	public static boolean isValidOrcidWithSpaces(String orcid) {
+		boolean result = false;
+		if (orcidPatternWithSpaces.matcher(orcid).matches()) {
 			result = true;
-    	}
-    	return result;
-    }
+		}
+		return result;
+	}
 
-    public static boolean isValidOrcidWithoutSpacesWithoutHyphens(String orcid) {
-    	boolean result = false;
-    	 if(orcidPatternOnlyDigits.matcher(orcid).matches()) {
- 			result = true;
-     	} 
-    	return result;
-    }
-    
-    public static String getOrcidNumber(String orcid) {
-        Matcher matcher = orcidPatternNormal.matcher(orcid);
-        if (matcher.find()) {
-            return matcher.group(0);
-        }
-        return null;
-    }
+	public static boolean isValidOrcidWithoutSpacesWithoutHyphens(String orcid) {
+		boolean result = false;
+		if (orcidPatternOnlyDigits.matcher(orcid).matches()) {
+			result = true;
+		}
+		return result;
+	}
 
-    public static boolean isClientId(String clientId) {
-        if (StringUtils.isNotBlank(clientId)) {
-            return clientIdPattern.matcher(clientId).matches();
-        } else {
-            return false;
-        }
-    }
+	public static String getOrcidNumber(String orcid) {
+		Matcher matcher = orcidPatternNormal.matcher(orcid);
+		if (matcher.find()) {
+			return matcher.group(0);
+		}
+		return null;
+	}
 
-    public static Map<String, String> resourceBundleToMap(ResourceBundle resource) {
-        Map<String, String> map = new HashMap<String, String>();
+	public static boolean isClientId(String clientId) {
+		if (StringUtils.isNotBlank(clientId)) {
+			return clientIdPattern.matcher(clientId).matches();
+		} else {
+			return false;
+		}
+	}
 
-        Enumeration<String> keys = resource.getKeys();
-        while (keys.hasMoreElements()) {
-            String key = keys.nextElement();
-            map.put(key, resource.getString(key));
-        }
+	public static Map<String, String> resourceBundleToMap(
+			ResourceBundle resource) {
+		Map<String, String> map = new HashMap<String, String>();
 
-        return map;
-    }
+		Enumeration<String> keys = resource.getKeys();
+		while (keys.hasMoreElements()) {
+			String key = keys.nextElement();
+			map.put(key, resource.getString(key));
+		}
 
-    /*
-     * http://stackoverflow.com/questions/14453047/jsoup-to-strip-only-html-tagsnot
-     * -new-line-character
-     */
-    public static String stripHtml(String s) {
-        String output = Jsoup.clean(s, "", Whitelist.simpleText(), outputSettings);
-        // According to
-        // http://jsoup.org/apidocs/org/jsoup/nodes/Entities.EscapeMode.html#xhtml
-        // jsoup scape lt, gt, amp, apos, and quot for xhtml
-        // So we want to restore them
-        output = output.replace(LT, DECODED_LT);
-        output = output.replace(GT, DECODED_GT);
-        output = output.replace(AMP, DECODED_AMP);
-        output = output.replace(APOS, DECODED_APOS);
-        output = output.replace(QUOT, DECODED_QUOT);
-        return output;
-    }
+		return map;
+	}
 
-    /**
-     * Strips html and restore the following characters: ' " & > < If the string
-     * resulting after that process doesnt match the given string, we can say it
-     * contains html
-     * 
-     * @param s
-     *            String to be cleared
-     * @return true if the give string has html tags in it
-     * */
-    public static boolean hasHtml(String s) {
-        String striped = stripHtml(s);
-        return !striped.equals(s);
-    }
-    
-    public static int compareStrings(String string, String otherString) {        
-        if (NullUtils.anyNull(string, otherString)) {
-            return NullUtils.compareNulls(string, otherString);
-        }
-        return string.compareTo(otherString);
-    }
+	/*
+	 * http://stackoverflow.com/questions/14453047/jsoup-to-strip-only-html-tagsnot
+	 * -new-line-character
+	 */
+	public static String stripHtml(String s) {
+		String output = Jsoup.clean(s, "", Whitelist.simpleText(),
+				outputSettings);
+		// According to
+		// http://jsoup.org/apidocs/org/jsoup/nodes/Entities.EscapeMode.html#xhtml
+		// jsoup scape lt, gt, amp, apos, and quot for xhtml
+		// So we want to restore them
+		output = output.replace(LT, DECODED_LT);
+		output = output.replace(GT, DECODED_GT);
+		output = output.replace(AMP, DECODED_AMP);
+		output = output.replace(APOS, DECODED_APOS);
+		output = output.replace(QUOT, DECODED_QUOT);
+		return output;
+	}
+
+	/**
+	 * Strips html and restore the following characters: ' " & > < If the string
+	 * resulting after that process doesnt match the given string, we can say it
+	 * contains html
+	 * 
+	 * @param s
+	 *            String to be cleared
+	 * @return true if the give string has html tags in it
+	 * */
+	public static boolean hasHtml(String s) {
+		String striped = stripHtml(s);
+		return !striped.equals(s);
+	}
+
+	public static int compareStrings(String string, String otherString) {
+		if (NullUtils.anyNull(string, otherString)) {
+			return NullUtils.compareNulls(string, otherString);
+		}
+		return string.compareTo(otherString);
+	}
 }


### PR DESCRIPTION
User can now login with the public profile link, the orcid id with spaces instead of hyphens, the orcid id with no spaces and no hyphens; The original pattern was accepting orcids in bad formats too. Fixed it; Added an integration test for this new functionality.

https://trello.com/c/pLIvDjfq/1958-let-users-log-in-with-the-full-orcid-id-i-e-http-orcid-org-1234-1111-1111-111x