### PR TITLE
Removed extra emails from the sample OrcidMessages. Client can create a profile with 1 email only.

### DIFF
--- a/orcid-integration-test/src/test/java/org/orcid/integration/api/t2/AbstractT2ClientIntegrationTest.java
+++ b/orcid-integration-test/src/test/java/org/orcid/integration/api/t2/AbstractT2ClientIntegrationTest.java
@@ -57,21 +57,21 @@ public abstract class AbstractT2ClientIntegrationTest {
         OrcidMessage emptyOrcid = (OrcidMessage) unmarshaller.unmarshal(AbstractT2ClientIntegrationTest.class.getResourceAsStream(xmlLoc));
         emptyOrcid.getOrcidProfile().getOrcidBio().getContactDetails()
                 .addOrReplacePrimaryEmail(new Email("orcid.integration.test+" + System.currentTimeMillis() + "@semantico.com"));
+          List<Email> emails = emptyOrcid.getOrcidProfile().getOrcidBio().getContactDetails().getEmail();
 
-        List<Email> emails = emptyOrcid.getOrcidProfile().getOrcidBio().getContactDetails().getEmail();
-
-        Email secondaryEmail1 = new Email("   test1+" + System.currentTimeMillis() + "@test.com   ");
-        secondaryEmail1.setPrimary(false);
-
-        Email secondaryEmail2 = new Email("test2+" + System.currentTimeMillis() + "@test.com   ");
-        secondaryEmail2.setPrimary(false);
-
-        Email secondaryEmail3 = new Email("   test3+" + System.currentTimeMillis() + "@test.com");
-        secondaryEmail3.setPrimary(false);
-
-        emails.add(secondaryEmail1);
-        emails.add(secondaryEmail2);
-        emails.add(secondaryEmail3);
+//		  Cannot create a profile with more than 1 email.
+//        Email secondaryEmail1 = new Email("   test1+" + System.currentTimeMillis() + "@test.com   ");
+//        secondaryEmail1.setPrimary(false);
+//
+//        Email secondaryEmail2 = new Email("test2+" + System.currentTimeMillis() + "@test.com   ");
+//        secondaryEmail2.setPrimary(false);
+//
+//        Email secondaryEmail3 = new Email("   test3+" + System.currentTimeMillis() + "@test.com");
+//        secondaryEmail3.setPrimary(false);
+//
+//        emails.add(secondaryEmail1);
+//        emails.add(secondaryEmail2);
+//        emails.add(secondaryEmail3);
 
         emptyOrcid.getOrcidProfile().getOrcidBio().getContactDetails().setEmail(emails);
 
@@ -86,18 +86,19 @@ public abstract class AbstractT2ClientIntegrationTest {
 
         List<Email> emails = emptyOrcid.getOrcidProfile().getOrcidBio().getContactDetails().getEmail();
 
-        Email secondaryEmail1 = new Email("   test1+" + System.currentTimeMillis() + "@test.com   ");
-        secondaryEmail1.setPrimary(false);
-
-        Email secondaryEmail2 = new Email("test2+" + System.currentTimeMillis() + "@test.com   ");
-        secondaryEmail2.setPrimary(false);
-
-        Email secondaryEmail3 = new Email("   test3+" + System.currentTimeMillis() + "@test.com");
-        secondaryEmail3.setPrimary(false);
-
-        emails.add(secondaryEmail1);
-        emails.add(secondaryEmail2);
-        emails.add(secondaryEmail3);
+//		  Client cannot add more than 1 emails
+//        Email secondaryEmail1 = new Email("   test1+" + System.currentTimeMillis() + "@test.com   ");
+//        secondaryEmail1.setPrimary(false);
+//
+//        Email secondaryEmail2 = new Email("test2+" + System.currentTimeMillis() + "@test.com   ");
+//        secondaryEmail2.setPrimary(false);
+//
+//        Email secondaryEmail3 = new Email("   test3+" + System.currentTimeMillis() + "@test.com");
+//        secondaryEmail3.setPrimary(false);
+//
+//        emails.add(secondaryEmail1);
+//        emails.add(secondaryEmail2);
+//        emails.add(secondaryEmail3);
 
         emptyOrcid.getOrcidProfile().getOrcidBio().getContactDetails().setEmail(emails);
 

--- a/orcid-integration-test/src/test/java/org/orcid/integration/api/test/T2OrcidApiClientIntegrationTest.java
+++ b/orcid-integration-test/src/test/java/org/orcid/integration/api/test/T2OrcidApiClientIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.orcid.core.api.OrcidApiConstants.STATUS_OK_MESSAGE;
 
 import java.util.List;
@@ -171,7 +172,8 @@ public class T2OrcidApiClientIntegrationTest extends AbstractT2ClientIntegration
         assertTrue(orcidProfileFullDetails.indexOf("<title>Work title 2</title>") != -1);
         assertTrue(orcidProfileFullDetails.indexOf("<subtitle>Work subtitle 2</subtitle>") != -1);
         assertTrue(orcidProfileFullDetails.indexOf("<orcid-history>") != -1);
-        assertTrue(orcidProfileFullDetails.indexOf("<email primary=\"false\" current=\"true\" verified=\"false\" visibility=\"private\">") != -1);
+// 		A secondary email can only be added using the UI
+//      assertTrue(orcidProfileFullDetails.indexOf("<email primary=\"false\" current=\"true\" verified=\"false\" visibility=\"private\">") != -1);
         assertTrue(orcidProfileFullDetails.indexOf("<email primary=\"true\" current=\"true\" verified=\"false\" visibility=\"private\">") != -1);
     }
 
@@ -552,7 +554,9 @@ public class T2OrcidApiClientIntegrationTest extends AbstractT2ClientIntegration
         String familyName = responseEntity.getOrcidProfile().getOrcidBio().getPersonalDetails().getFamilyName().getContent();
         assertEquals("Bowen", familyName);
         List<Email> updatedEmails = responseEntity.getOrcidProfile().getOrcidBio().getContactDetails().getEmail();
-        assertTrue(updatedEmails.contains(email6));
+        
+        //Client cannot add emails
+        assertFalse(updatedEmails.contains(email6));
     }
 
     @Test
@@ -577,7 +581,8 @@ public class T2OrcidApiClientIntegrationTest extends AbstractT2ClientIntegration
         String familyName = responseEntity.getOrcidProfile().getOrcidBio().getPersonalDetails().getFamilyName().getContent();
         assertEquals("Bowen", familyName);
         List<Email> updatedEmails = responseEntity.getOrcidProfile().getOrcidBio().getContactDetails().getEmail();
-        assertTrue(updatedEmails.contains(email6));
+        //Client cannot add emails
+        assertFalse(updatedEmails.contains(email6));
     }
 
     private void createOrcidAndVerifyResponse201() throws Exception {

--- a/orcid-integration-test/src/test/resources/orcid-client/orcid-internal-sponsor-message-client.xml
+++ b/orcid-integration-test/src/test/resources/orcid-client/orcid-internal-sponsor-message-client.xml
@@ -41,7 +41,6 @@
 				</other-names>				
 			</personal-details>
 			<contact-details>
-				<email>jimmyb@semantico.com</email>
 			</contact-details>			
 		</orcid-bio>		
 	</orcid-profile>


### PR DESCRIPTION
https://trello.com/c/gq4zcHGW/2105-do-not-allow-the-client-to-add-emails