### PR TITLE
Don't add notification scope to new clients for the time being.

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidClientGroupManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/OrcidClientGroupManagerImpl.java
@@ -671,7 +671,7 @@ public class OrcidClientGroupManagerImpl implements OrcidClientGroupManager {
 
     private void addPremiumOnlyScopes(Set<String> scopes) {
         scopes.add(ScopePathType.WEBHOOK.value());
-        scopes.add(ScopePathType.PREMIUM_NOTIFICATION.value());
+        // scopes.add(ScopePathType.PREMIUM_NOTIFICATION.value());
     }
 
     /**


### PR DESCRIPTION
https://trello.com/c/aEdv2urv/2300-notifications-turn-off-the-notification-scope-for-all-prod-clients-except-for-crossref-and-our-testing-accounts