### PR TITLE
Corrected SQL command to ensure orcidro has SELECT permissions on tab…

### DIFF
--- a/DEVSETUP.md
+++ b/DEVSETUP.md
@@ -55,7 +55,7 @@ We'll set up postgres using the default settings in
     
     psql -c "CREATE USER orcidro WITH PASSWORD 'orcidro';"
     psql -c "GRANT CONNECT ON DATABASE orcid to orcidro;"
-    psql -d postgres -c "GRANT SELECT ON ALL TABLES IN SCHEMA public to orcidro;"
+    psql -d orcid -c "GRANT SELECT ON ALL TABLES IN SCHEMA public to orcidro;"
     ```
     
 * Exit postgres user prompt


### PR DESCRIPTION
…les in orcid db, rather than postgres db