### PR TITLE
modified work cache manager to use IN clause in SQL queries 

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/manager/WorkCacheManager.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/WorkCacheManager.java
@@ -16,7 +16,9 @@
  */
 package org.orcid.core.manager;
 
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.orcid.persistence.jpa.entities.MinimizedWorkEntity;
 import org.orcid.persistence.jpa.entities.WorkLastModifiedEntity;
@@ -34,8 +36,11 @@ public interface WorkCacheManager {
 
     MinimizedWorkEntity retrieveMinimizedWork(long workId, long workLastModified);
 
+    List<MinimizedWorkEntity> retrieveMinimizedWorkList(Map<Long, Date> workIdsWithLastModified, String orcid);
+
     List<MinimizedWorkEntity> retrieveMinimizedWorks(String orcid, long profileLastModified);
 
     List<MinimizedWorkEntity> retrievePublicMinimizedWorks(String orcid, long profileLastModified);
+
 
 }

--- a/orcid-core/src/main/java/org/orcid/core/manager/WorkCacheManager.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/WorkCacheManager.java
@@ -36,7 +36,7 @@ public interface WorkCacheManager {
 
     MinimizedWorkEntity retrieveMinimizedWork(long workId, long workLastModified);
 
-    List<MinimizedWorkEntity> retrieveMinimizedWorkList(Map<Long, Date> workIdsWithLastModified, String orcid);
+    List<MinimizedWorkEntity> retrieveMinimizedWorkList(Map<Long, Date> workIdsWithLastModified);
 
     List<MinimizedWorkEntity> retrieveMinimizedWorks(String orcid, long profileLastModified);
 

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkCacheManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkCacheManagerImpl.java
@@ -133,7 +133,7 @@ public class WorkCacheManagerImpl implements WorkCacheManager {
      * @return
      */
     @Override
-    public List<MinimizedWorkEntity> retrieveMinimizedWorkList(Map<Long,Date> workIdsWithLastModified, String orcid) {
+    public List<MinimizedWorkEntity> retrieveMinimizedWorkList(Map<Long,Date> workIdsWithLastModified) {
         List<MinimizedWorkEntity> returnList = new ArrayList<MinimizedWorkEntity>();
         List<Long> fetchList = new ArrayList<Long>();
         
@@ -151,7 +151,7 @@ public class WorkCacheManagerImpl implements WorkCacheManager {
             
         //now fetch all the others that are *not* in the cache
         if (fetchList.size()>0){
-            List<MinimizedWorkEntity> refreshedWorks = workDao.getMinimizedWorkEntities(fetchList, orcid);
+            List<MinimizedWorkEntity> refreshedWorks = workDao.getMinimizedWorkEntities(fetchList);
             for (MinimizedWorkEntity mWorkRefreshedFromDB : refreshedWorks){
                 Object key = new WorkCacheKey(mWorkRefreshedFromDB.getId(), releaseName);
                 try {
@@ -181,14 +181,14 @@ public class WorkCacheManagerImpl implements WorkCacheManager {
     public List<MinimizedWorkEntity> retrieveMinimizedWorks(String orcid, long profileLastModified) {
         List<WorkLastModifiedEntity> workLastModifiedList = retrieveWorkLastModifiedList(orcid, profileLastModified);        
         Map<Long, Date> workIdsWithLastModified = workLastModifiedList.stream().collect(Collectors.toMap(WorkLastModifiedEntity::getId, WorkLastModifiedEntity::getLastModified));
-        return this.retrieveMinimizedWorkList(workIdsWithLastModified,orcid);
+        return this.retrieveMinimizedWorkList(workIdsWithLastModified);
     }
 
     @Override
     public List<MinimizedWorkEntity> retrievePublicMinimizedWorks(String orcid, long profileLastModified) {
         List<WorkLastModifiedEntity> workLastModifiedList = retrievePublicWorkLastModifiedList(orcid, profileLastModified);
         Map<Long, Date> workIdsWithLastModified = workLastModifiedList.stream().collect(Collectors.toMap(WorkLastModifiedEntity::getId, WorkLastModifiedEntity::getLastModified));
-        return this.retrieveMinimizedWorkList(workIdsWithLastModified,orcid);
+        return this.retrieveMinimizedWorkList(workIdsWithLastModified);
     }
 
     private MinimizedWorkEntity toMinimizedWork(Element element) {

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkCacheManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkCacheManagerImpl.java
@@ -16,7 +16,11 @@
  */
 package org.orcid.core.manager.impl;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
@@ -121,21 +125,70 @@ public class WorkCacheManagerImpl implements WorkCacheManager {
         }
         return minimizedWorkEntity;
     }
+        
+    
+    /** Fetches a list of minimised works - does this by checking cache and then fetching all misses in one go from the DB.
+     * 
+     * @param workIdsWithLastModified
+     * @return
+     */
+    @Override
+    public List<MinimizedWorkEntity> retrieveMinimizedWorkList(Map<Long,Date> workIdsWithLastModified, String orcid) {
+        List<MinimizedWorkEntity> returnList = new ArrayList<MinimizedWorkEntity>();
+        List<Long> fetchList = new ArrayList<Long>();
+        
+        for (Long workId : workIdsWithLastModified.keySet()){
+            
+            //get works from the cache if we can
+            Object key = new WorkCacheKey(workId, releaseName);
+            MinimizedWorkEntity cachedWork = toMinimizedWork(minimizedWorkCache.get(key));
+            if (cachedWork == null || cachedWork.getLastModified().getTime() < workIdsWithLastModified.get(workId).getTime()) {
+                fetchList.add(workId);
+            }else{
+                returnList.add(cachedWork);
+            }
+        }
+            
+        //now fetch all the others that are *not* in the cache
+        if (fetchList.size()>0){
+            List<MinimizedWorkEntity> refreshedWorks = workDao.getMinimizedWorkEntities(fetchList, orcid);
+            for (MinimizedWorkEntity mWorkRefreshedFromDB : refreshedWorks){
+                Object key = new WorkCacheKey(mWorkRefreshedFromDB.getId(), releaseName);
+                try {
+                    synchronized (lockerMinimizedWork.obtainLock(Long.toString(mWorkRefreshedFromDB.getId()))) {
+                        //check cache again here to prevent race condition since something could have updated while we were fetching from DB 
+                        //(or can we skip because new last modified is always going to be after profile last modified as provided)
+                        MinimizedWorkEntity cachedWork = toMinimizedWork(minimizedWorkCache.get(key));
+                        if (cachedWork == null || cachedWork.getLastModified().getTime() < workIdsWithLastModified.get(mWorkRefreshedFromDB.getId()).getTime()) {
+                            workDao.detach(mWorkRefreshedFromDB);                        
+                            minimizedWorkCache.put(new Element(key, mWorkRefreshedFromDB));
+                            returnList.add(mWorkRefreshedFromDB);
+                        }else{
+                            returnList.add(cachedWork);
+                        }
+                        
+                    }
+                } finally {
+                    publicWorkLastModifiedListLockers.releaseLock(Long.toString(mWorkRefreshedFromDB.getId()));
+                }
+            }
+        }
+
+        return returnList;
+    }
 
     @Override
     public List<MinimizedWorkEntity> retrieveMinimizedWorks(String orcid, long profileLastModified) {
-        List<WorkLastModifiedEntity> workLastModifiedList = retrieveWorkLastModifiedList(orcid, profileLastModified);
-        List<MinimizedWorkEntity> works = workLastModifiedList.stream().map(e -> retrieveMinimizedWork(e.getId(), e.getLastModified().getTime()))
-                .collect(Collectors.toList());
-        return works;
+        List<WorkLastModifiedEntity> workLastModifiedList = retrieveWorkLastModifiedList(orcid, profileLastModified);        
+        Map<Long, Date> workIdsWithLastModified = workLastModifiedList.stream().collect(Collectors.toMap(WorkLastModifiedEntity::getId, WorkLastModifiedEntity::getLastModified));
+        return this.retrieveMinimizedWorkList(workIdsWithLastModified,orcid);
     }
 
     @Override
     public List<MinimizedWorkEntity> retrievePublicMinimizedWorks(String orcid, long profileLastModified) {
         List<WorkLastModifiedEntity> workLastModifiedList = retrievePublicWorkLastModifiedList(orcid, profileLastModified);
-        List<MinimizedWorkEntity> works = workLastModifiedList.stream().map(e -> retrieveMinimizedWork(e.getId(), e.getLastModified().getTime()))
-                .collect(Collectors.toList());
-        return works;
+        Map<Long, Date> workIdsWithLastModified = workLastModifiedList.stream().collect(Collectors.toMap(WorkLastModifiedEntity::getId, WorkLastModifiedEntity::getLastModified));
+        return this.retrieveMinimizedWorkList(workIdsWithLastModified,orcid);
     }
 
     private MinimizedWorkEntity toMinimizedWork(Element element) {

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkEntityCacheManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkEntityCacheManagerImpl.java
@@ -141,7 +141,7 @@ public class WorkEntityCacheManagerImpl implements WorkEntityCacheManager {
             
             //get works from the cache if we can
             Object key = new WorkCacheKey(workId, releaseName);
-            MinimizedWorkEntity cachedWork = toMinimizedWork(minimizedWorkCache.get(key));
+            MinimizedWorkEntity cachedWork = toMinimizedWork(minimizedWorkEntityCache.get(key));
             if (cachedWork == null || cachedWork.getLastModified().getTime() < workIdsWithLastModified.get(workId).getTime()) {
                 fetchList.add(workId);
             }else{
@@ -158,10 +158,10 @@ public class WorkEntityCacheManagerImpl implements WorkEntityCacheManager {
                     synchronized (lockerMinimizedWork.obtainLock(Long.toString(mWorkRefreshedFromDB.getId()))) {
                         //check cache again here to prevent race condition since something could have updated while we were fetching from DB 
                         //(or can we skip because new last modified is always going to be after profile last modified as provided)
-                        MinimizedWorkEntity cachedWork = toMinimizedWork(minimizedWorkCache.get(key));
+                        MinimizedWorkEntity cachedWork = toMinimizedWork(minimizedWorkEntityCache.get(key));
                         if (cachedWork == null || cachedWork.getLastModified().getTime() < workIdsWithLastModified.get(mWorkRefreshedFromDB.getId()).getTime()) {
                             workDao.detach(mWorkRefreshedFromDB);                        
-                            minimizedWorkCache.put(new Element(key, mWorkRefreshedFromDB));
+                            minimizedWorkEntityCache.put(new Element(key, mWorkRefreshedFromDB));
                             returnList.add(mWorkRefreshedFromDB);
                         }else{
                             returnList.add(cachedWork);

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkManagerImpl.java
@@ -185,6 +185,7 @@ public class WorkManagerImpl implements WorkManager {
         
         if (applyAPIValidations) {
             activityValidator.validateWork(work, sourceEntity, true, applyAPIValidations, null);
+            /*
             Date lastModified = profileEntityManager.getLastModified(orcid);
             long lastModifiedTime = (lastModified == null) ? 0 : lastModified.getTime();
             List<MinimizedWorkEntity> works = workCacheManager.retrieveMinimizedWorks(orcid, lastModifiedTime);
@@ -198,7 +199,7 @@ public class WorkManagerImpl implements WorkManager {
                                 sourceEntity);
                     }
                 }
-            }
+            }*/
         } else {
             // validate external ID vocab
             externalIDValidator.validateWorkOrPeerReview(work.getExternalIdentifiers());

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/WorkManagerImpl.java
@@ -185,7 +185,7 @@ public class WorkManagerImpl implements WorkManager {
         
         if (applyAPIValidations) {
             activityValidator.validateWork(work, sourceEntity, true, applyAPIValidations, null);
-            /*
+            
             Date lastModified = profileEntityManager.getLastModified(orcid);
             long lastModifiedTime = (lastModified == null) ? 0 : lastModified.getTime();
             List<MinimizedWorkEntity> works = workEntityCacheManager.retrieveMinimizedWorks(orcid, lastModifiedTime);
@@ -199,7 +199,7 @@ public class WorkManagerImpl implements WorkManager {
                                 sourceEntity);
                     }
                 }
-            }*/
+            }
         } else {
             // validate external ID vocab
             externalIDValidator.validateWorkOrPeerReview(work.getExternalIdentifiers());

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/WorkDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/WorkDao.java
@@ -155,5 +155,5 @@ public interface WorkDao extends GenericDao<WorkEntity, Long> {
     
     boolean increaseDisplayIndexOnAllElements(String orcid);
 
-    List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids, String orcid);
+    List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/WorkDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/WorkDao.java
@@ -17,6 +17,7 @@
 package org.orcid.persistence.dao;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.orcid.jaxb.model.common_rc2.Visibility;
@@ -153,4 +154,6 @@ public interface WorkDao extends GenericDao<WorkEntity, Long> {
     void detach(MinimizedWorkEntity minimizedWorkEntity);
     
     boolean increaseDisplayIndexOnAllElements(String orcid);
+
+    List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids, String orcid);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WorkDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WorkDaoImpl.java
@@ -17,6 +17,7 @@
 package org.orcid.persistence.dao.impl;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -140,6 +141,15 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
                 .createQuery("from MinimizedWorkEntity where id = :id", MinimizedWorkEntity.class);
         query.setParameter("id", id);
         return query.getSingleResult();
+    }
+    
+    @Override
+    public List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids, String orcid) {
+        TypedQuery<MinimizedWorkEntity> query = entityManager
+                .createQuery("SELECT x FROM MinimizedWorkEntity x WHERE x.orcid=:orcid AND x.id IN :ids", MinimizedWorkEntity.class);
+        query.setParameter("orcid", orcid);
+        query.setParameter("ids", ids);
+        return query.getResultList();
     }
     
     @Override

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WorkDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WorkDaoImpl.java
@@ -144,10 +144,9 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
     
     @Override
-    public List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids, String orcid) {
+    public List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids) {
         TypedQuery<MinimizedWorkEntity> query = entityManager
-                .createQuery("SELECT x FROM MinimizedWorkEntity x WHERE x.orcid=:orcid AND x.id IN :ids", MinimizedWorkEntity.class);
-        query.setParameter("orcid", orcid);
+                .createQuery("SELECT x FROM MinimizedWorkEntity x WHERE x.id IN :ids", MinimizedWorkEntity.class);
         query.setParameter("ids", ids);
         return query.getResultList();
     }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WorkDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WorkDaoImpl.java
@@ -32,6 +32,8 @@ import org.orcid.persistence.jpa.entities.WorkLastModifiedEntity;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.google.common.collect.Lists;
+
 public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements WorkDao {
 
     public WorkDaoImpl() {
@@ -145,10 +147,16 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     
     @Override
     public List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids) {
-        TypedQuery<MinimizedWorkEntity> query = entityManager
-                .createQuery("SELECT x FROM MinimizedWorkEntity x WHERE x.id IN :ids", MinimizedWorkEntity.class);
-        query.setParameter("ids", ids);
-        return query.getResultList();
+        //batch up list into sets of 50;
+        List<MinimizedWorkEntity> list = new ArrayList<MinimizedWorkEntity>();
+        for (List<Long> partition : Lists.partition(ids, 50)){
+            TypedQuery<MinimizedWorkEntity> query = entityManager
+                    .createQuery("SELECT x FROM MinimizedWorkEntity x WHERE x.id IN :ids", MinimizedWorkEntity.class);
+            query.setParameter("ids", partition);
+            list.addAll(query.getResultList());            
+        }
+        return list;
+        
     }
     
     @Override


### PR DESCRIPTION
instead of individual queries per workid.  

For 16000 works on my local machine
**new code: 37 first time. 23 second time.
old code: 155 first time. 23 second time.**
(in seconds)


https://trello.com/c/5kco8oIl/2942-improve-performance-of-reads-for-large-sets-of-works-by-workscachemanager