### PR TITLE
500 error was hardcoded. Updated the code to get it from the exception map

### DIFF
--- a/orcid-api-common/src/main/java/org/orcid/api/common/jaxb/OrcidExceptionMapper.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/jaxb/OrcidExceptionMapper.java
@@ -184,7 +184,7 @@ public class OrcidExceptionMapper implements ExceptionMapper<Throwable> {
             return Response.status(Response.Status.NOT_FOUND).entity(entity).build();
         } else {
             OrcidMessage entity = getLegacy500OrcidEntity(t);
-            return Response.serverError().entity(entity).build();
+            return Response.status(getHttpStatusAndErrorCode(t).getKey()).entity(entity).build();
         }
     }
 


### PR DESCRIPTION
https://trello.com/c/Y1DIEOId/1926-incorrect-http-codes-for-errors