### PR TITLE
added group-id search to v2.0 and modified error handling

### DIFF
--- a/orcid-api-web/src/main/java/org/orcid/api/memberV2/server/MemberV2ApiServiceImplV2_0.java
+++ b/orcid-api-web/src/main/java/org/orcid/api/memberV2/server/MemberV2ApiServiceImplV2_0.java
@@ -571,7 +571,11 @@ public class MemberV2ApiServiceImplV2_0 extends MemberV2ApiServiceImplHelper {
     @Path(GROUP_ID_RECORD)
     @ApiOperation(value = "Fetch Groups", response = GroupIdRecords.class, authorizations = {
             @Authorization(value = "orcid_auth", scopes = { @AuthorizationScope(scope = ScopeConstants.GROUP_ID_RECORD_READ, description = "you need this") }) })
-    public Response viewGroupIdRecords(@QueryParam("page-size") String pageSize, @QueryParam("page") String page) {
+    public Response viewGroupIdRecords(@QueryParam("page-size") @DefaultValue("100") String pageSize, @QueryParam("page") @DefaultValue("1") String page,
+            @QueryParam("name") String name) {
+        if (name != null) {
+            return serviceDelegator.findGroupIdRecordByName(name);
+        }
         return serviceDelegator.viewGroupIdRecords(pageSize, page);
     }
 

--- a/orcid-api-web/src/main/java/org/orcid/api/memberV2/server/delegator/impl/MemberV2ApiServiceDelegatorImpl.java
+++ b/orcid-api-web/src/main/java/org/orcid/api/memberV2/server/delegator/impl/MemberV2ApiServiceDelegatorImpl.java
@@ -675,7 +675,7 @@ public class MemberV2ApiServiceDelegatorImpl implements
         Optional<GroupIdRecord> record = groupIdRecordManager.findGroupIdRecordByName(name);
         if (record.isPresent())
             return Response.ok(record.get()).build();
-        throw new NotFoundException();
+        return Response.ok(new GroupIdRecord()).build();
     }
 
     /**


### PR DESCRIPTION
curl -i -L -H 'Accept: application/json' -d 'client_id=4444-4444-4444-4445' -d 'client_secret=client-secret' -d 'scope=/group-id-record/update' -d 'grant_type=client_credentials' 'https://localhost:8443/orcid-web/oauth/token' --insecure

curl -i -L -H 'Content-type: application/vnd.orcid+xml' -H 'Authorization: Bearer 679b5c92-a0cb-4308-a71f-dbeadb830dcd' -X GET 'https://localhost:8443/orcid-api-web/v2.0/group-id-record?name=group-id:name' --insecure

curl -i -L -H 'Content-type: application/vnd.orcid+xml' -H 'Authorization: Bearer 679b5c92-a0cb-4308-a71f-dbeadb830dcd' -X GET 'https://localhost:8443/orcid-api-web/v2.0/group-id-record?name=group-id:name-does-not-exist' --insecure

curl -i -L -H 'Content-type: application/vnd.orcid+xml' -H 'Authorization: Bearer 679b5c92-a0cb-4308-a71f-dbeadb830dcd' -X GET 'https://localhost:8443/orcid-api-web/v2.0/group-id-record' --insecure

curl -i -L -H 'Content-type: application/vnd.orcid+xml' -H 'Authorization: Bearer 679b5c92-a0cb-4308-a71f-dbeadb830dcd' -X GET 'https://localhost:8443/orcid-api-web/v2.0/group-id-record?page=1&page-size=2' --insecure

curl -i -L -H 'Content-type: application/vnd.orcid+xml' -H 'Authorization: Bearer 679b5c92-a0cb-4308-a71f-dbeadb830dcd' -X GET 'https://localhost:8443/orcid-api-web/v2.0/group-id-record?page=2&page-size=2' --insecure