### PR TITLE
fixed grouping bug in api 2

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/utils/activities/ActivitiesGroupGenerator.java
+++ b/orcid-core/src/main/java/org/orcid/core/utils/activities/ActivitiesGroupGenerator.java
@@ -64,9 +64,11 @@ public class ActivitiesGroupGenerator {
                 if(belongsTo.size() > 1) {
                     for(int i = 1; i < belongsTo.size(); i++){
                         //Merge the group
-                        firstGroup.merge(belongsTo.get(i));
-                        //Remove it from the list of groups
-                        groups.remove(belongsTo.get(i));
+                        if (firstGroup != belongsTo.get(i)){
+                            firstGroup.merge(belongsTo.get(i));
+                            //Remove it from the list of groups
+                            groups.remove(belongsTo.get(i));                            
+                        }
                     }                        
                 }
                 for (GroupAble g :thisGroup.getGroupKeys()){


### PR DESCRIPTION
https://trello.com/c/1jNXSfU7/2972-groups-with-works-that-have-two-matching-identifiers-are-not-returned-in-the-2-0-api