### PR TITLE
Allowing secure calls only for version 2

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/web/filters/ApiVersionCheckFilter.java
+++ b/orcid-core/src/main/java/org/orcid/core/web/filters/ApiVersionCheckFilter.java
@@ -50,6 +50,11 @@ public class ApiVersionCheckFilter implements ContainerRequestFilter {
 
         if (version != null && version.startsWith("1.1") && v1xDisabled) {
             throw new OrcidBadRequestException(localeManager.resolveMessage("apiError.badrequest_version_disabled.exception"));
+        } else if(version != null && version.startsWith("2.0")) {
+            String headerVal = request.getHeaderValue("X-Forwarded-Proto");
+            if(!"HTTPS".equals(headerVal) && !request.isSecure()) {
+                throw new OrcidBadRequestException(localeManager.resolveMessage("apiError.badrequest_secure_only.exception"));
+            }
         }
 
         return request;

--- a/orcid-core/src/main/resources/i18n/api_en.properties
+++ b/orcid-core/src/main/resources/i18n/api_en.properties
@@ -17,7 +17,7 @@
 
 #
 # Add keys that need translating here:
-#
+# apiError.badrequest_secure_only.exception=API Version 2.0 only allows HTTPS calls.
 #
 #
 apiError.9000.userMessage=There was an error connecting to ORCID
@@ -135,6 +135,7 @@ apiError.badrequest_invalid_search_rows.exception=The rows parameter must be an 
 apiError.badrequest_incorrect_webhook.exception=Webhook uri: {0} is syntactically incorrect
 apiError.badrequest_affiliations_notsupported.exception=Affiliations are not supported in this version of the API
 apiError.badrequest_version_disabled.exception=API Version 1.1 is no longer available. Please use the latest version of the API.
+apiError.badrequest_secure_only.exception=API Version 2.0 only allows HTTPS calls.
 apiError.forbidden_unregister_webhook.exception=Unable to unregister webhook: Only the client that register the webhook can unregister it.
 apiError.validation_claimedstatus.exception=Claimed status should not be specified when creating a profile
 apiError.validation_creationmethod.exception=Creation method should not be specified when creating a profile


### PR DESCRIPTION
https://trello.com/c/8kQPUocF/1919-api-2-0-require-calls-to-use-https