### PR TITLE
Adding a custom request matcher for CSRF validation, so, we can bypas…

### DIFF
--- a/orcid-web/src/main/java/org/orcid/frontend/spring/CustomCsrfSecurityRequestMatcher.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/spring/CustomCsrfSecurityRequestMatcher.java
@@ -1,0 +1,43 @@
+/**
+ * =============================================================================
+ *
+ * ORCID (R) Open Source
+ * http://orcid.org
+ *
+ * Copyright (c) 2012-2014 ORCID, Inc.
+ * Licensed under an MIT-Style License (MIT)
+ * http://orcid.org/open-source-license
+ *
+ * This copyright and license information (including a link to the full license)
+ * shall be included in its entirety in all copies or substantial portion of
+ * the software.
+ *
+ * =============================================================================
+ */
+package org.orcid.frontend.spring;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.orcid.core.manager.impl.OrcidUrlManager;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+public class CustomCsrfSecurityRequestMatcher implements RequestMatcher {
+
+    private final String[] pathsToIgnore = { "/userStatus.json" };
+
+    public static Pattern allowedMethods = Pattern.compile("^(GET|TRACE|HEAD|OPTIONS)$");
+
+    @Override
+    public boolean matches(HttpServletRequest request) {
+        if (allowedMethods.matcher(request.getMethod()).matches()) {
+            return false;
+        }
+
+        String path = OrcidUrlManager.getPathWithoutContextPath(request);
+        return !Arrays.stream(pathsToIgnore).filter(s -> path.startsWith(s)).findFirst().isPresent();        
+    }
+
+}

--- a/orcid-web/src/main/resources/orcid-frontend-security.xml
+++ b/orcid-web/src/main/resources/orcid-frontend-security.xml
@@ -244,7 +244,7 @@
 	<sec:http use-expressions="false" access-decision-manager-ref="accessDecisionManager" authentication-manager-ref="authenticationManager" create-session="ifRequired"
 		request-matcher="regex">
 		<sec:access-denied-handler error-page="/signin"/>
-		<sec:csrf token-repository-ref="csrfTokenRepo"/>
+		<sec:csrf token-repository-ref="csrfTokenRepo" request-matcher-ref="customCsrfSecurityRequestMatcher"/>
 		<sec:headers>
 			<sec:frame-options policy="SAMEORIGIN" />
 		</sec:headers>
@@ -461,4 +461,6 @@
         <property name="authenticationEntryPoint" ref="oauthAuthenticationEntryPoint"/>
         <property name="authenticationManager" ref="clientAuthenticationManager"/>
     </bean>        
+    
+    <bean id="customCsrfSecurityRequestMatcher" class="org.orcid.frontend.spring.CustomCsrfSecurityRequestMatcher" />
 </beans>

--- a/orcid-web/src/test/java/org/orcid/frontend/spring/CustomCsrfSecurityRequestMatcherTest.java
+++ b/orcid-web/src/test/java/org/orcid/frontend/spring/CustomCsrfSecurityRequestMatcherTest.java
@@ -1,0 +1,415 @@
+/**
+ * =============================================================================
+ *
+ * ORCID (R) Open Source
+ * http://orcid.org
+ *
+ * Copyright (c) 2012-2014 ORCID, Inc.
+ * Licensed under an MIT-Style License (MIT)
+ * http://orcid.org/open-source-license
+ *
+ * This copyright and license information (including a link to the full license)
+ * shall be included in its entirety in all copies or substantial portion of
+ * the software.
+ *
+ * =============================================================================
+ */
+package org.orcid.frontend.spring;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CustomCsrfSecurityRequestMatcherTest {
+
+    private CustomCsrfSecurityRequestMatcher requestMatcher = new CustomCsrfSecurityRequestMatcher();
+
+    private final String CONTEXT_PATH = "https://test.orcid.org";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(request.getContextPath()).thenReturn("https://test.orcid.org");
+    }
+
+    /**
+     * All HEAD requests will bypass the CSRF check, so, they will return false
+     */
+    @Test
+    public void matches_HEAD_Test() {
+        when(request.getMethod()).thenReturn("HEAD");
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+
+    /**
+     * All OPTIONS requests will bypass the CSRF check, so, they will return
+     * false
+     */
+    @Test
+    public void matches_OPTIONS_Test() {
+        when(request.getMethod()).thenReturn("OPTIONS");
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+
+    /**
+     * All TRACE requests will bypass the CSRF check, so, they will return false
+     */
+    @Test
+    public void matches_TRACE_Test() {
+        when(request.getMethod()).thenReturn("TRACE");
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+
+    /**
+     * All GET requests will bypass the CSRF check, so, they will return false
+     */
+    @Test
+    public void matches_GET_Test() {
+        when(request.getMethod()).thenReturn("GET");
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+
+    /**
+     * All CONNECT requests should be CSRF validated so they return true, but,
+     * the /userStatus.json end point which should bypass the CSRF validation
+     * and hence return false
+     */
+    @Test
+    public void matches_CONNECT_Test() {
+        when(request.getMethod()).thenReturn("CONNECT");
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+
+    /**
+     * All PATCH requests should be CSRF validated so they return true, but,
+     * the /userStatus.json end point which should bypass the CSRF validation
+     * and hence return false
+     */
+    @Test
+    public void matches_PATCH_Test() {
+        when(request.getMethod()).thenReturn("PATCH");
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+
+    /**
+     * All DELETE requests should be CSRF validated so they return true, but,
+     * the /userStatus.json end point which should bypass the CSRF validation
+     * and hence return false
+     */
+    @Test
+    public void matches_DELETE_Test() {
+        when(request.getMethod()).thenReturn("DELETE");
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+
+    /**
+     * All POST requests should be CSRF validated so they return true, but,
+     * the /userStatus.json end point which should bypass the CSRF validation
+     * and hence return false
+     */
+    @Test
+    public void matches_POST_Test() {
+        when(request.getMethod()).thenReturn("POST");
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+
+    /**
+     * All PUT requests should be CSRF validated so they return true, but,
+     * the /userStatus.json end point which should bypass the CSRF validation
+     * and hence return false
+     */
+    @Test
+    public void matches_PUT_Test() {
+        when(request.getMethod()).thenReturn("PUT");
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/signin");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/affiliations/affiliations.json?affiliationIds=xxx1,xxx2,xxx3&_=random_number");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/inbox/notification-alerts.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever");
+        assertTrue(requestMatcher.matches(request));
+
+        // true
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/what_ever/what_ever/what_ever/userStatus.json");
+        assertTrue(requestMatcher.matches(request));
+
+        // false
+        when(request.getRequestURI()).thenReturn(CONTEXT_PATH + "/userStatus.json");
+        assertFalse(requestMatcher.matches(request));
+    }
+}


### PR DESCRIPTION
…s it on the /userStatus.json endpoint