### PR TITLE
External identifiers now have default types 

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/ExternalIdentifierTypeConverter.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/ExternalIdentifierTypeConverter.java
@@ -37,6 +37,8 @@ public final class ExternalIdentifierTypeConverter extends BidirectionalConverte
 
     @Override
     public String convertFrom(String source, Type<String> destinationType) {
+        if (source == null)
+            return null;
         // annoying hack because grant_number does it different.
         if (source.equals("GRANT_NUMBER"))
             return "grant_number";

--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/FundingExternalIdentifier.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/FundingExternalIdentifier.java
@@ -173,7 +173,10 @@ public class FundingExternalIdentifier implements Serializable, JSONIdentifierAd
         try {
             // note that funding identifiers use "_" in the api e.g.
             // grant_number wheras works use "-". Isn't that fun?
-            messagePojo.setType(FundingExternalIdentifierType.fromValue(this.getType().toLowerCase()));
+            if (this.getType() != null)
+                messagePojo.setType(FundingExternalIdentifierType.fromValue(this.getType().toLowerCase()));
+            else
+                messagePojo.setType(FundingExternalIdentifierType.GRANT_NUMBER);
         } catch (IllegalArgumentException e) {
             messagePojo.setType(FundingExternalIdentifierType.GRANT_NUMBER);
         }
@@ -191,7 +194,10 @@ public class FundingExternalIdentifier implements Serializable, JSONIdentifierAd
 
         // note that funding identifiers use "_" in the api e.g. grant_number
         // wheras works use "-". Isn't that fun?
-        recordPojo.setType(this.getType().toLowerCase());
+        if (this.getType() == null)
+            recordPojo.setType(FundingExternalIdentifierType.GRANT_NUMBER.value());
+        else
+            recordPojo.setType(this.getType().toLowerCase());
 
         if (this.getUrl() != null && !PojoUtil.isEmpty(this.getUrl().value)) {
             org.orcid.jaxb.model.common_rc2.Url url = new org.orcid.jaxb.model.common_rc2.Url(this.getUrl().value);

--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/PeerReviewWorkExternalIDConverter.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/PeerReviewWorkExternalIDConverter.java
@@ -51,37 +51,4 @@ public class PeerReviewWorkExternalIDConverter extends BidirectionalConverter<Ex
         return id.toDBJSONString();
     }
 
-    /**
-     * Transforms RC1 into RC2
-     * 
-     * protected ExternalID convertRC1toRC2(WorkExternalIdentifier id){
-     * ExternalID result = new ExternalID(); if
-     * (id.getWorkExternalIdentifierType() != null){
-     * result.setType(id.getWorkExternalIdentifierType().value()); }else{
-     * result.setType(WorkExternalIdentifierType.OTHER_ID.value()); } if
-     * (id.getRelationship() !=null)
-     * result.setRelationship(org.orcid.jaxb.model.record_rc2.Relationship.
-     * fromValue(id.getRelationship().value())); if (id.getUrl() != null)
-     * result.setUrl(new
-     * org.orcid.jaxb.model.common_rc2.Url(id.getUrl().getValue())); if
-     * (id.getWorkExternalIdentifierId() !=null)
-     * result.setValue(id.getWorkExternalIdentifierId().getContent()); else
-     * result.setValue(""); return result; }
-     * 
-     * protected WorkExternalIdentifier convertRC2toRC1(ExternalID externalID){
-     * WorkExternalIdentifier id = new WorkExternalIdentifier(); try{
-     * id.setWorkExternalIdentifierType(WorkExternalIdentifierType.fromValue(
-     * externalID.getType())); }catch(IllegalArgumentException e){ throw new
-     * ActivityIdentifierValidationException(e); } if (externalID.getValue()
-     * !=null) id.setWorkExternalIdentifierId(new
-     * WorkExternalIdentifierId(externalID.getValue())); else
-     * id.setWorkExternalIdentifierId(new WorkExternalIdentifierId(""));
-     * 
-     * if (externalID.getUrl()!=null) id.setUrl(new
-     * Url(externalID.getUrl().getValue())); if (externalID.getRelationship() !=
-     * null) try{
-     * id.setRelationship(Relationship.fromValue(externalID.getRelationship().
-     * value())); }catch (IllegalArgumentException e){ } return id; }
-     */
-
 }

--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/WorkExternalIdentifier.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/WorkExternalIdentifier.java
@@ -103,14 +103,19 @@ public class WorkExternalIdentifier implements Serializable, JSONIdentifierAdapt
             messagePojo.setWorkExternalIdentifierType(WorkExternalIdentifierType.OTHER_ID);
         }
         messagePojo.setWorkExternalIdentifierId(new org.orcid.jaxb.model.message.WorkExternalIdentifierId());
-        messagePojo.getWorkExternalIdentifierId().setContent(this.getWorkExternalIdentifierId().content);
+        if (this.getWorkExternalIdentifierId() != null)
+            messagePojo.getWorkExternalIdentifierId().setContent(this.getWorkExternalIdentifierId().content);
         return messagePojo;
     }
 
     public ExternalID toRecordPojo() {
         ExternalID id = new ExternalID();
-        id.setType(conv.convertFrom(this.getWorkExternalIdentifierType(), null));
-        id.setValue(this.getWorkExternalIdentifierId().content);
+        if (this.getWorkExternalIdentifierType() == null)
+            id.setType(WorkExternalIdentifierType.OTHER_ID.value());
+        else
+            id.setType(conv.convertFrom(this.getWorkExternalIdentifierType(), null));
+        if (this.getWorkExternalIdentifierId() != null)
+            id.setValue(this.getWorkExternalIdentifierId().content);
         if (this.url != null)
             id.setUrl(new org.orcid.jaxb.model.common_rc2.Url(this.getUrl().value));
         if (this.getRelationship() != null)


### PR DESCRIPTION
(other-id for works, grant_number for funding) if there are nulls in the database.

Also fixed issue where null identifier values were failing.

I've created the pull request in advance of waiting for the unit tests to finish.  Hopefully they'll work (I'm at a conference!)