### PR TITLE
Id unit test visibility 1 2 again

### DIFF
--- a/orcid-api-web/src/test/java/org/orcid/api/t2/server/delegator/T2OrcidApiServiceDelegatorTest.java
+++ b/orcid-api-web/src/test/java/org/orcid/api/t2/server/delegator/T2OrcidApiServiceDelegatorTest.java
@@ -85,6 +85,7 @@ import org.orcid.jaxb.model.message.WorkTitle;
 import org.orcid.jaxb.model.message.WorkType;
 import org.orcid.test.DBUnitTest;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -655,6 +656,75 @@ public class T2OrcidApiServiceDelegatorTest extends DBUnitTest {
         assertEquals(new Url("http://rurl2.com"),p.getOrcidBio().getResearcherUrls().getResearcherUrl().get(0).getUrl());
         assertEquals(Visibility.PUBLIC,p.getOrcidBio().getResearcherUrls().getVisibility());
 
+        //now test what happens if we add a new one.
+        
     }
+    
+    @Test
+    public void testReadPrivacyOnBioAsPublic(){
+        SecurityContextTestUtils.setUpSecurityContext("4444-4444-4444-4497",ScopePathType.READ_PUBLIC);
+        /*Example A List on 4444-4444-4444-4497:
+        Item 1 Private (client is source)
+        Item 2 Private (other source)
+        Item 3 Limited
+        Item 4 Public 
+        */
+        OrcidProfile p = ((OrcidMessage)t2OrcidApiServiceDelegator.findBioDetails("4444-4444-4444-4497").getEntity()).getOrcidProfile();
+        System.out.println(p.toString());
+        assertEquals(1,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().size());
+        assertEquals("type4",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getExternalIdCommonName().getContent());
+        
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getVisibility());
+        
+    }
+    
+    @Test
+    public void testReadPrivacyOnBio(){
+        SecurityContextTestUtils.setUpSecurityContext("4444-4444-4444-4497",ScopePathType.READ_LIMITED);
+        //ARGH - authentication object does not contain a client ID.  
+        /*Example A List on 4444-4444-4444-4497:
+        Item 1 Private (client is source)
+        Item 2 Private (other source)
+        Item 3 Limited
+        Item 4 Public 
+        */
+        OrcidProfile p = ((OrcidMessage)t2OrcidApiServiceDelegator.findBioDetails("4444-4444-4444-4497").getEntity()).getOrcidProfile();
+        System.out.println(p.toString());
+        assertEquals(3,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().size());
+        assertEquals("type2",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getExternalIdCommonName().getContent());
+        assertEquals(Visibility.PRIVATE,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getVisibility());
+        assertEquals("type3",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(1).getExternalIdCommonName().getContent());
+        assertEquals(Visibility.LIMITED,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(1).getVisibility());
+        assertEquals("type4",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(2).getExternalIdCommonName().getContent());
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(2).getVisibility());
+        assertEquals(Visibility.PRIVATE,p.getOrcidBio().getExternalIdentifiers().getVisibility());
+    }
+        
+        
+    
+        //use manager to set up record two
+        /*Example B List:
+        Item 1 Limited
+        Item 2 Public 
+         */
+    
+        //use manager to set up record three
+        /*Example C List:
+        Item 1 Public
+        Item 2 Public 
+         */
+    
+    @Test
+    @DirtiesContext
+    public void testUpdateBioByDifferentClientNoConflicts(){
+       //tests that when client one posts a keyword, it doesn't remove ones added by client 2.
+        
+    }
+    
+    //which endpoints can be used to update the bio...?
+    //e.g. update external identifiers.
+    //review code to discover where we can change visibility of bio elements.
+    
+    //add sanity test for updateProfile.
 
 }

--- a/orcid-api-web/src/test/java/org/orcid/api/t2/server/delegator/T2OrcidApiServiceDelegatorTest.java
+++ b/orcid-api-web/src/test/java/org/orcid/api/t2/server/delegator/T2OrcidApiServiceDelegatorTest.java
@@ -670,18 +670,14 @@ public class T2OrcidApiServiceDelegatorTest extends DBUnitTest {
         Item 4 Public 
         */
         OrcidProfile p = ((OrcidMessage)t2OrcidApiServiceDelegator.findBioDetails("4444-4444-4444-4497").getEntity()).getOrcidProfile();
-        System.out.println(p.toString());
         assertEquals(1,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().size());
         assertEquals("type4",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getExternalIdCommonName().getContent());
-        
         assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getVisibility());
-        
     }
     
     @Test
     public void testReadPrivacyOnBio(){
         SecurityContextTestUtils.setUpSecurityContext("4444-4444-4444-4497",ScopePathType.READ_LIMITED);
-        //ARGH - authentication object does not contain a client ID.  
         /*Example A List on 4444-4444-4444-4497:
         Item 1 Private (client is source)
         Item 2 Private (other source)
@@ -689,7 +685,6 @@ public class T2OrcidApiServiceDelegatorTest extends DBUnitTest {
         Item 4 Public 
         */
         OrcidProfile p = ((OrcidMessage)t2OrcidApiServiceDelegator.findBioDetails("4444-4444-4444-4497").getEntity()).getOrcidProfile();
-        System.out.println(p.toString());
         assertEquals(3,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().size());
         assertEquals("type2",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getExternalIdCommonName().getContent());
         assertEquals(Visibility.PRIVATE,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getVisibility());
@@ -699,32 +694,66 @@ public class T2OrcidApiServiceDelegatorTest extends DBUnitTest {
         assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(2).getVisibility());
         assertEquals(Visibility.PRIVATE,p.getOrcidBio().getExternalIdentifiers().getVisibility());
     }
-        
-        
     
-        //use manager to set up record two
+    @Test
+    public void testReadPrivacyOnBio2(){
         /*Example B List:
         Item 1 Limited
         Item 2 Public 
          */
+                
+        //read the profile with LIMITED
+        SecurityContextTestUtils.setUpSecurityContext("4444-4444-4444-4441",ScopePathType.READ_LIMITED);
+        OrcidProfile p = ((OrcidMessage)t2OrcidApiServiceDelegator.findBioDetails("4444-4444-4444-4441").getEntity()).getOrcidProfile();
+        assertEquals(2,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().size());
+        assertEquals("A-0001",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getExternalIdCommonName().getContent());
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getVisibility());
+        assertEquals("A-0002",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(1).getExternalIdCommonName().getContent());
+        assertEquals(Visibility.LIMITED,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(1).getVisibility());
+        assertEquals(Visibility.LIMITED,p.getOrcidBio().getExternalIdentifiers().getVisibility());
+        
+        //read the profile with PUBLIC
+        SecurityContextTestUtils.setUpSecurityContext("4444-4444-4444-4441",ScopePathType.READ_PUBLIC);
+        p = ((OrcidMessage)t2OrcidApiServiceDelegator.findBioDetails("4444-4444-4444-4441").getEntity()).getOrcidProfile();
+        assertEquals(1,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().size());
+        assertEquals("A-0001",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getExternalIdCommonName().getContent());
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getVisibility());
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getVisibility());        
+    }
     
-        //use manager to set up record three
+    @Test
+    public void testReadPrivacyOnBio3(){
         /*Example C List:
         Item 1 Public
-        Item 2 Public 
          */
+        SecurityContextTestUtils.setUpSecurityContext("4444-4444-4444-4443",ScopePathType.READ_LIMITED);
+        OrcidProfile p = ((OrcidMessage)t2OrcidApiServiceDelegator.findBioDetails("4444-4444-4444-4443").getEntity()).getOrcidProfile();
+        System.out.println(p.toString());        
+        assertEquals(1,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().size());
+        assertEquals("Facebook",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getExternalIdCommonName().getContent());
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getVisibility());
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getVisibility());
+
+        SecurityContextTestUtils.setUpSecurityContext("4444-4444-4444-4443",ScopePathType.READ_PUBLIC);
+        p = ((OrcidMessage)t2OrcidApiServiceDelegator.findBioDetails("4444-4444-4444-4443").getEntity()).getOrcidProfile();
+        System.out.println(p.toString());        
+        assertEquals(1,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().size());
+        assertEquals("Facebook",p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getExternalIdCommonName().getContent());
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().get(0).getVisibility());
+        assertEquals(Visibility.PUBLIC,p.getOrcidBio().getExternalIdentifiers().getVisibility());
+    }
     
     @Test
     @DirtiesContext
+    //which endpoints can be used to update the bio...?
+    //e.g. update external identifiers.
+    //review code to discover where we can change visibility of bio elements.    
+    //add sanity test for updateProfile.
     public void testUpdateBioByDifferentClientNoConflicts(){
        //tests that when client one posts a keyword, it doesn't remove ones added by client 2.
         
     }
     
-    //which endpoints can be used to update the bio...?
-    //e.g. update external identifiers.
-    //review code to discover where we can change visibility of bio elements.
-    
-    //add sanity test for updateProfile.
+   
 
 }

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerImplTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerImplTest.java
@@ -510,6 +510,23 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         assertEquals(Visibility.LIMITED,profile.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().iterator().next().getVisibility());
         assertEquals("other",profile.getOrcidBio().getPersonalDetails().getOtherNames().getOtherName().iterator().next().getContent());
         assertEquals(Visibility.LIMITED,profile.getOrcidBio().getPersonalDetails().getOtherNames().getOtherName().iterator().next().getVisibility());
+        
+        //now attempt to alter privacy.  It should fail as record has been claimed.
+        profile.getOrcidBio().getKeywords().setVisibility(Visibility.PUBLIC);
+        profile.getOrcidBio().getResearcherUrls().setVisibility(Visibility.PUBLIC);
+        profile.getOrcidBio().getExternalIdentifiers().setVisibility(Visibility.PUBLIC);
+        profile.getOrcidBio().getPersonalDetails().getOtherNames().setVisibility(Visibility.PUBLIC);
+        profile = orcidProfileManager.updateOrcidProfile(profile);
+        
+        assertEquals("word",profile.getOrcidBio().getKeywords().getKeyword().iterator().next().getContent());
+        assertEquals(Visibility.LIMITED,profile.getOrcidBio().getKeywords().getKeyword().iterator().next().getVisibility());
+        assertEquals(new Url("http://whatever.com"),profile.getOrcidBio().getResearcherUrls().getResearcherUrl().iterator().next().getUrl());
+        assertEquals(Visibility.LIMITED,profile.getOrcidBio().getResearcherUrls().getResearcherUrl().iterator().next().getVisibility());
+        assertEquals("cn",profile.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().iterator().next().getExternalIdCommonName().getContent());
+        assertEquals(Visibility.LIMITED,profile.getOrcidBio().getExternalIdentifiers().getExternalIdentifier().iterator().next().getVisibility());
+        assertEquals("other",profile.getOrcidBio().getPersonalDetails().getOtherNames().getOtherName().iterator().next().getContent());
+        assertEquals(Visibility.LIMITED,profile.getOrcidBio().getPersonalDetails().getOtherNames().getOtherName().iterator().next().getVisibility());        
+
     }      
     
     @Test

--- a/orcid-core/src/test/java/org/orcid/core/oauth/service/ClientDetailsManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/oauth/service/ClientDetailsManagerTest.java
@@ -30,6 +30,7 @@ import javax.annotation.Resource;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.orcid.core.manager.ClientDetailsManager;
@@ -161,12 +162,13 @@ public class ClientDetailsManagerTest extends DBUnitTest {
         List<ClientDetailsEntity> all = clientDetailsManager.getAll();
         assertEquals(9, all.size());
         for (ClientDetailsEntity clientDetailsEntity : all) {
-            if (!"APP-5555555555555555".equals(clientDetailsEntity.getId())) {
+            if (!"APP-5555555555555555".equals(clientDetailsEntity.getId()) &&
+                    !"APP-55555555555555556".equals(clientDetailsEntity.getId())) {
                 clientDetailsManager.deleteClientDetail(clientDetailsEntity.getId());
             }
         }
         all = clientDetailsManager.getAll();
-        assertEquals(1, all.size());
+        assertEquals(2, all.size());
     }
 
     private void checkClientDetails(ClientDetailsEntity clientDetails) {

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/ExternalIdentifier.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/ExternalIdentifier.java
@@ -62,7 +62,7 @@ import java.io.Serializable;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder = { "orcid", "externalIdOrcid", "externalIdCommonName", "externalIdReference", "externalIdUrl", "externalIdSource", "source" })
 @XmlRootElement(name = "external-identifier")
-public class ExternalIdentifier implements VisibilityType, Serializable {
+public class ExternalIdentifier implements VisibilityType, PrivateVisibleToSource, Serializable {
 
     /**
      * 

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/Keyword.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/Keyword.java
@@ -56,7 +56,7 @@ import java.io.Serializable;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType( propOrder = { "content" })
 @XmlRootElement(name = "keyword")
-public class Keyword implements VisibilityType, Serializable {
+public class Keyword implements VisibilityType, PrivateVisibleToSource,Serializable {
 
     /**
      * 

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/OtherName.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/OtherName.java
@@ -56,7 +56,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType( propOrder = { "content" })
 @XmlRootElement(name = "other-name")
-public class OtherName implements VisibilityType, Serializable {
+public class OtherName implements VisibilityType, PrivateVisibleToSource,Serializable {
 
     /**
      * 

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/PrivateVisibleToSource.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/PrivateVisibleToSource.java
@@ -1,0 +1,6 @@
+package org.orcid.jaxb.model.message;
+
+public interface PrivateVisibleToSource {
+
+    public Source getSource();
+}

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/PrivateVisibleToSource.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/PrivateVisibleToSource.java
@@ -1,3 +1,19 @@
+/**
+ * =============================================================================
+ *
+ * ORCID (R) Open Source
+ * http://orcid.org
+ *
+ * Copyright (c) 2012-2014 ORCID, Inc.
+ * Licensed under an MIT-Style License (MIT)
+ * http://orcid.org/open-source-license
+ *
+ * This copyright and license information (including a link to the full license)
+ * shall be included in its entirety in all copies or substantial portion of
+ * the software.
+ *
+ * =============================================================================
+ */
 package org.orcid.jaxb.model.message;
 
 public interface PrivateVisibleToSource {

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/message/ResearcherUrl.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/message/ResearcherUrl.java
@@ -60,7 +60,7 @@ import java.io.Serializable;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType( propOrder = { "urlName", "url" })
 @XmlRootElement(name = "researcher-url")
-public class ResearcherUrl implements Comparable<ResearcherUrl>, VisibilityType, Serializable {
+public class ResearcherUrl implements Comparable<ResearcherUrl>, VisibilityType, PrivateVisibleToSource, Serializable {
 
     /**
      * 

--- a/orcid-persistence/src/test/java/org/orcid/persistence/dao/ProfileDaoTest.java
+++ b/orcid-persistence/src/test/java/org/orcid/persistence/dao/ProfileDaoTest.java
@@ -144,9 +144,9 @@ public class ProfileDaoTest extends DBUnitTest {
     public void testFindAll() {
         List<ProfileEntity> all = profileDao.getAll();
         assertNotNull(all);
-        assertEquals(12, all.size());
+        assertEquals(13, all.size());
         Long count = profileDao.countAll();
-        assertEquals(Long.valueOf(12), count);
+        assertEquals(Long.valueOf(13), count);
     }
 
     @Test
@@ -168,7 +168,7 @@ public class ProfileDaoTest extends DBUnitTest {
         assertEquals(dateCreated.getTime(), profile.getDateCreated().getTime());
 
         Long count = profileDao.countAll();
-        assertEquals(Long.valueOf(13), count);
+        assertEquals(Long.valueOf(14), count);
         profile = profileDao.find(newOrcid);
 
         assertNotNull(profile);
@@ -194,7 +194,7 @@ public class ProfileDaoTest extends DBUnitTest {
         assertEquals(dateCreated.getTime(), profile.getDateCreated().getTime());
 
         Long count = profileDao.countAll();
-        assertEquals(Long.valueOf(13), count);
+        assertEquals(Long.valueOf(14), count);
         profile = profileDao.find(newOrcid);
 
         assertNotNull(profile);
@@ -222,7 +222,7 @@ public class ProfileDaoTest extends DBUnitTest {
         assertEquals(dateCreated.getTime(), retrievedProfile.getDateCreated().getTime());
 
         Long count = profileDao.countAll();
-        assertEquals(Long.valueOf(13), count);
+        assertEquals(Long.valueOf(14), count);
     }
 
     @Test
@@ -344,7 +344,7 @@ public class ProfileDaoTest extends DBUnitTest {
         assertNull(profile);
 
         List<ProfileEntity> all = profileDao.getAll();
-        assertEquals(10, all.size());
+        assertEquals(11, all.size());
     }
 
     @Test
@@ -381,7 +381,7 @@ public class ProfileDaoTest extends DBUnitTest {
         assertEquals("4444-4444-4444-4446", results.get(1));
 
         results = profileDao.findOrcidsByIndexingStatus(IndexingStatus.DONE, Integer.MAX_VALUE);
-        assertEquals(10, results.size());
+        assertEquals(11, results.size());
 
         results = profileDao.findOrcidsByIndexingStatus(IndexingStatus.DONE, 3);
         assertEquals(3, results.size());
@@ -448,12 +448,12 @@ public class ProfileDaoTest extends DBUnitTest {
     public void testGetConfirmedProfileCount() {
         String orcid = "4444-4444-4444-4446";
         Long confirmedProfileCount = profileDao.getConfirmedProfileCount();
-        assertEquals(Long.valueOf(12), confirmedProfileCount);
+        assertEquals(Long.valueOf(13), confirmedProfileCount);
         ProfileEntity profileEntity = profileDao.find(orcid);
         profileEntity.setCompletedDate(null);
         profileDao.persist(profileEntity);
         confirmedProfileCount = profileDao.getConfirmedProfileCount();
-        assertEquals(Long.valueOf(11), confirmedProfileCount);
+        assertEquals(Long.valueOf(12), confirmedProfileCount);
     }
 
     @Test

--- a/orcid-persistence/src/test/java/org/orcid/persistence/dao/StatisticsGeneratorDaoTest.java
+++ b/orcid-persistence/src/test/java/org/orcid/persistence/dao/StatisticsGeneratorDaoTest.java
@@ -65,7 +65,7 @@ public class StatisticsGeneratorDaoTest extends DBUnitTest {
     public void testStatistics() {
         assertEquals(11, statisticsGeneratorDao.getAccountsWithVerifiedEmails());
         assertEquals(4, statisticsGeneratorDao.getAccountsWithWorks());
-        assertEquals(12, statisticsGeneratorDao.getLiveIds());
+        assertEquals(13, statisticsGeneratorDao.getLiveIds());
         assertEquals(10, statisticsGeneratorDao.getNumberOfWorks());
         //TODO: Restore this test when we know how to make it work on HSQLDB
         //assertEquals(0, statisticsGeneratorDao.getNumberOfUniqueDOIs());

--- a/orcid-test/src/main/resources/data/ProfileEntityData.xml
+++ b/orcid-test/src/main/resources/data/ProfileEntityData.xml
@@ -372,6 +372,8 @@
             orcid_type="USER"
             reviewed="false"          
             />
+            
+            
 
 	<profile
             orcid="4444-4444-4444-4498"
@@ -407,6 +409,40 @@
             orcid_type="CLIENT" 
             client_type="PREMIUM_CREATOR"
             reviewed="false"
+            />
+            
+            <profile
+            orcid="4444-4444-4444-4497"
+            creation_method="API"
+            completed_date="2011-07-02 15:31:00.00"
+            date_created="2011-06-29 15:31:00.00"
+            submission_date="2011-06-29 15:31:00.00"
+            last_indexed_date="2011-07-02 15:31:00.00"
+            last_modified="2011-07-02 15:31:00.00"
+            claimed="true"
+            given_names="Tom"
+            family_name="McTomson"
+            vocative_name="yeah, one of those"
+            credit_name="Multi Cred Name"
+            external_identifiers_visibility="PUBLIC"
+            biography_visibility="PUBLIC"
+            keywords_visibility="PUBLIC"
+            other_names_visibility="PUBLIC"
+            researcher_urls_visibility="PUBLIC"           
+            source_id="4444-4444-4444-4441"
+            is_selectable_sponsor="false"
+            encrypted_password="e9adO9I4UpBwqI5tGR+qDodvAZ7mlcISn+T+kyqXPf2Z6PPevg7JijqYr6KGO8VOskOYqVOEK2FEDwebxWKGDrV/TQ9gRfKWZlzxssxsOnA="
+            security_question_id="1"
+            encrypted_security_answer="iTlIoR2JsFl5guE56cazmg=="
+            encrypted_verification_code="1vLkD2Lm8c24TyALcW0Brg=="
+            send_change_notifications="false"
+            send_orcid_news="false"
+            activities_visibility_default='PUBLIC'
+            credentials_expiry="2013-02-01"
+            biography="biog"
+            indexing_status="DONE"
+            orcid_type="USER"
+            reviewed="false"          
             />
 
     <granted_authority
@@ -544,6 +580,56 @@
             external_id_url="http://ext-id/A-0002"
             client_source_id="APP-5555555555555555"
             visibility="LIMITED"
+            date_created="2011-06-29 15:31:00.00"            
+            last_modified="2011-07-02 15:31:00.00"
+            display_index="0"
+            />
+    
+    <!-- 9,10,11,12 for bio visibility tests testReadPrivacyOnBio() -->        
+	<external_identifier
+            id="9"
+            external_id_reference="ref1"
+            external_id_type="type1"
+            orcid="4444-4444-4444-4497"
+            external_id_url="http://ext-id/ref1"
+            client_source_id="APP-5555555555555556"
+            visibility="PRIVATE"
+            date_created="2011-06-29 15:31:00.00"            
+            last_modified="2011-07-02 15:31:00.00"
+            display_index="0"
+            />            
+      <external_identifier
+            id="10"
+            external_id_reference="ref2"
+            external_id_type="type2"
+            orcid="4444-4444-4444-4497"
+            external_id_url="http://ext-id/ref2"
+            client_source_id="APP-5555555555555555"
+            visibility="PRIVATE"
+            date_created="2011-06-29 15:31:00.00"            
+            last_modified="2011-07-02 15:31:00.00"
+            display_index="0"
+            />
+      <external_identifier
+            id="11"
+            external_id_reference="ref3"
+            external_id_type="type3"
+            orcid="4444-4444-4444-4497"
+            external_id_url="http://ext-id/ref3"
+            client_source_id="APP-5555555555555555"
+            visibility="LIMITED"
+            date_created="2011-06-29 15:31:00.00"            
+            last_modified="2011-07-02 15:31:00.00"
+            display_index="0"
+            />
+       <external_identifier
+            id="12"
+            external_id_reference="ref4"
+            external_id_type="type4"
+            orcid="4444-4444-4444-4497"
+            external_id_url="http://ext-id/ref4"
+            client_source_id="APP-5555555555555555"
+            visibility="PUBLIC"
             date_created="2011-06-29 15:31:00.00"            
             last_modified="2011-07-02 15:31:00.00"
             display_index="0"


### PR DESCRIPTION
Visibility filter now updates section visibility to contain most restrictive of visible items.

Added unit tests to check Getting identifiers, when are they returned? section of https://docs.google.com/document/d/15jYA2wJLlzaO2K8M7_AEuZg7q3moq38MOB12uti0cxc/edit#heading=h.rzwpdxq5ymvy 

Note, I had to modify OrcidApiAuthorizationSecurityAspect so that it would work with mocked OrcidOAuth2Authentication.

card: https://trello.com/c/8DajvAfE/2687-add-unit-test-for-1-2-api
