### PR TITLE
first pass at improving grouping speed

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/utils/activities/ActivitiesGroupGenerator.java
+++ b/orcid-core/src/main/java/org/orcid/core/utils/activities/ActivitiesGroupGenerator.java
@@ -17,13 +17,18 @@
 package org.orcid.core.utils.activities;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.orcid.jaxb.model.record_rc2.GroupAble;
 import org.orcid.jaxb.model.record_rc2.GroupableActivity;
 
 public class ActivitiesGroupGenerator {    
 
     private List<ActivitiesGroup> groups = new ArrayList<ActivitiesGroup>();
+    
+    private Map<GroupAble, ActivitiesGroup> lookup = new HashMap<GroupAble, ActivitiesGroup>();
     
     
     public void group(GroupableActivity activity) {
@@ -31,23 +36,35 @@ public class ActivitiesGroupGenerator {
             //If it is the first activity, create a new group for it
             ActivitiesGroup newGroup = new ActivitiesGroup(activity);
             groups.add(newGroup);
+            for (GroupAble g :newGroup.getGroupKeys()){
+                lookup.put(g, newGroup);
+            }
         } else {            
             //If it is not the first activity, check which groups it belongs to
-            List<Integer> belongsTo = new ArrayList<Integer>();
+            List<ActivitiesGroup> belongsTo = new ArrayList<ActivitiesGroup>();
+            ActivitiesGroup thisGroup = new ActivitiesGroup(activity);
+            for (GroupAble g :thisGroup.getGroupKeys()){
+                if (lookup.containsKey(g))
+                    belongsTo.add(lookup.get(g));
+            }
+            /*
             for(int i = 0; i < groups.size(); i++) {
                 ActivitiesGroup group = groups.get(i);
                 if(group.belongsToGroup(activity)) {
                     belongsTo.add(i);
                 }
-            }
+            }*/
             
             //If it doesnt belong to any group, create a new group for it
             if(belongsTo.isEmpty()) {
                 ActivitiesGroup newGroup = new ActivitiesGroup(activity);
                 groups.add(newGroup);
+                for (GroupAble g :newGroup.getGroupKeys()){
+                    lookup.put(g, newGroup);
+                }
             } else {
                 //Get the first group it belongs to
-                ActivitiesGroup firstGroup = groups.get(belongsTo.get(0));
+                ActivitiesGroup firstGroup = belongsTo.get(0);
                 firstGroup.add(activity);
                 
                 //If it belongs to other groups, merge them into the first one
@@ -58,6 +75,9 @@ public class ActivitiesGroupGenerator {
                         //Remove it from the list of groups
                         groups.remove(i);
                     }                        
+                }
+                for (GroupAble g :thisGroup.getGroupKeys()){
+                    lookup.put(g, firstGroup);
                 }
             }
         }

--- a/orcid-core/src/main/java/org/orcid/core/utils/activities/ActivitiesGroupGenerator.java
+++ b/orcid-core/src/main/java/org/orcid/core/utils/activities/ActivitiesGroupGenerator.java
@@ -64,9 +64,9 @@ public class ActivitiesGroupGenerator {
                 if(belongsTo.size() > 1) {
                     for(int i = 1; i < belongsTo.size(); i++){
                         //Merge the group
-                        firstGroup.merge(groups.get(i));
+                        firstGroup.merge(belongsTo.get(i));
                         //Remove it from the list of groups
-                        groups.remove(i);
+                        groups.remove(belongsTo.get(i));
                     }                        
                 }
                 for (GroupAble g :thisGroup.getGroupKeys()){
@@ -74,6 +74,9 @@ public class ActivitiesGroupGenerator {
                 }
             }
         }
+        
+        //TODO: make sure this orders correctly
+        //TODO: look at v1.2 post/put work....
     }
     
     public List<ActivitiesGroup> getGroups() {

--- a/orcid-core/src/main/java/org/orcid/core/utils/activities/ActivitiesGroupGenerator.java
+++ b/orcid-core/src/main/java/org/orcid/core/utils/activities/ActivitiesGroupGenerator.java
@@ -47,13 +47,6 @@ public class ActivitiesGroupGenerator {
                 if (lookup.containsKey(g))
                     belongsTo.add(lookup.get(g));
             }
-            /*
-            for(int i = 0; i < groups.size(); i++) {
-                ActivitiesGroup group = groups.get(i);
-                if(group.belongsToGroup(activity)) {
-                    belongsTo.add(i);
-                }
-            }*/
             
             //If it doesnt belong to any group, create a new group for it
             if(belongsTo.isEmpty()) {


### PR DESCRIPTION
Modifies algorithm to use a lookup rather than recursively iterating lists.  Scales in a more linear fashion and provides massive performance improvements seen with large sets of works.  Small sets will see no improvement. Order of groups is slightly different but contents the same.

https://trello.com/c/xWbVxENG/2949-refactor-the-way-grouping-is-done-to-improve-performance-over-large-groups-of-works#

For a user with 16k works, this change makes the request 90 seconds faster on my dev machine, halving request time with a cold cache and reducing request time to a few seconds with a warm one.
Before cold: 03:14
Before warm: 01:32
After cold: 01:43
After warm: 00:04

Tested against record with:
workA: doi:1
workB: doi:2
workC: no external id
workD: agr:1
workE: doi:1
workF: doi:2, agr:1

And groups correctly into three groups: 
group (doi:1) = A, E
group (no id) = C
group (doi2 + agr:1) = B, D, F




