### PR TITLE
removed duplicate context loading

### DIFF
--- a/orcid-core/src/test/java/org/orcid/core/manager/AffiliationsManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/AffiliationsManagerTest.java
@@ -49,8 +49,6 @@ import org.orcid.persistence.jpa.entities.SourceEntity;
 import org.orcid.test.OrcidJUnit4ClassRunner;
 import org.springframework.test.context.ContextConfiguration;
 
-@RunWith(OrcidJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "classpath:orcid-core-context.xml" })
 public class AffiliationsManagerTest extends BaseTest {
     private static final List<String> DATA_FILES = Arrays.asList("/data/SecurityQuestionEntityData.xml", "/data/SourceClientDetailsEntityData.xml",
             "/data/ProfileEntityData.xml", "/data/ClientDetailsEntityData.xml");

--- a/orcid-core/src/test/java/org/orcid/core/manager/NotificationManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/NotificationManagerTest.java
@@ -34,7 +34,9 @@ import javax.xml.bind.Unmarshaller;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.orcid.core.BaseTest;
 import org.orcid.core.manager.impl.NotificationManagerImpl;
 import org.orcid.jaxb.model.message.CreditName;
@@ -61,12 +63,15 @@ import org.orcid.persistence.jpa.entities.ProfileEntity;
 import org.orcid.persistence.jpa.entities.ProfileEventEntity;
 import org.orcid.persistence.jpa.entities.RecordNameEntity;
 import org.orcid.persistence.jpa.entities.SecurityQuestionEntity;
+import org.orcid.test.OrcidJUnit4ClassRunner;
+import org.orcid.test.TargetProxyHelper;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
+@RunWith(OrcidJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-orcid-core-context.xml" })
 @Transactional
-public class NotificationManagerTest extends BaseTest {
+public class NotificationManagerTest {
 
     public static final String ORCID_INTERNAL_FULL_XML = "/orcid-internal-full-message-latest.xml";
 
@@ -104,12 +109,18 @@ public class NotificationManagerTest extends BaseTest {
 
     @Before
     public void initMocks() throws Exception {
+        MockitoAnnotations.initMocks(this);
         NotificationManagerImpl notificationManagerImpl = getTargetObject(notificationManager, NotificationManagerImpl.class);
         notificationManagerImpl.setEncryptionManager(encryptionManager);
         notificationManagerImpl.setProfileEventDao(profileEventDao);
         notificationManagerImpl.setSourceManager(sourceManager);
     }
 
+    @SuppressWarnings( { "unchecked" })
+    protected <T> T getTargetObject(Object proxy, Class<T> targetClass) throws Exception {
+        return TargetProxyHelper.getTargetObject(proxy, targetClass);
+    }
+    
     @Test
     public void testSendWelcomeEmail() throws JAXBException, IOException, URISyntaxException {
         OrcidMessage orcidMessage = (OrcidMessage) unmarshaller.unmarshal(getClass().getResourceAsStream(ORCID_INTERNAL_FULL_XML));

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidClientGroupManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidClientGroupManagerTest.java
@@ -58,7 +58,6 @@ import org.springframework.transaction.support.TransactionTemplate;
  * @author Will Simpson
  * 
  */
-@ContextConfiguration(locations = { "classpath:orcid-core-context.xml" })
 public class OrcidClientGroupManagerTest extends BaseTest {
 
     public static final String CLIENT_GROUP = "/orcid-client-group-request.xml";

--- a/orcid-core/src/test/java/org/orcid/core/manager/impl/OrcidUrlManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/impl/OrcidUrlManagerTest.java
@@ -40,7 +40,6 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Will Simpson
  *
  */
-@ContextConfiguration(locations = { "classpath:test-orcid-core-context.xml" })
 public class OrcidUrlManagerTest extends BaseTest {
 
     @Resource

--- a/orcid-core/src/test/java/org/orcid/core/security/DefaultOAuthClientVisibilityTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/security/DefaultOAuthClientVisibilityTest.java
@@ -51,8 +51,6 @@ import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-@RunWith(OrcidJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "classpath:orcid-core-context.xml" })
 public class DefaultOAuthClientVisibilityTest extends BaseTest {
 
     @Resource(name = "defaultPermissionChecker")

--- a/orcid-pub-web/src/test/java/org/orcid/api/t1/stats/StatsApiServiceBaseImplTest.java
+++ b/orcid-pub-web/src/test/java/org/orcid/api/t1/stats/StatsApiServiceBaseImplTest.java
@@ -49,7 +49,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 
 @RunWith(OrcidJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "classpath:orcid-t1-web-context.xml", "classpath:orcid-core-context.xml", "classpath:orcid-t1-security-context.xml" })
+@ContextConfiguration(locations = { "classpath:orcid-t1-web-context.xml", "classpath:orcid-t1-security-context.xml" })
 @SuppressWarnings("deprecation")
 public class StatsApiServiceBaseImplTest {
 


### PR DESCRIPTION
This modifies some of the test definitions so that they don't load the Spring context twice.