### PR TITLE
If visibility is null we have a problem, so, we should return the nul…

### DIFF
--- a/orcid-model/src/main/java/org/orcid/jaxb/model/record_rc2/PersonExternalIdentifier.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/record_rc2/PersonExternalIdentifier.java
@@ -119,8 +119,6 @@ public class PersonExternalIdentifier implements VisibilityType, Serializable, F
         this.putCode = putCode;
     }
     public Visibility getVisibility() {
-        if (visibility == null)
-            return Visibility.PUBLIC;
         return visibility;
     }
     public void setVisibility(Visibility visibility) {


### PR DESCRIPTION
…l one instead of a default value