### PR TITLE
Seems that POST method is not allowed by the server, changed to GET

### DIFF
--- a/orcid-web/src/main/webapp/static/javascript/script.js
+++ b/orcid-web/src/main/webapp/static/javascript/script.js
@@ -232,7 +232,7 @@ function checkOrcidLoggedIn() {
             $.ajax(
                     {
                         url : orcidVar.baseUri + '/userStatus.json?callback=?',
-                        type : 'POST',
+                        type : 'GET',
                         dataType : 'json',
                         success : function(data) {
                             if (data.loggedIn == false


### PR DESCRIPTION
https://trello.com/c/C7XDnG7p/2751-firefox-error-with-login-check