### PR TITLE
Updated to show spinner while delegates are loading on account settings

### DIFF
--- a/orcid-integration-test/src/test/java/org/orcid/integration/blackbox/client/AccountSettingsPage.java
+++ b/orcid-integration-test/src/test/java/org/orcid/integration/blackbox/client/AccountSettingsPage.java
@@ -54,7 +54,12 @@ public class AccountSettingsPage {
     }
 
     public DelegatesSection getDelegatesSection() {
-        utils.getWait().until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//table[@ng-show='delegation.givenPermissionTo.delegationDetails']")));
+        utils.getWait().until(new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver driver) {
+                return !xpath.isVisible("id('delegates-spinner')");
+            }
+        });
         return new DelegatesSection();
     }
 
@@ -165,10 +170,10 @@ public class AccountSettingsPage {
             int numOfDelegates = 0;
             try {
                 numOfDelegates = getDelegatesSection().getDelegates().size();
-            } catch(Exception e) {
-                //There are no 
+            } catch (Exception e) {
+                // There are no
             }
-            
+
             final int numberOfDelegatesBefore = numOfDelegates;
             localXPath.click("td[3]/span/span");
             xpath.click("//form[@ng-submit='addDelegate()']/button");

--- a/orcid-web/src/main/resources/freemarker/manage.ftl
+++ b/orcid-web/src/main/resources/freemarker/manage.ftl
@@ -405,6 +405,12 @@
                 target=_blank"">${springMacroRequestContext.getMessage("manage.findoutmore")}</a>
         </p>
         <div ng-controller="DelegatesCtrl" id="DelegatesCtrl" data-search-query-url="${searchBaseUrl}">
+            <div class="ng-hide" ng-show="showInitLoader == true;">
+                <i id="delegates-spinner" class="glyphicon glyphicon-refresh spin x4 green"></i>
+                <!--[if lt IE 8]>    
+                    <img src="${staticCdn}/img/spin-big.gif" width="85" height ="85"/>
+                <![endif]-->
+            </div>
             <table class="table table-bordered settings-table normal-width" ng-show="delegation.givenPermissionTo.delegationDetails" ng-cloak>
                 <thead>
                     <tr>

--- a/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
+++ b/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
@@ -6483,6 +6483,7 @@ orcidNgModule.controller('DelegatesCtrl',['$scope', '$compile', function Delegat
     $scope.input = {};
     $scope.input.start = 0;
     $scope.input.rows = 10;
+    $scope.showInitLoader = true;
     $scope.showLoader = false;
     $scope.effectiveUserOrcid = orcidVar.orcidId;
     $scope.realUserOrcid = orcidVar.realOrcidId;
@@ -6752,9 +6753,11 @@ orcidNgModule.controller('DelegatesCtrl',['$scope', '$compile', function Delegat
                         $scope.delegatesByOrcid[delegate.delegateSummary.orcidIdentifier.path] = delegate;
                     }
                 }
+                $scope.showInitLoader = false;
                 $scope.$apply();
             }
         }).fail(function() {
+            $scope.showInitLoader = false;
             // something bad is happening!
             console.log("error with delegates");
         });


### PR DESCRIPTION
This is better for users, and also makes it possible for black box tests to see when the delegates section finishes loading.

This is to help with https://trello.com/c/J30tM4x4/2609-create-a-single-whitebox-test-that-sets-up-blackbox-test.