### PR TITLE
Public record no longer returned when client uses wrong token to acce…

### DIFF
--- a/orcid-api-web/src/main/java/org/orcid/api/memberV2/server/delegator/impl/MemberV2ApiServiceDelegatorImpl.java
+++ b/orcid-api-web/src/main/java/org/orcid/api/memberV2/server/delegator/impl/MemberV2ApiServiceDelegatorImpl.java
@@ -199,7 +199,7 @@ public class MemberV2ApiServiceDelegatorImpl
         try {
             orcidSecurityManager.checkPermissions(ScopePathType.READ_LIMITED, orcid);
             record = visibilityFilter.filter(recordManager.getRecord(orcid), orcid);             
-        } catch(AccessControlException | OrcidUnauthorizedException e) {
+        } catch(AccessControlException e) {
             //If the user have the READ_PUBLIC scope, return him the list of public activities.
             if(orcidSecurityManager.hasScope(ScopePathType.READ_PUBLIC)) {
                 record = recordManager.getPublicRecord(orcid);                

--- a/orcid-api-web/src/test/java/org/orcid/api/memberV2/server/delegator/MemberV2ApiServiceDelegatorTest.java
+++ b/orcid-api-web/src/test/java/org/orcid/api/memberV2/server/delegator/MemberV2ApiServiceDelegatorTest.java
@@ -3878,6 +3878,20 @@ public class MemberV2ApiServiceDelegatorTest extends DBUnitTest {
         assertEquals("/0000-0000-0000-0003/personal-details", personalDetails.getPath());        
     }        
     
+    @Test(expected = OrcidUnauthorizedException.class)
+    public void testViewRecordWrongToken() {        
+        SecurityContextTestUtils.setUpSecurityContext("some-other-user", ScopePathType.READ_LIMITED);
+        serviceDelegator.viewRecord(ORCID);
+    }
+    
+    @Test
+    public void testViewRecordWrongScope() {        
+        SecurityContextTestUtils.setUpSecurityContext(ORCID, ScopePathType.READ_PUBLIC);
+        Response response = serviceDelegator.viewRecord(ORCID);
+        assertNotNull(response);
+    }
+        
+    
     @Test
     public void testViewRecord() {        
         SecurityContextTestUtils.setUpSecurityContext(ORCID, ScopePathType.READ_LIMITED);


### PR DESCRIPTION
…ss it

Previously returning public record of requested user, now returns 401 unauthorized