### PR TITLE
Fixing URL

### DIFF
--- a/orcid-web/src/main/resources/freemarker/includes/id_banner.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/id_banner.ftl
@@ -62,7 +62,7 @@
 				 arrowStyle="left: 48px;"	                 	     
 			/>
 			<div style="float: left">
-				<a href="http://support.orcid.org/knowledgebase/articles/124518-orcid-privacy-settings" target="_blank"><i class="glyphicon glyphicon-question-sign" style="width: 14px;"></i></a>
+				<a href="http://support.orcid.org/knowledgebase/articles/142948-names-in-the-orcid-registry" target="_blank"><i class="glyphicon glyphicon-question-sign" style="width: 14px;"></i></a>
 			</div>
 		   <ul class="workspace-section-toolbar">
  				<li class="pull-right">


### PR DESCRIPTION
https://trello.com/c/Bu3EDH9q/3035-help-icon-for-names-no-longer-links-to-help-article