### PR TITLE
On groupable activities, display an empty <common:external-ids/> elem…

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/PeerReviewManagerReadOnlyImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/PeerReviewManagerReadOnlyImpl.java
@@ -112,13 +112,18 @@ public class PeerReviewManagerReadOnlyImpl implements PeerReviewManagerReadOnly 
             Set<GroupableActivity> activities = group.getActivities();
             PeerReviewGroup peerReviewGroup = new PeerReviewGroup();
             // Fill the peer review groups with the external identifiers
-            for (GroupAble groupKey : groupKeys) {
-                PeerReviewGroupKey key = (PeerReviewGroupKey) groupKey;
-                ExternalID id = new ExternalID();
-                id.setType(PeerReviewGroupKey.KEY_NAME);//TODO: this is not nice
-                id.setValue(key.getGroupId());
-                peerReviewGroup.getIdentifiers().getExternalIdentifier().add(id);
-            }
+            if(groupKeys == null || groupKeys.isEmpty()) {
+                // Initialize the ids as an empty list
+                peerReviewGroup.getIdentifiers().getExternalIdentifier();
+            } else {
+                for (GroupAble groupKey : groupKeys) {
+                    PeerReviewGroupKey key = (PeerReviewGroupKey) groupKey;
+                    ExternalID id = new ExternalID();
+                    id.setType(PeerReviewGroupKey.KEY_NAME);//TODO: this is not nice
+                    id.setValue(key.getGroupId());
+                    peerReviewGroup.getIdentifiers().getExternalIdentifier().add(id);
+                }
+            }            
 
             // Fill the peer review group with the list of activities
             for (GroupableActivity activity : activities) {

--- a/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/ProfileFundingManagerReadOnlyImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/ProfileFundingManagerReadOnlyImpl.java
@@ -171,10 +171,15 @@ public class ProfileFundingManagerReadOnlyImpl implements ProfileFundingManagerR
             FundingGroup fundingGroup = new FundingGroup();
 
             // Fill the funding groups with the external identifiers
-            for (GroupAble extId : externalIdentifiers) {
-                ExternalID fundingExtId = (ExternalID) extId;
-                fundingGroup.getIdentifiers().getExternalIdentifier().add(fundingExtId.clone());
-            }
+            if(externalIdentifiers == null || externalIdentifiers.isEmpty()) {
+                // Initialize the ids as an empty list
+                fundingGroup.getIdentifiers().getExternalIdentifier();
+            } else {
+                for (GroupAble extId : externalIdentifiers) {
+                    ExternalID fundingExtId = (ExternalID) extId;
+                    fundingGroup.getIdentifiers().getExternalIdentifier().add(fundingExtId.clone());
+                }
+            }            
 
             // Fill the funding group with the list of activities
             for (GroupableActivity activity : activities) {

--- a/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/WorkManagerReadOnlyImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/WorkManagerReadOnlyImpl.java
@@ -163,11 +163,16 @@ public class WorkManagerReadOnlyImpl extends ManagerReadOnlyBaseImpl implements 
             Set<GroupableActivity> activities = group.getActivities();
             WorkGroup workGroup = new WorkGroup();
             // Fill the work groups with the external identifiers
-            for (GroupAble extId : externalIdentifiers) {
-                ExternalID workExtId = (ExternalID) extId;
-                workGroup.getIdentifiers().getExternalIdentifier().add(workExtId.clone());
+            if(externalIdentifiers == null || externalIdentifiers.isEmpty()) {
+                // Initialize the ids as an empty list
+                workGroup.getIdentifiers().getExternalIdentifier();
+            } else {
+                for (GroupAble extId : externalIdentifiers) {
+                    ExternalID workExtId = (ExternalID) extId;
+                    workGroup.getIdentifiers().getExternalIdentifier().add(workExtId.clone());
+                }
             }
-
+            
             // Fill the work group with the list of activities
             for (GroupableActivity activity : activities) {
                 WorkSummary workSummary = (WorkSummary) activity;

--- a/orcid-core/src/test/java/org/orcid/core/manager/WorkManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/WorkManagerTest.java
@@ -44,6 +44,7 @@ import org.orcid.jaxb.model.common_v2.Title;
 import org.orcid.jaxb.model.common_v2.Url;
 import org.orcid.jaxb.model.common_v2.Visibility;
 import org.orcid.jaxb.model.error_v2.OrcidError;
+import org.orcid.jaxb.model.record.summary_v2.WorkGroup;
 import org.orcid.jaxb.model.record.summary_v2.WorkSummary;
 import org.orcid.jaxb.model.record.summary_v2.Works;
 import org.orcid.jaxb.model.record_v2.BulkElement;
@@ -744,6 +745,58 @@ public class WorkManagerTest extends BaseTest {
         fail();
     }
 
+    @Test
+    public void nonGroupableIdsGenerateEmptyIdsListTest() {
+        WorkSummary s1 = getWorkSummary("Element 1", "ext-id-1", Visibility.PUBLIC);
+        WorkSummary s2 = getWorkSummary("Element 2", "ext-id-2", Visibility.LIMITED);
+        WorkSummary s3 = getWorkSummary("Element 3", "ext-id-3", Visibility.PRIVATE);
+        
+        // s1 will be a part of identifier, so, it will go in its own group
+        s1.getExternalIdentifiers().getExternalIdentifier().get(0).setRelationship(Relationship.PART_OF);
+        
+        List<WorkSummary> workList = Arrays.asList(s1, s2, s3);
+        
+        /**
+         * They should be grouped as
+         * 
+         * Group 1: Element 1
+         * Group 2: Element 2
+         * Group 3: Element 3
+         * */
+        Works works = workManager.groupWorks(workList, false);
+        assertNotNull(works);
+        assertEquals(3, works.getWorkGroup().size());
+        boolean foundEmptyGroup = false;
+        boolean found2 = false;
+        boolean found3 = false;
+        for(WorkGroup group : works.getWorkGroup()) {
+            assertEquals(1, group.getWorkSummary().size());
+            assertNotNull(group.getIdentifiers().getExternalIdentifier());
+            if(group.getIdentifiers().getExternalIdentifier().isEmpty()) {
+                assertEquals("Element 1", group.getWorkSummary().get(0).getTitle().getTitle().getContent());
+                assertEquals("ext-id-1", group.getWorkSummary().get(0).getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
+                foundEmptyGroup = true;
+            } else {
+                assertEquals(1, group.getIdentifiers().getExternalIdentifier().size());
+                assertThat(group.getIdentifiers().getExternalIdentifier().get(0).getValue(), anyOf(is("ext-id-2"), is("ext-id-3")));
+                if(group.getIdentifiers().getExternalIdentifier().get(0).getValue().equals("ext-id-2")) {
+                    assertEquals("Element 2", group.getWorkSummary().get(0).getTitle().getTitle().getContent());
+                    assertEquals("ext-id-2", group.getWorkSummary().get(0).getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
+                    found2 = true;
+                } else if(group.getIdentifiers().getExternalIdentifier().get(0).getValue().equals("ext-id-3")) {
+                    assertEquals("Element 3", group.getWorkSummary().get(0).getTitle().getTitle().getContent());
+                    assertEquals("ext-id-3", group.getWorkSummary().get(0).getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
+                    found3 = true;
+                } else {
+                    fail("Invalid ext id found " + group.getIdentifiers().getExternalIdentifier().get(0).getValue());
+                }
+            }
+        }
+        assertTrue(foundEmptyGroup);
+        assertTrue(found2);
+        assertTrue(found3);
+    }
+    
     private WorkSummary getWorkSummary(String titleValue, String extIdValue, Visibility visibility) {
         return getWorkSummary(titleValue, extIdValue, visibility, "0");
     }

--- a/orcid-model/src/main/resources/record_2.0/samples/read_samples/fundings-2.0.xml
+++ b/orcid-model/src/main/resources/record_2.0/samples/read_samples/fundings-2.0.xml
@@ -17,6 +17,42 @@
 	<common:last-modified-date>2017-01-18T15:10:27.247-06:00</common:last-modified-date>
 	<activities:group>
 		<common:last-modified-date>2017-01-18T15:09:59.455-06:00</common:last-modified-date>
+		<common:external-ids />			
+		<funding:summary put-code="2020"
+			path="/8888-8888-8888-8888/funding/2020" visibility="public"
+			display-index="1">
+			<common:created-date>2017-01-18T13:32:28.446-06:00</common:created-date>
+			<common:last-modified-date>2017-01-18T15:09:59.455-06:00</common:last-modified-date>
+			<common:source>
+				<common:source-orcid>
+					<common:uri>http://orcid.org/8888-8888-8888-8888</common:uri>
+					<common:path>8888-8888-8888-8888</common:path>
+					<common:host>orcid.org</common:host>
+				</common:source-orcid>
+				<common:source-name>User One Credit name</common:source-name>
+			</common:source>
+			<funding:title>
+				<common:title>Funding # 1</common:title>
+			</funding:title>
+			<common:external-ids>
+				<common:external-id>
+					<common:external-id-type>grant_number</common:external-id-type>
+					<common:external-id-value>1234</common:external-id-value>
+					<common:external-id-relationship>part-of</common:external-id-relationship>
+				</common:external-id>
+			</common:external-ids>
+			<funding:type>award</funding:type>
+			<funding:organization>
+				<common:name>a</common:name>
+				<common:address>
+					<common:city>a</common:city>
+					<common:country>DZ</common:country>
+				</common:address>
+			</funding:organization>
+		</funding:summary>
+	</activities:group>
+	<activities:group>
+		<common:last-modified-date>2017-01-18T15:09:59.455-06:00</common:last-modified-date>
 		<common:external-ids>
 			<common:external-id>
 				<common:external-id-type>grant_number</common:external-id-type>

--- a/orcid-model/src/main/resources/record_2.0/samples/read_samples/works-2.0.xml
+++ b/orcid-model/src/main/resources/record_2.0/samples/read_samples/works-2.0.xml
@@ -18,6 +18,44 @@
 	<activities:group>
 		<common:last-modified-date>2017-01-18T15:03:56.856-06:00
 		</common:last-modified-date>
+		<common:external-ids />				
+		<work:work-summary put-code="3356"
+			path="/8888-8888-8888-8880/work/3356" visibility="public"
+			display-index="1">
+			<common:created-date>2017-01-18T15:03:56.680-06:00
+			</common:created-date>
+			<common:last-modified-date>2017-01-18T15:03:56.856-06:00
+			</common:last-modified-date>
+			<common:source>
+				<common:source-orcid>
+					<common:uri>http://orcid.org/8888-8888-8888-8880</common:uri>
+					<common:path>8888-8888-8888-8880</common:path>
+					<common:host>orcid.org</common:host>
+				</common:source-orcid>
+				<common:source-name>User One Credit name</common:source-name>
+			</common:source>
+			<work:title>
+				<common:title>Work # 0</common:title>
+			</work:title>			
+			<common:external-ids>
+				<common:external-id>
+					<common:external-id-type>doi</common:external-id-type>
+					<common:external-id-value>123456</common:external-id-value>
+					<common:external-id-url>http://arxiv.org/abs/123456</common:external-id-url>
+					<common:external-id-relationship>part-of</common:external-id-relationship>
+				</common:external-id>
+			</common:external-ids>
+			<work:type>conference-paper</work:type>
+			<common:publication-date>
+				<common:year>2017</common:year>
+				<common:month>02</common:month>
+				<common:day>02</common:day>
+			</common:publication-date>
+		</work:work-summary>
+	</activities:group>
+	<activities:group>
+		<common:last-modified-date>2017-01-18T15:03:56.856-06:00
+		</common:last-modified-date>
 		<common:external-ids>
 			<common:external-id>
 				<common:external-id-type>arxiv</common:external-id-type>

--- a/orcid-model/src/main/resources/record_2.0/samples/read_samples/works-2.0.xml
+++ b/orcid-model/src/main/resources/record_2.0/samples/read_samples/works-2.0.xml
@@ -41,15 +41,15 @@
 				<common:external-id>
 					<common:external-id-type>doi</common:external-id-type>
 					<common:external-id-value>123456</common:external-id-value>
-					<common:external-id-url>http://arxiv.org/abs/123456</common:external-id-url>
+					<common:external-id-url>https://doi.org/123456</common:external-id-url>
 					<common:external-id-relationship>part-of</common:external-id-relationship>
 				</common:external-id>
 			</common:external-ids>
 			<work:type>conference-paper</work:type>
 			<common:publication-date>
 				<common:year>2017</common:year>
-				<common:month>02</common:month>
-				<common:day>02</common:day>
+				<common:month>03</common:month>
+				<common:day>03</common:day>
 			</common:publication-date>
 		</work:work-summary>
 	</activities:group>

--- a/orcid-model/src/test/java/org/orcid/record/ValidateV2SamplesTest.java
+++ b/orcid-model/src/test/java/org/orcid/record/ValidateV2SamplesTest.java
@@ -1035,55 +1035,75 @@ public class ValidateV2SamplesTest {
         assertNotNull(works);
         assertNotNull(works.getLastModifiedDate());
         assertNotNull(works.getLastModifiedDate().getValue());
-        assertEquals(2, works.getWorkGroup().size());
+        assertEquals(3, works.getWorkGroup().size());
+        boolean foundWorkWithNoExtIds = false;
         for(WorkGroup group : works.getWorkGroup()) {
             assertNotNull(group.getLastModifiedDate().getValue());
-            assertEquals(1, group.getIdentifiers().getExternalIdentifier().size());
-            ExternalID extId = group.getIdentifiers().getExternalIdentifier().get(0);
-            if(extId.getType().equals("arxiv")) {                
-                assertEquals(Relationship.SELF, extId.getRelationship());
-                assertEquals("http://arxiv.org/abs/123456", extId.getUrl().getValue());
-                assertEquals("123456", extId.getValue());
-            } else if(extId.getType().equals("bibcode")) {                
-                assertEquals(Relationship.SELF, extId.getRelationship());
-                assertEquals("http://adsabs.harvard.edu/abs/4567", extId.getUrl().getValue());
-                assertEquals("4567", extId.getValue());
-            } else {
-                fail("Invalid ext id type " + extId.getType());
-            }
-            
-            assertEquals(1, group.getWorkSummary().size());
-            WorkSummary summary = group.getWorkSummary().get(0);
-            if(summary.getPutCode().equals(Long.valueOf(3357))) {
+            assertNotNull(group.getIdentifiers().getExternalIdentifier());            
+            if(group.getIdentifiers().getExternalIdentifier().isEmpty()) {
+                WorkSummary summary = group.getWorkSummary().get(0);
                 assertEquals("1", summary.getDisplayIndex());
                 assertEquals(1, summary.getExternalIdentifiers().getExternalIdentifier().size());
-                assertEquals("arxiv", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getType());
-                assertEquals("http://arxiv.org/abs/123456", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getUrl().getValue());
+                assertEquals("doi", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getType());
+                assertEquals("https://doi.org/123456", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getUrl().getValue());
                 assertEquals("123456", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
-                assertEquals("/8888-8888-8888-8880/work/3357", summary.getPath());
-                assertEquals("02", summary.getPublicationDate().getDay().getValue());
-                assertEquals("02", summary.getPublicationDate().getMonth().getValue());
-                assertEquals("2017", summary.getPublicationDate().getYear().getValue());
-                assertEquals("Work # 1", summary.getTitle().getTitle().getContent());
-                assertEquals(WorkType.CONFERENCE_PAPER, summary.getType());
-                assertEquals(Visibility.PUBLIC, summary.getVisibility());                                
-            } else if(summary.getPutCode().equals(Long.valueOf(3358))) {
-                assertEquals("1", summary.getDisplayIndex());
-                assertEquals(1, summary.getExternalIdentifiers().getExternalIdentifier().size());
-                assertEquals("bibcode", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getType());
-                assertEquals("http://adsabs.harvard.edu/abs/4567", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getUrl().getValue());
-                assertEquals("4567", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
-                assertEquals("/8888-8888-8888-8880/work/3358", summary.getPath());
+                assertEquals("/8888-8888-8888-8880/work/3356", summary.getPath());
                 assertEquals("03", summary.getPublicationDate().getDay().getValue());
                 assertEquals("03", summary.getPublicationDate().getMonth().getValue());
                 assertEquals("2017", summary.getPublicationDate().getYear().getValue());
-                assertEquals("Work # 2", summary.getTitle().getTitle().getContent());
-                assertEquals(WorkType.JOURNAL_ARTICLE, summary.getType());
+                assertEquals("Work # 0", summary.getTitle().getTitle().getContent());
+                assertEquals(WorkType.CONFERENCE_PAPER, summary.getType());
                 assertEquals(Visibility.PUBLIC, summary.getVisibility());
+                foundWorkWithNoExtIds = true;
             } else {
-                fail("Invalid put code " + summary.getPutCode());
-            }
-        }                
+                assertEquals(1, group.getIdentifiers().getExternalIdentifier().size());
+                ExternalID extId = group.getIdentifiers().getExternalIdentifier().get(0);
+                if(extId.getType().equals("arxiv")) {                
+                    assertEquals(Relationship.SELF, extId.getRelationship());
+                    assertEquals("http://arxiv.org/abs/123456", extId.getUrl().getValue());
+                    assertEquals("123456", extId.getValue());
+                } else if(extId.getType().equals("bibcode")) {                
+                    assertEquals(Relationship.SELF, extId.getRelationship());
+                    assertEquals("http://adsabs.harvard.edu/abs/4567", extId.getUrl().getValue());
+                    assertEquals("4567", extId.getValue());
+                } else {
+                    fail("Invalid ext id type " + extId.getType());
+                }
+                
+                assertEquals(1, group.getWorkSummary().size());
+                WorkSummary summary = group.getWorkSummary().get(0);
+                if(summary.getPutCode().equals(Long.valueOf(3357))) {
+                    assertEquals("1", summary.getDisplayIndex());
+                    assertEquals(1, summary.getExternalIdentifiers().getExternalIdentifier().size());
+                    assertEquals("arxiv", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getType());
+                    assertEquals("http://arxiv.org/abs/123456", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getUrl().getValue());
+                    assertEquals("123456", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
+                    assertEquals("/8888-8888-8888-8880/work/3357", summary.getPath());
+                    assertEquals("02", summary.getPublicationDate().getDay().getValue());
+                    assertEquals("02", summary.getPublicationDate().getMonth().getValue());
+                    assertEquals("2017", summary.getPublicationDate().getYear().getValue());
+                    assertEquals("Work # 1", summary.getTitle().getTitle().getContent());
+                    assertEquals(WorkType.CONFERENCE_PAPER, summary.getType());
+                    assertEquals(Visibility.PUBLIC, summary.getVisibility());                                
+                } else if(summary.getPutCode().equals(Long.valueOf(3358))) {
+                    assertEquals("1", summary.getDisplayIndex());
+                    assertEquals(1, summary.getExternalIdentifiers().getExternalIdentifier().size());
+                    assertEquals("bibcode", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getType());
+                    assertEquals("http://adsabs.harvard.edu/abs/4567", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getUrl().getValue());
+                    assertEquals("4567", summary.getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
+                    assertEquals("/8888-8888-8888-8880/work/3358", summary.getPath());
+                    assertEquals("03", summary.getPublicationDate().getDay().getValue());
+                    assertEquals("03", summary.getPublicationDate().getMonth().getValue());
+                    assertEquals("2017", summary.getPublicationDate().getYear().getValue());
+                    assertEquals("Work # 2", summary.getTitle().getTitle().getContent());
+                    assertEquals(WorkType.JOURNAL_ARTICLE, summary.getType());
+                    assertEquals(Visibility.PUBLIC, summary.getVisibility());
+                } else {
+                    fail("Invalid put code " + summary.getPutCode());
+                }
+            }                        
+        }       
+        assertTrue(foundWorkWithNoExtIds);
     }
     
     private Object unmarshallFromPath(String path, Class<?> type) throws SAXException, URISyntaxException {


### PR DESCRIPTION
…ent instead of none when the activity have no groupable identifiers