### PR TITLE
Changing color of Peer Review detail labels

### DIFF
--- a/orcid-web/src/main/webapp/static/css/orcid.new.css
+++ b/orcid-web/src/main/webapp/static/css/orcid.new.css
@@ -4262,7 +4262,7 @@ ul.id-details li{
 .workspace-title{
 	float: left;
 	display: block;
-	color: #494A4C;
+	color: #939598;
 	font-weight: normal;
 }
 


### PR DESCRIPTION
https://trello.com/c/fyGse6Zn/3076-peer-review-show-details-field-labels-are-black-instead-of-gray