### PR TITLE
fixed https://trello.com/c/fMMmpug3/2628-rc2-identifiers-types-listed…

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/SingleWorkExternalIdentifierFromJsonConverter.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/SingleWorkExternalIdentifierFromJsonConverter.java
@@ -45,7 +45,7 @@ public final class SingleWorkExternalIdentifierFromJsonConverter extends Bidirec
         try{
             workExternalIdentifier.setWorkExternalIdentifierType(WorkExternalIdentifierType.fromValue(source.getType()));
         }catch (IllegalArgumentException e){
-            workExternalIdentifier.setWorkExternalIdentifierType(WorkExternalIdentifierType.OTHER_ID);
+            throw e;
         }
         return JsonUtils.convertToJsonString(workExternalIdentifiers);
     }

--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/WorkExternalIDConverter.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/WorkExternalIDConverter.java
@@ -46,17 +46,20 @@ public class WorkExternalIDConverter extends BidirectionalConverter<ExternalID, 
     }
 
     /** Currently transforms into rc1 format
-     * TODO: make local class to use JSONUtils on.
      * 
      */
     @Override
     public String convertTo(ExternalID externalID, Type<String> arg1) {
-        //tranform to rc1 WorkExternalIdentifier
+        return JsonUtils.convertToJsonString(convertToRC1(externalID));
+    }
+    
+    protected WorkExternalIdentifier convertToRC1(ExternalID externalID){
         WorkExternalIdentifier id = new WorkExternalIdentifier();
         try{
             id.setWorkExternalIdentifierType(WorkExternalIdentifierType.fromValue(externalID.getType()));            
         }catch(IllegalArgumentException e){
-            id.setWorkExternalIdentifierType(WorkExternalIdentifierType.OTHER_ID); 
+            //not in the enum (case sensitive - must be lower case
+            throw e;
         }
         id.setWorkExternalIdentifierId(new WorkExternalIdentifierId(externalID.getValue()));
         if (externalID.getUrl()!=null)
@@ -66,7 +69,7 @@ public class WorkExternalIDConverter extends BidirectionalConverter<ExternalID, 
                 id.setRelationship(Relationship.fromValue(externalID.getRelationship().value()));
             }catch (IllegalArgumentException e){
             }
-        return JsonUtils.convertToJsonString(id);
+        return id;
     }
 
 }

--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/WorkExternalIDsConverter.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/WorkExternalIDsConverter.java
@@ -56,26 +56,9 @@ public class WorkExternalIDsConverter extends BidirectionalConverter<ExternalIDs
     @Override
     public String convertTo(ExternalIDs externalIDs, Type<String> arg1) {
         WorkExternalIdentifiers ids = new WorkExternalIdentifiers();
+        WorkExternalIDConverter conv = new WorkExternalIDConverter();
         for (ExternalID externalID : externalIDs.getExternalIdentifier()){
-            WorkExternalIdentifier id = new WorkExternalIdentifier();
-            try{
-                id.setWorkExternalIdentifierType(WorkExternalIdentifierType.fromValue(externalID.getType()));            
-            }catch(IllegalArgumentException e){
-                id.setWorkExternalIdentifierType(WorkExternalIdentifierType.OTHER_ID); 
-            }
-            
-            id.setWorkExternalIdentifierId(new WorkExternalIdentifierId(externalID.getValue()));
-            
-            if (externalID.getUrl() != null){
-                id.setUrl(new Url(externalID.getUrl().getValue()));                
-            }
-            if (externalID.getRelationship() != null)
-                try{
-                    id.setRelationship(Relationship.fromValue(externalID.getRelationship().value()));
-                }catch (IllegalArgumentException e){
-                }
-            
-            ids.getExternalIdentifier().add(id);
+            ids.getExternalIdentifier().add(conv.convertToRC1(externalID));
         }        
         return JsonUtils.convertToJsonString(ids);
     }


### PR DESCRIPTION
works now return 400 if upper case is used.

<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<error xmlns="http://www.orcid.org/ns/error">
      <response-code>400</response-code>
      <developer-message>java.lang.IllegalArgumentException: DOI</developer-message>
      <user-message>The client application sent a bad request to ORCID.</user-message>
      <error-code>9006</error-code>
      <more-info>http://members.orcid.org/api/api-error-codes</more-info>
</error>

https://trello.com/c/fMMmpug3/2628-rc2-identifiers-types-listed-in-an-unexpected-case-don-t-save-correctly

