### PR TITLE
Fix some lgtm alerts

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/oauth/OrcidOauth2UserAuthentication.java
+++ b/orcid-core/src/main/java/org/orcid/core/oauth/OrcidOauth2UserAuthentication.java
@@ -169,7 +169,7 @@ public class OrcidOauth2UserAuthentication implements Authentication {
             return StringUtils.EMPTY;
         }
         
-        if(Visibility.PUBLIC.value().equals(recordName.getVisibility())) {
+        if(recordName.getVisibility() == Visibility.PUBLIC) {
             if(!PojoUtil.isEmpty(recordName.getCreditName())) {
                 return recordName.getCreditName();
             } else {

--- a/orcid-core/src/main/java/org/orcid/core/salesforce/model/Contact.java
+++ b/orcid-core/src/main/java/org/orcid/core/salesforce/model/Contact.java
@@ -88,7 +88,7 @@ public class Contact implements Serializable {
     }
 
     public boolean isMainContact() {
-        return ContactRoleType.MAIN_CONTACT.equals(role);
+        return ContactRoleType.MAIN_CONTACT.equals(role.getRoleType());
     }
 
     public String getOrcid() {

--- a/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/PeerReviewEntityDisplayIndexComparatorDesc.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/PeerReviewEntityDisplayIndexComparatorDesc.java
@@ -36,7 +36,7 @@ public class PeerReviewEntityDisplayIndexComparatorDesc<T> implements Comparator
     public int compare(PeerReviewEntity o1, PeerReviewEntity o2) {
         Long index = o1.getDisplayIndex();
         Long otherIndex = o2.getDisplayIndex();
-        if (index == otherIndex) return o2.compareTo(o1);
+        if (index == null? otherIndex == null : index.equals(otherIndex)) return o2.compareTo(o1);
         if (index == null) return 1;
         if (otherIndex == null) return -1;
         return otherIndex.compareTo(index);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/ProfileFundingEntityDisplayIndexComparatorDesc.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/ProfileFundingEntityDisplayIndexComparatorDesc.java
@@ -36,7 +36,7 @@ public class ProfileFundingEntityDisplayIndexComparatorDesc<T> implements Compar
     public int compare(ProfileFundingEntity o1, ProfileFundingEntity o2) {
         Long index = o1.getDisplayIndex();
         Long otherIndex = o2.getDisplayIndex();
-        if (index == otherIndex) return o2.compareTo(o1);
+        if (index == null? otherIndex == null : index.equals(otherIndex)) return o2.compareTo(o1);
         if (index == null) return 1;
         if (otherIndex == null) return -1;
         return otherIndex.compareTo(index);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/WorkEntityDisplayIndexComparatorDesc.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/WorkEntityDisplayIndexComparatorDesc.java
@@ -31,7 +31,7 @@ public class WorkEntityDisplayIndexComparatorDesc<T> implements Comparator<WorkE
     public int compare(WorkEntity o1, WorkEntity o2) {
         Long index = o1.getDisplayIndex();
         Long otherIndex = o2.getDisplayIndex();
-        if (index == otherIndex) return o2.compareTo(o1);
+        if (index == null? otherIndex == null : index.equals(otherIndex)) return o2.compareTo(o1);
         if (index == null) return 1;
         if (otherIndex == null) return -1;
         return otherIndex.compareTo(index);


### PR DESCRIPTION
Hi!
Just wanted to quickly fix these alerts flagged up on lgtm.com - I hope it helps.

Some the enums comparison appeared to be wrong and using the '==' and '!=' operators on boxed integers only tests for reference equality, rather than for value equality.

For instance the below triggers if `index` and other `otherIndex` are both null (since `null == null`) or have the same reference but it does not test for equality of the values:
`if (index == otherIndex) return o2.compareTo(o1); `

A total of 252 alerts have been flagged up by lgtm.com:
https://lgtm.com/projects/g/ORCID/ORCID-Source/alerts/

You can enable pull request integration for fully automated PR reviews that will flag these in the future so they don't get past code review :)