### PR TITLE
Fixing loader and revoke window size

### DIFF
--- a/orcid-web/src/main/resources/freemarker/manage.ftl
+++ b/orcid-web/src/main/resources/freemarker/manage.ftl
@@ -669,27 +669,28 @@
 </script>
 
 <script type="text/ng-template" id="revoke-social-account-modal">
-    <div class="lightbox-container">
-        <h3>Revoke Social Account</h3>
-        <p>{{socialRemoteUserToRevoke}}</p>
- 		<h3><@orcid.msg 'check_password_modal.confirm_password' /></h3>
-        <form ng-submit="revoke()">
-            <div ng-show="isPasswordConfirmationRequired">
-                <h3><@orcid.msg 'check_password_modal.confirm_password' /></h3>
-                <div class="form-group">
-                    <label for="confirm_add_delegate_modal.password" class=""><@orcid.msg 'check_password_modal.password' /></label><span class="required">*</span>
-                    <input id="confirm_add_delegate_modal.password" type="password" name="confirm_add_delegate_modal.password" ng-model="password" class="form-control"/>
-                </div>
-                <span class="orcid-error" ng-show="errors.length > 0">
-                    <span ng-repeat='error in errors' ng-bind-html="error"></span>
-                </span>
-            </div>
-            <button class="btn btn-danger"><@orcid.msg 'manage_delegation.btnrevokeaccess'/></button>
-            <a href="" ng-click="closeModal()"><@orcid.msg 'freemarker.btnclose'/></a>
-        </form>
-        <div ng-show="errors.length === 0">
-            <br></br>
-        </div>
+    <div class="lightbox-container revoke-social">
+		<div class="row">
+			<div class="col-md-12 col-sm-12 col-xs-12">
+	        	<h3>Revoke Social Account</h3>
+        		<p>{{socialRemoteUserToRevoke}}</p>
+ 				<h3><@orcid.msg 'check_password_modal.confirm_password' /></h3>
+        		<form ng-submit="revoke()">
+		            <div ng-show="isPasswordConfirmationRequired">
+                		<h3><@orcid.msg 'check_password_modal.confirm_password' /></h3>
+                		<div class="form-group">
+		                    <label for="confirm_add_delegate_modal.password" class=""><@orcid.msg 'check_password_modal.password' /></label><span class="required">*</span>
+                    		<input id="confirm_add_delegate_modal.password" type="password" name="confirm_add_delegate_modal.password" ng-model="password" class="form-control"/>
+                		</div>
+                		<span class="orcid-error" ng-show="errors.length > 0">
+		                    <span ng-repeat='error in errors' ng-bind-html="error"></span>
+                		</span>
+            		</div>
+            		<button class="btn btn-danger"><@orcid.msg 'manage_delegation.btnrevokeaccess'/></button>
+            		<a href="" ng-click="closeModal()"><@orcid.msg 'freemarker.btnclose'/></a>
+        		</form>
+			</div>
+		</div>        
     </div>
 </script>
 

--- a/orcid-web/src/main/resources/freemarker/social_link_signin.ftl
+++ b/orcid-web/src/main/resources/freemarker/social_link_signin.ftl
@@ -71,9 +71,12 @@
             
             <div class=" col-md-offset-3 col-md-8 col-sm-9 col-sm-offset-3 col-xs-12">
 	            <div class="control-group">                    
-	                            
-	                <button id='form-sign-in-button' class="btn btn-primary social-signin-btn" type="submit">${springMacroRequestContext.getMessage("login.signin")}</button>                
-	                <span id="ajax-loader" class="no-visible"><i id="ajax-loader" class="glyphicon glyphicon-refresh spin x2 green"></i></span>                
+	                
+	                <ul class="inline-list">
+	                	<li><button id='form-sign-in-button' class="btn btn-primary social-signin-btn" type="submit">${springMacroRequestContext.getMessage("login.signin")}</button></li>
+	                	<li><span id="ajax-loader" class="no-visible"><i id="ajax-loader" class="glyphicon glyphicon-refresh spin x2 green"></i></span></li>
+	                </ul>                
+	                                
 	                
 	                <#if (RequestParameters['alreadyClaimed'])??>
 	                    <div class="alert"><@spring.message "orcid.frontend.security.already_claimed"/></div>

--- a/orcid-web/src/main/webapp/static/css/orcid.new.css
+++ b/orcid-web/src/main/webapp/static/css/orcid.new.css
@@ -6376,6 +6376,14 @@ a:hover .mozilla-badge{
 	height: 80px;
 }
 
+.revoke-social .form-social-sign-in #ajax-loader{
+	margin-left: 5px;
+}
+
+.revoke-social{
+	min-height: 195px; 
+}
+
 
 /* Media Queries */
 @media ( max-width : 767px) { /* Mobile */

--- a/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
+++ b/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
@@ -6787,10 +6787,12 @@ orcidNgModule.controller('SocialCtrl',['$scope', '$compile', function SocialCtrl
         $scope.socialRemoteUserToRevoke = id.providerid;
         $scope.idToManage = id;
         $.colorbox({
-            html : $compile($('#revoke-social-account-modal').html())($scope)
-
+            html : $compile($('#revoke-social-account-modal').html())($scope),            
+            onComplete: function() {
+                $.colorbox.resize();        
+            }
         });
-        $.colorbox.resize();
+        
     };
 
     $scope.revoke = function () {


### PR DESCRIPTION
Fixes two issues, cards related:

https://trello.com/c/Sj3RIilw/2514-on-link-accounts-screen-the-spinner-after-you-click-sign-in-pushes-text-down
https://trello.com/c/bM6nt3p7/2510-social-account-revoke-access-box-is-too-big