### PR TITLE
fixed bibtex export bugs

### DIFF
--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/WorksController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/WorksController.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang3.StringUtils;
 import org.orcid.core.locale.LocaleManager;
@@ -795,7 +796,7 @@ public class WorksController extends BaseWorkspaceController {
         return types;
     }
     
-    @RequestMapping(value = "/works.bib", method = RequestMethod.GET)
+    @RequestMapping(value = "/works.bib", method = RequestMethod.GET, produces = "application/x-bibtex")
     public @ResponseBody String fetchBibtex(){
         return bibtexManager.generateBibtexReferenceList(getEffectiveUserOrcid());        
     }


### PR DESCRIPTION
https://trello.com/c/Ic7ApiD6/3342-bibtex-export-is-it-possible-to-save-files-as-text-bib
- now downloads as works.bib (tested on chrome)

https://trello.com/c/GaWNPsiT/3343-bibtex-export-files-generated-from-orcid-metadata-only-take-doi-identifiers
- now includes ISBN and ISSN

https://trello.com/c/0CgeyPI3/3345-bibtex-export-a-server-error-is-returned-if-crossref-has-a-problem-with-the-doi
- now skips bad dois and uses our metadata to create bibtex