### PR TITLE
Fixed 1.2 ext id conversion when ext id type contains underscore character.

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/WorkExternalIdentifiers.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/jsonidentifiers/WorkExternalIdentifiers.java
@@ -58,7 +58,7 @@ public class WorkExternalIdentifiers implements Serializable, JSONIdentifierAdap
 
             for (WorkExternalIdentifier extId : this.getWorkExternalIdentifier()) {
                 org.orcid.jaxb.model.message.WorkExternalIdentifierType type = org.orcid.jaxb.model.message.WorkExternalIdentifierType
-                        .fromValue(extId.getWorkExternalIdentifierType());
+                        .valueOf(extId.getWorkExternalIdentifierType());
 
                 if (org.orcid.jaxb.model.message.WorkExternalIdentifierType.ISSN.equals(type)) {
                     if (!workType.equals(org.orcid.jaxb.model.message.WorkType.BOOK)) {

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerBaseTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerBaseTest.java
@@ -248,8 +248,13 @@ public class OrcidProfileManagerBaseTest extends BaseTest {
         WorkExternalIdentifier work1ExternalIdentifier2 = new WorkExternalIdentifier();
         work1ExternalIdentifier2.setWorkExternalIdentifierType(WorkExternalIdentifierType.PMID);
         work1ExternalIdentifier2.setWorkExternalIdentifierId(new WorkExternalIdentifierId("work1-pmid"));
+        WorkExternalIdentifier work1ExternalIdentifier3 = new WorkExternalIdentifier();
+        work1ExternalIdentifier3.setWorkExternalIdentifierType(WorkExternalIdentifierType.SOURCE_WORK_ID);
+        work1ExternalIdentifier3.setWorkExternalIdentifierId(new WorkExternalIdentifierId("work1-source-id"));
         work1ExternalIdentifiers.getWorkExternalIdentifier().add(work1ExternalIdentifier1);
         work1ExternalIdentifiers.getWorkExternalIdentifier().add(work1ExternalIdentifier2);
+        work1ExternalIdentifiers.getWorkExternalIdentifier().add(work1ExternalIdentifier3);
+
         return work1ExternalIdentifiers;
     }
 

--- a/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerImplTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/OrcidProfileManagerImplTest.java
@@ -289,7 +289,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
 
         List<WorkExternalIdentifier> workExternalIdentifiers = profile1.getOrcidActivities().getOrcidWorks().getOrcidWork().get(0).getWorkExternalIdentifiers()
                 .getWorkExternalIdentifier();
-        assertEquals(2, workExternalIdentifiers.size());
+        assertEquals(3, workExternalIdentifiers.size());
         Iterator<WorkExternalIdentifier> workExternalIdentifiersIterator = workExternalIdentifiers.iterator();
         while (workExternalIdentifiersIterator.hasNext()) {
             if (WorkExternalIdentifierType.PMID.equals(workExternalIdentifiersIterator.next().getWorkExternalIdentifierType())) {
@@ -306,7 +306,7 @@ public class OrcidProfileManagerImplTest extends OrcidProfileManagerBaseTest {
         assertEquals(1, resultProfile.retrieveOrcidWorks().getOrcidWork().size());
         assertEquals(1, resultProfile.getOrcidBio().getResearcherUrls().getResearcherUrl().size());
         assertEquals("http://www.wjrs.co.uk", resultProfile.getOrcidBio().getResearcherUrls().getResearcherUrl().get(0).getUrl().getValue());
-        assertEquals(1, resultProfile.getOrcidActivities().getOrcidWorks().getOrcidWork().get(0).getWorkExternalIdentifiers().getWorkExternalIdentifier().size());
+        assertEquals(2, resultProfile.getOrcidActivities().getOrcidWorks().getOrcidWork().get(0).getWorkExternalIdentifiers().getWorkExternalIdentifier().size());
     }
 
     @Test


### PR DESCRIPTION
https://trello.com/c/4J3VNpez/2873-put-requests-in-1-2-return-bad-request-source-work-id