### PR TITLE
fixed identifier API to work on the v2.0 endpoint only.

### DIFF
--- a/orcid-core/src/main/java/org/orcid/pojo/IdentifierType.java
+++ b/orcid-core/src/main/java/org/orcid/pojo/IdentifierType.java
@@ -19,17 +19,23 @@ package org.orcid.pojo;
 import java.io.Serializable;
 import java.util.Date;
 
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
 import org.orcid.persistence.jpa.entities.ClientDetailsEntity;
 
+@XmlRootElement
 public class IdentifierType implements Serializable{
 
     private static final long serialVersionUID = 1L;
+    
     private String name;
     private Long id;
     private String validationRegex;
     private String resolutionPrefix;
     private String description;
-    
     private Date dateCreated;
     private Date lastModified;
     
@@ -55,6 +61,7 @@ public class IdentifierType implements Serializable{
     public String getValidationRegex() {
         return validationRegex;
     }
+    @XmlTransient
     public void setValidationRegex(String validationRegex) {
         this.validationRegex = validationRegex;
     }
@@ -82,6 +89,7 @@ public class IdentifierType implements Serializable{
     public void setLastModified(Date lastModified) {
         this.lastModified = lastModified;
     }
+    @XmlTransient
     public ClientDetailsEntity getSourceClient() {
         return sourceClient;
     }

--- a/orcid-pub-web/src/main/java/org/orcid/api/identifiers/IdentifierApiServiceImplV2_0.java
+++ b/orcid-pub-web/src/main/java/org/orcid/api/identifiers/IdentifierApiServiceImplV2_0.java
@@ -35,8 +35,8 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 
-@Api("Identifier API")
-@Path("/v2.0_rc2" + OrcidApiConstants.IDENTIFIER_PATH)
+@Api("Identifier API v2.0")
+@Path("/v2.0" + OrcidApiConstants.IDENTIFIER_PATH)
 public class IdentifierApiServiceImplV2_0 {
 
     private IdentifierApiServiceDelegator serviceDelegator;

--- a/orcid-pub-web/src/main/java/org/orcid/api/identifiers/delegator/impl/IdentifierApiServiceDelegatorImpl.java
+++ b/orcid-pub-web/src/main/java/org/orcid/api/identifiers/delegator/impl/IdentifierApiServiceDelegatorImpl.java
@@ -16,13 +16,11 @@
  */
 package org.orcid.api.identifiers.delegator.impl;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
 
 import javax.annotation.Resource;
+import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.LocaleUtils;
@@ -32,6 +30,8 @@ import org.orcid.core.manager.IdentifierTypeManager;
 import org.orcid.core.security.visibility.aop.AccessControl;
 import org.orcid.jaxb.model.message.ScopePathType;
 import org.orcid.pojo.IdentifierType;
+
+import com.google.common.collect.Lists;
 
 public class IdentifierApiServiceDelegatorImpl implements IdentifierApiServiceDelegator {
     
@@ -45,7 +45,8 @@ public class IdentifierApiServiceDelegatorImpl implements IdentifierApiServiceDe
     @AccessControl(requiredScope = ScopePathType.READ_PUBLIC, enableAnonymousAccess = true)
     public Response getIdentifierTypes(String locale) {
         Collection<IdentifierType> types = identifierTypeManager.fetchIdentifierTypesByAPITypeName(LocaleUtils.toLocale(locale)).values();
-        return Response.ok(types).build();
+        GenericEntity<List<IdentifierType>> entity = new GenericEntity<List<IdentifierType>>(Lists.newArrayList(types)) {};        
+        return Response.ok(entity).build();
     }
 
 }

--- a/orcid-pub-web/src/test/java/org/orcid/api/identifiers/IdentifierApiServiceDelegatorTest.java
+++ b/orcid-pub-web/src/test/java/org/orcid/api/identifiers/IdentifierApiServiceDelegatorTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Resource;
+import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.Response;
 
 import org.junit.Before;
@@ -59,9 +60,9 @@ public class IdentifierApiServiceDelegatorTest {
         assertEquals(service.viewIdentifierTypes(null).getStatus(), 200);
         Response r = service.viewIdentifierTypes(null);
         @SuppressWarnings("unchecked")
-        Collection<IdentifierType> types = (Collection<IdentifierType>) r.getEntity();
+        GenericEntity<List<IdentifierType>> types = (GenericEntity<List<IdentifierType>>) r.getEntity();
         Boolean found = false;
-        for (IdentifierType t : types){
+        for (IdentifierType t : types.getEntity()){
             if (t.getName().equals("doi")){
                 assertEquals("doi: Digital object identifier",t.getDescription());
                 found = true;
@@ -75,9 +76,9 @@ public class IdentifierApiServiceDelegatorTest {
         assertEquals(service.viewIdentifierTypes("es").getStatus(), 200);
         Response r = service.viewIdentifierTypes("es");
         @SuppressWarnings("unchecked")
-        Collection<IdentifierType> types = (Collection<IdentifierType>) r.getEntity();
+        GenericEntity<List<IdentifierType>> types = (GenericEntity<List<IdentifierType>>) r.getEntity();
         Boolean found = false;
-        for (IdentifierType t : types){
+        for (IdentifierType t : types.getEntity()){
             if (t.getName().equals("doi")){
                 assertEquals("doi: Identificador de objeto digital",t.getDescription());
                 found = true;


### PR DESCRIPTION
Also added default xml content type so list is accessable from the browser
Example: https://localhost:8443/orcid-pub-web/v2.0/identifiers?locale=fr