### PR TITLE
added pdb identifier using db only (no modify to enums in v2rc1 or 1.2)

### DIFF
--- a/orcid-core/src/main/resources/i18n/messages_en.properties
+++ b/orcid-core/src/main/resources/i18n/messages_en.properties
@@ -1370,6 +1370,7 @@ org.orcid.jaxb.model.record.WorkExternalIdentifierType.uri=uri\: URI
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.urn=urn\: URN
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.wosuid=wosuid\: Web of Science™ identifier
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.zbl=zbl\: Zentralblatt MATH
+org.orcid.jaxb.model.record.WorkExternalIdentifierType.pdb=pdb\: Protein Data Bank identifier
 org.orcid.jaxb.model.record.WorkType.artistic-performance=Artistic/performance
 org.orcid.jaxb.model.record.WorkType.book=Book
 org.orcid.jaxb.model.record.WorkType.book-chapter=Book chapter

--- a/orcid-core/src/test/java/org/orcid/core/manager/IdentifierTypeManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/IdentifierTypeManagerTest.java
@@ -83,7 +83,7 @@ public class IdentifierTypeManagerTest extends BaseTest{
     @Test
     public void test0FetchEntities(){
         Map<String,IdentifierType> map = idTypeMan.fetchIdentifierTypesByAPITypeName();
-        assertEquals(34, map.size()); //default set is 34 
+        assertEquals(35, map.size()); //default set is 34 
         assertTrue(map.containsKey("other-id"));
         assertEquals("other-id",map.get("other-id").getName());
         assertNotNull(map.get("other-id").getPutCode());        

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/record_rc1/WorkExternalIdentifierType.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/record_rc1/WorkExternalIdentifierType.java
@@ -96,7 +96,7 @@ public enum WorkExternalIdentifierType implements Serializable {
                 return wit;
             }
         }
-        throw new IllegalArgumentException(value);
+        return OTHER_ID;
     }
 
 }

--- a/orcid-persistence/src/main/resources/db-master.xml
+++ b/orcid-persistence/src/main/resources/db-master.xml
@@ -212,4 +212,5 @@
     <include file="/db/updates/change_refresh_token_scope_length_on_unit_tests.xml"/>
     <include file="/db/updates/federated-idp-name.xml" />
     <include file="/db/updates/fix-null-relationship-on-funding-ext-ids.xml" />
+    <include file="/db/updates/identifier-type-pdb.xml" />
 </databaseChangeLog>

--- a/orcid-persistence/src/main/resources/db/updates/identifier-type-pdb.xml
+++ b/orcid-persistence/src/main/resources/db/updates/identifier-type-pdb.xml
@@ -1,0 +1,38 @@
+<!--
+
+    =============================================================================
+
+    ORCID (R) Open Source
+    http://orcid.org
+
+    Copyright (c) 2012-2014 ORCID, Inc.
+    Licensed under an MIT-Style License (MIT)
+    http://orcid.org/open-source-license
+
+    This copyright and license information (including a link to the full license)
+    shall be included in its entirety in all copies or substantial portion of
+    the software.
+
+    =============================================================================
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+            
+    <changeSet id="CREATE-PDB-IDENTIFIER" author="Tom D">
+    	<preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="identifier_type"/>
+                <sqlCheck expectedResult="0">select count(*) from identifier_type where id_name='PDB';</sqlCheck>
+            </and>
+        </preConditions>
+		    <insert tableName="identifier_type">
+			<column name="id" value="34"/>
+            <column name="id_name" value="PDB"/>
+            <column name="id_deprecated" value="false"/>
+            <column name="date_created" valueComputed="now()"/>
+            <column name="last_modified" valueComputed="now()"/>
+        </insert>
+    </changeSet>
+    
+</databaseChangeLog>


### PR DESCRIPTION
Behaviour:
You can add and get PDB ids on works rc2+.
You cannot add on rc1 or below.
If you query on older apis, you get OTHER-ID (checked on rc1 and v1.2).
Internationalisation is handled as before (for now).

bugfix to org/orcid/jaxb/model/record_rc1/WorkExternalIdentifierType.java