### PR TITLE
Fix group id desc col length

### DIFF
--- a/orcid-model/src/main/resources/group-id-2.0_rc1/README.md
+++ b/orcid-model/src/main/resources/group-id-2.0_rc1/README.md
@@ -12,6 +12,15 @@ In order to get access to these scopes, one should manually map the scopes with 
 
 ``insert into client_scope values(<Client ID>,'/group-id-record/read','2015-07-20 14:08:42.128','2015-07-20 14:08:42.128' );``
 
+##### Generate the input XML >>>
+
+The maximum length of the following fields should not exceed :
+
+Name : 1000 chars
+Groupid : 1000 chars
+Decription : 1000 chars
+
+
 ##### To use the API >>>
 
 1) Get the access_token :

--- a/orcid-model/src/main/resources/group-id-2.0_rc1/group-id-2.0_rc1.xsd
+++ b/orcid-model/src/main/resources/group-id-2.0_rc1/group-id-2.0_rc1.xsd
@@ -49,7 +49,7 @@
 							</xs:annotation>
 						</xs:element>																		
 						<xs:element name="group-id"  type="common:group-id" maxOccurs="1" minOccurs="1" />
-						<xs:element name="description" type="common:non-empty-string"
+						<xs:element name="description" type="common:string-1000"
 							maxOccurs="1" minOccurs="1">
 							<xs:annotation>
 								<xs:documentation>Description

--- a/orcid-persistence/src/main/resources/db/updates/group-id-record.xml
+++ b/orcid-persistence/src/main/resources/db/updates/group-id-record.xml
@@ -64,7 +64,9 @@
         <addAutoIncrement tableName="group_id_record" columnName="id" columnDataType="bigint"/>
     </changeSet>
     
-    <changeSet id="UPDATE-DESCRIPTION-FIELD-SIZE" author="Shobhit Tyagi" dbms="postgresql">    	
+    <changeSet id="UPDATE-FIELDS-SIZE" author="Shobhit Tyagi" dbms="postgresql">    	
+        <sql>ALTER TABLE group_id_record ALTER COLUMN group_id TYPE VARCHAR(1000)</sql>
+        <sql>ALTER TABLE group_id_record ALTER COLUMN group_name TYPE VARCHAR(1000)</sql>
         <sql>ALTER TABLE group_id_record ALTER COLUMN group_description TYPE VARCHAR(1000)</sql>
     </changeSet>
 </databaseChangeLog>

--- a/orcid-persistence/src/main/resources/db/updates/group-id-record.xml
+++ b/orcid-persistence/src/main/resources/db/updates/group-id-record.xml
@@ -64,4 +64,7 @@
         <addAutoIncrement tableName="group_id_record" columnName="id" columnDataType="bigint"/>
     </changeSet>
     
+    <changeSet id="UPDATE-DESCRIPTION-FIELD-SIZE" author="Shobhit Tyagi" dbms="postgresql">    	
+        <sql>ALTER TABLE group_id_record ALTER COLUMN group_description TYPE VARCHAR(1000)</sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
https://trello.com/c/ioxGpPux/2149-group-id-increase-description-character-limit
https://trello.com/c/XZUZJ6i1/2150-group-id-improve-error-message-when-description-is-too-long