### PR TITLE
Fixed problem where show more notifications button is not shown...

### DIFF
--- a/orcid-web/src/main/resources/freemarker/notifications.ftl
+++ b/orcid-web/src/main/resources/freemarker/notifications.ftl
@@ -31,13 +31,13 @@
                 ${springMacroRequestContext.getMessage("notifications.showArchived")}
             </label>
         </div>
-        <div ng-show="notificationsSrvc.loading == true" class="text-center" id="workSpinner">
+        <div ng-show="notificationsSrvc.loading == true" class="text-center" id="notificationsSpinner">
             <i class="glyphicon glyphicon-refresh spin x4 green" id="spinner"></i><!-- Hidden with a CSS hack on IE 7 only -->
             <!--[if lt IE 8]>    
                 <img src="${staticCdn}/img/spin-big.gif" width="85" height ="85"/>
             <![endif]-->
         </div>
-        <div ng-cloak ng-show="notificationsSrvc.loading == false && notifications.length == 0">${springMacroRequestContext.getMessage("notifications.none")}</div>
+        <div ng-cloak ng-show="notificationsSrvc.loading == false && notifications.length == 0  &&!areMore()">${springMacroRequestContext.getMessage("notifications.none")}</div>
         <div ng-cloak ng-show="notificationsSrvc.loading == false && notifications.length &gt; 0">            
             <table class="table table-responsive table-condensed notifications">
            		<thead>					
@@ -68,13 +68,18 @@
                 </tbody>
 
             </table>
-            
-            
-            <div ng-cloak>
-                <button ng-show="areMore()" ng-click="showMore()" class="btn" type="submit" id="show-more-button">Show more</button>
-                <br></br>
-                <br></br>
-            </div>
+        </div>
+        <div ng-cloak ng-hide="notificationsSrvc.loading == false && notifications.length &gt; 0">
+            <br/><br/>
+        </div>   
+        <div ng-cloak>
+            <button ng-show="areMore() && notificationsSrvc.loadingMore == false" ng-click="showMore()" class="btn" type="submit" id="show-more-button">Show more</button>
+        </div>
+        <div ng-cloak ng-show="notificationsSrvc.loadingMore == true" id="moreNotificationsSpinner">
+            <i class="glyphicon glyphicon-refresh spin x4 green" id="spinner"></i><!-- Hidden with a CSS hack on IE 7 only -->
+            <!--[if lt IE 8]>    
+                <img src="${staticCdn}/img/spin-big.gif" width="85" height ="85"/>
+            <![endif]-->
         </div>
     </div>
 </div>

--- a/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
+++ b/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
@@ -1345,6 +1345,7 @@ orcidNgModule.factory("notificationsSrvc", ['$rootScope', function ($rootScope) 
     var defaultMaxResults = 10;
     var serv = {
         loading: true,
+        loadingMore: false,
         firstResult: 0,
         maxResults: defaultMaxResults,
         areMoreFlag: false,
@@ -1353,7 +1354,6 @@ orcidNgModule.factory("notificationsSrvc", ['$rootScope', function ($rootScope) 
         unreadCount: 0,
         showArchived: false,
         getNotifications: function() {
-            serv.loading = true;
             var url = getBaseUri() + '/inbox/notifications.json?firstResult=' + serv.firstResult + '&maxResults=' + serv.maxResults;
             if(serv.showArchived){
                 url += "&includeArchived=true";                
@@ -1372,11 +1372,13 @@ orcidNgModule.factory("notificationsSrvc", ['$rootScope', function ($rootScope) 
                         serv.notifications.push(data[i]);
                     }
                     serv.loading = false;
+                    serv.loadingMore = false;
                     $rootScope.$apply();
                     serv.resizeIframes();
                 }
             }).fail(function() {
                 serv.loading = false;
+                serv.loadingMore = false;
                 // something bad is happening!
                 console.log("error with getting notifications");
             });
@@ -1411,6 +1413,7 @@ orcidNgModule.factory("notificationsSrvc", ['$rootScope', function ($rootScope) 
             return serv.unreadCount;
         },
         showMore: function() {
+            serv.loadingMore = true;
             serv.firstResult += serv.maxResults;
             serv.getNotifications();
         },


### PR DESCRIPTION
…when the user has clicked archive for all the notifications currently on the screen.

Added spinner for showing progress when show more notifications button is clicked.

https://trello.com/c/mRkW9C1v/2277-notifications-show-more-messages-doesn-t-load-as-you-archive-more-recent-messages