### PR TITLE
Forced load of external id descriptions from server on display of work.

### DIFF
--- a/orcid-web/src/main/webapp/static/javascript/angular_orcid_generated.js
+++ b/orcid-web/src/main/webapp/static/javascript/angular_orcid_generated.js
@@ -10650,9 +10650,25 @@
 	            //caches name->description lookup so we can display the description not the name after selection
 	            $scope.externalIDNamesToDescriptions = [];
 	            $scope.formatExternalIDType = function(model) {
+	                console.log(model);
 	                if (!model)
 	                    return "";
-	                return $scope.externalIDNamesToDescriptions[model].description;
+	                if ($scope.externalIDNamesToDescriptions[model])
+	                    return $scope.externalIDNamesToDescriptions[model].description;
+	                //not loaded any descriptions yet, fetch them
+	                var url = getBaseUri()+'/works/idTypes.json?query='+model;
+	                ajax = $.ajax({
+	                    url: url,
+	                    dataType: 'json',
+	                    cache: true,
+	                    async: false,
+	                  }).done(function(data) {
+	                      for (var key in data) {
+	                          $scope.externalIDNamesToDescriptions[data[key].name] = data[key];
+	                      }
+	                  });   
+	                $scope.externalIDTypeCache[model] = ajax;
+	                return $scope.externalIDNamesToDescriptions[model].description;   
 	              }
 	            //--typeahead end
 	    

--- a/orcid-web/src/main/webapp/static/javascript/angular_orcid_generated.js
+++ b/orcid-web/src/main/webapp/static/javascript/angular_orcid_generated.js
@@ -10650,7 +10650,6 @@
 	            //caches name->description lookup so we can display the description not the name after selection
 	            $scope.externalIDNamesToDescriptions = [];
 	            $scope.formatExternalIDType = function(model) {
-	                console.log(model);
 	                if (!model)
 	                    return "";
 	                if ($scope.externalIDNamesToDescriptions[model])

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/workCtrl.js
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/workCtrl.js
@@ -676,9 +676,25 @@ angular.module('orcidApp').controller(
             //caches name->description lookup so we can display the description not the name after selection
             $scope.externalIDNamesToDescriptions = [];
             $scope.formatExternalIDType = function(model) {
+                console.log(model);
                 if (!model)
                     return "";
-                return $scope.externalIDNamesToDescriptions[model].description;
+                if ($scope.externalIDNamesToDescriptions[model])
+                    return $scope.externalIDNamesToDescriptions[model].description;
+                //not loaded any descriptions yet, fetch them
+                var url = getBaseUri()+'/works/idTypes.json?query='+model;
+                ajax = $.ajax({
+                    url: url,
+                    dataType: 'json',
+                    cache: true,
+                    async: false,
+                  }).done(function(data) {
+                      for (var key in data) {
+                          $scope.externalIDNamesToDescriptions[data[key].name] = data[key];
+                      }
+                  });   
+                $scope.externalIDTypeCache[model] = ajax;
+                return $scope.externalIDNamesToDescriptions[model].description;   
               }
             //--typeahead end
     

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/workCtrl.js
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/workCtrl.js
@@ -676,7 +676,6 @@ angular.module('orcidApp').controller(
             //caches name->description lookup so we can display the description not the name after selection
             $scope.externalIDNamesToDescriptions = [];
             $scope.formatExternalIDType = function(model) {
-                console.log(model);
                 if (!model)
                     return "";
                 if ($scope.externalIDNamesToDescriptions[model])


### PR DESCRIPTION
Seems to be a known bug that typeahead input formatting does not work with promises.  So populating from an existing model fails.  ffs.