### PR TITLE
Created session if absent, to ensure saved request is saved.

### DIFF
--- a/orcid-web/src/main/java/org/orcid/frontend/web/filter/OAuthAuthorizeNotSignedInFilter.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/filter/OAuthAuthorizeNotSignedInFilter.java
@@ -55,7 +55,7 @@ public class OAuthAuthorizeNotSignedInFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) req;
         if (OrcidUrlManager.getPathWithoutContextPath(request).equals("/oauth/authorize")) {
             HttpServletResponse response = (HttpServletResponse) res;
-            HttpSession session = request.getSession(false);
+            HttpSession session = request.getSession();
             SecurityContext sci = null;
             if (session != null)
                 sci = (SecurityContext)session.getAttribute("SPRING_SECURITY_CONTEXT");


### PR DESCRIPTION
https://trello.com/c/iq0ezTEF/3030-inst-sign-in-institutional-signin-during-an-oauth-flow-pulls-you-out-of-the-flow