### PR TITLE
Allowing to show form to add an external identifiers when an error is…

### DIFF
--- a/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
+++ b/orcid-web/src/main/webapp/static/javascript/angularOrcid.js
@@ -5848,8 +5848,11 @@ orcidNgModule.controller('WorkCtrl', ['$scope', '$compile', '$filter', 'worksSrv
                         $scope.worksSrvc.loadAbbrWorks(worksSrvc.constants.access_type.USER);
                     }
                 } else {
-                    $scope.editWork = data;
+                    $scope.editWork = data;                    
                     commonSrvc.copyErrorsLeft($scope.editWork, data);
+                    
+                    $scope.addExternalIdentifier();
+                    
                     $scope.addingWork = false;
                     $scope.$apply();
                     // make sure colorbox is shown if there are errors


### PR DESCRIPTION
https://trello.com/c/7gjFLPPH/2678-external-identifiers-inputs-disappears-when-no-values-were-set-on-save-and-errors-were-returned