### PR TITLE
Resend claim email spanish warning fix

### DIFF
--- a/orcid-core/src/main/resources/i18n/messages_es.properties
+++ b/orcid-core/src/main/resources/i18n/messages_es.properties
@@ -1151,7 +1151,7 @@ orcid.frontend.verify.current_work_external_id_invalid=Si se especifica un valor
 orcid.frontend.verify.duplicate_email={0} ya existe en nuestro sistema.. ¿Desea <a href\="{1}">iniciar sesión</a> usando {0}?
 orcid.frontend.verify.email_sent=Se ha enviado un correo electrónico de verificación.
 orcid.frontend.verify.start_before_end=La fecha de inicio debe ser anterior a la fecha de finalización
-orcid.frontend.verify.unclaimed_email={0} ya existe en nuestro sistema como un registro no recuperado. ¿Desea <a href\="{{resendClaimUrl}}">reenviar el correo electrónico de recuperación</a>?
+orcid.frontend.verify.unclaimed_email={0} ya existe en nuestro sistema como un registro no recuperado. ¿Desea <a href\="{1}">reenviar el correo electrónico de recuperación</a>?
 orcid.frontend.web.details_deactivateEmailSent=Se ha enviado a {0} un correo electrónico para iniciar el proceso de desactivación.
 orcid.frontend.web.details_saved=Sus cambios se han guardado.
 orcid.frontend.web.email_updated=Su correo electrónico se ha actualizado.


### PR DESCRIPTION
https://trello.com/c/xyOz8k0P/2802-resend-claim-email-warning-not-displaying-when-in-spanish