### PR TITLE
Modify log4j

### DIFF
--- a/orcid-api-web/src/main/resources/log4j.xml
+++ b/orcid-api-web/src/main/resources/log4j.xml
@@ -22,7 +22,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
 
 	<appender name="FILE_APPENDER" class="org.apache.log4j.RollingFileAppender">
-		<param name="File" value="./logs/persistence-build.log" />
+		<param name="File" value="./logs/api-web.log" />
 		<param name="Append" value="true" />
 		<layout class="org.apache.log4j.PatternLayout">
 			<param name="ConversionPattern" value="%d %-5p [%t] %C{2} (%F:%L) - %m%n" />
@@ -30,8 +30,9 @@
 	</appender>
 
 	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Threshold" value="INFO"/>
 		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%d %p [%t] %c{1}.%M(%L) | %m%n" />
+			<param name="ConversionPattern" value="API %-5.5p [%-11.11t] %d{HH:mm:ss,SSS} (%F:%L) | %m %n" />
 		</layout>
 	</appender>
 
@@ -48,6 +49,10 @@
 
 	<logger name="org.hibernate">
 		<level value="INFO" />
+	</logger>
+	
+	<logger name="org.hibernate.engine.internal.StatisticalLoggingSessionEventListener">
+		<level value="WARN" />
 	</logger>
 	
 	<logger name="com.mchange.v2">

--- a/orcid-internal-api/src/main/resources/log4j.xml
+++ b/orcid-internal-api/src/main/resources/log4j.xml
@@ -30,8 +30,9 @@
 	</appender>
 
 	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Threshold" value="INFO"/>
 		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%d %p [%t] %c{1}.%M(%L) | %m%n" />
+			<param name="ConversionPattern" value="INT %-5.5p [%-11.11t] %d{HH:mm:ss,SSS} (%F:%L) | %m %n" />
 		</layout>
 	</appender>
 
@@ -42,6 +43,10 @@
 
 	<logger name="org.hibernate">
 		<level value="INFO" />
+	</logger>
+	
+	<logger name="org.hibernate.engine.internal.StatisticalLoggingSessionEventListener">
+		<level value="WARN" />
 	</logger>
 	
 	<logger name="com.mchange.v2">

--- a/orcid-persistence/src/main/resources/log4j.xml
+++ b/orcid-persistence/src/main/resources/log4j.xml
@@ -30,8 +30,9 @@
 	</appender>
 
 	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Threshold" value="INFO"/>
 		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%d %p [%t] %c{1}.%M(%L) | %m%n" />
+			<param name="ConversionPattern" value="PER %-5.5p [%-11.11t] %d{HH:mm:ss,SSS} (%F:%L) | %m %n" />
 		</layout>
 	</appender>
 

--- a/orcid-persistence/src/main/resources/staging-persistence.properties
+++ b/orcid-persistence/src/main/resources/staging-persistence.properties
@@ -30,7 +30,7 @@ org.orcid.persistence.db.class=org.postgresql.Driver
 org.orcid.persistence.db.username=orcid
 org.orcid.persistence.db.password=orcid
 org.orcid.persistence.db.dialect=org.hibernate.dialect.PostgreSQLDialect
-org.orcid.persistence.db.showSql=true
+org.orcid.persistence.db.showSql=false
 org.orcid.persistence.db.generateDdl=false
 org.orcid.persistence.db.hibernateStatistics=true
 #Available data sources are: simpleDataSource (dev and test) and pooledDataSource (production)
@@ -48,7 +48,7 @@ org.orcid.persistence.db.readonly.class=org.postgresql.Driver
 org.orcid.persistence.db.readonly.username=orcidro
 org.orcid.persistence.db.readonly.password=orcidro
 org.orcid.persistence.db.readonly.dialect=org.hibernate.dialect.PostgreSQLDialect
-org.orcid.persistence.db.readonly.showSql=true
+org.orcid.persistence.db.readonly.showSql=false
 org.orcid.persistence.db.readonly.generateDdl=false
 #Available data sources are: simpleDataSource (dev and test) and pooledDataSource (production)
 org.orcid.persistence.db.readonly.dataSource=pooledDataSourceReadOnly

--- a/orcid-pub-web/src/main/resources/log4j.xml
+++ b/orcid-pub-web/src/main/resources/log4j.xml
@@ -22,7 +22,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
 
 	<appender name="FILE_APPENDER" class="org.apache.log4j.RollingFileAppender">
-		<param name="File" value="./logs/persistence-build.log" />
+		<param name="File" value="./logs/pub-web.log" />
 		<param name="Append" value="true" />
 		<layout class="org.apache.log4j.PatternLayout">
 			<param name="ConversionPattern" value="%d %-5p [%t] %C{2} (%F:%L) - %m%n" />
@@ -30,8 +30,9 @@
 	</appender>
 
 	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Threshold" value="INFO"/>
 		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%d %p [%t] %c{1}.%M(%L) | %m%n" />
+			<param name="ConversionPattern" value="PUB %-5.5p [%-11.11t] %d{HH:mm:ss,SSS} (%F:%L) | %m %n" />
 		</layout>
 	</appender>
 
@@ -48,6 +49,10 @@
 
 	<logger name="org.hibernate">
 		<level value="INFO" />
+	</logger>
+	
+	<logger name="org.hibernate.engine.internal.StatisticalLoggingSessionEventListener">
+		<level value="WARN" />
 	</logger>
 	
 	<logger name="com.mchange.v2">

--- a/orcid-solr-web/src/main/resources/log4j.xml
+++ b/orcid-solr-web/src/main/resources/log4j.xml
@@ -22,7 +22,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
 
 	<appender name="FILE_APPENDER" class="org.apache.log4j.RollingFileAppender">
-		<param name="File" value="./logs/persistence-build.log" />
+		<param name="File" value="./logs/solr.log" />
 		<param name="Append" value="true" />
 		<layout class="org.apache.log4j.PatternLayout">
 			<param name="ConversionPattern" value="%d %-5p [%t] %C{2} (%F:%L) - %m%n" />
@@ -30,8 +30,9 @@
 	</appender>
 
 	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Threshold" value="INFO"/>
 		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%d %p [%t] %c{1}.%M(%L) | %m%n" />
+			<param name="ConversionPattern" value="SOL %-5.5p [%-11.11t] %d{HH:mm:ss,SSS} (%F:%L) | %m %n" />
 		</layout>
 	</appender>
 

--- a/orcid-web/src/main/resources/log4j.xml
+++ b/orcid-web/src/main/resources/log4j.xml
@@ -22,7 +22,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
 
 	<appender name="FILE_APPENDER" class="org.apache.log4j.RollingFileAppender">
-		<param name="File" value="./logs/persistence-build.log" />
+		<param name="File" value="./logs/orcid-web.log" />
 		<param name="Append" value="true" />
 		<layout class="org.apache.log4j.PatternLayout">
 			<param name="ConversionPattern" value="%d %-5p [%t] %C{2} (%F:%L) - %m%n" />
@@ -30,8 +30,9 @@
 	</appender>
 
 	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<param name="Threshold" value="INFO"/>
 		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%d %p [%t] %c{1}.%M(%L) | %m%n" />
+			<param name="ConversionPattern" value="WEB %-5.5p [%-11.11t] %d{HH:mm:ss,SSS} (%F:%L) | %m %n" />
 		</layout>
 	</appender>
 
@@ -53,6 +54,10 @@
 
 	<logger name="org.hibernate">
 		<level value="INFO" />
+	</logger>
+	
+	<logger name="org.hibernate.engine.internal.StatisticalLoggingSessionEventListener">
+		<level value="WARN" />
 	</logger>
 	
 	<logger name="com.mchange.v2">


### PR DESCRIPTION
Note: this only affects logging in dev environments

Modifies default appender threshold to INFO
Improves pattern layout for dev use
Prefixes log lines so you know which module produced them
Makes org.hibernate.engine.internal.StatisticalLoggingSessionEventListener less verbose
Sets org.orcid.persistence.db.showSql=false

I can actually see spring config errors when starting the server now!