### PR TITLE
Added a check when client adds an extra primary email

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidJaxbCopyManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidJaxbCopyManagerImpl.java
@@ -342,9 +342,14 @@ public class OrcidJaxbCopyManagerImpl implements OrcidJaxbCopyManager {
 				}
 			}
 		}
+		//Set primary = false for each remaining new email.
 		if(updatedContactDetails != null) {
-			allEmails.addAll(updatedContactDetails.getEmail());
+			for(Email newEmail : updatedContactDetails.getEmail()) {
+				newEmail.setPrimary(false);
+				allEmails.add(newEmail);
+			}
 		}
+		
 		for(Email email : allEmails) {
 			if(email.getVisibility() == null) {
 				email.setVisibility(OrcidVisibilityDefaults.ALTERNATIVE_EMAIL_DEFAULT.getVisibility());

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidJaxbCopyManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidJaxbCopyManagerTest.java
@@ -416,8 +416,8 @@ public class OrcidJaxbCopyManagerTest extends BaseTest {
             assertNotNull(email);
             assertEquals(Visibility.PRIVATE, email.getVisibility());
         }
-        // There's now 4 because can't remove private emails
-        assertEquals(4, existingContactDetails.getEmail().size());
+        //3 emails existing, out of which 1 is public. 1 email new and 1 for edit. public is removed so 3 remain
+        assertEquals(3, existingContactDetails.getEmail().size());
 
         assertEquals(Iso3166Country.AU, existingContactDetails.getAddress().getCountry().getValue());
     }


### PR DESCRIPTION
https://trello.com/c/p671ueAU/2005-client-apps-can-overwrite-user-privacy-setting-for-email-addresses