### PR TITLE
added workaround to deal with spring security userinfo requests

### DIFF
--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/OpenIDController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/OpenIDController.java
@@ -76,6 +76,8 @@ public class OpenIDController {
         if (authHeader != null) {
             //lookup token, check it's valid, check scope.
             String tokenValue = authHeader.replace("Bearer", "").trim();
+            //deal with incorrect bearer case in request (I'm looking at you spring security!)
+            tokenValue = authHeader.replace("bearer", "").trim();
             OAuth2AccessToken tok = tokenStore.readAccessToken(tokenValue);
             if (tok != null && !tok.isExpired()){
                 boolean hasScope = false;


### PR DESCRIPTION
Spring boot clients don't work because they send 'bearer' instead of 'Bearer' when requesting /oauth/userinfo.  Already an issue at spring, fixed in spring security 2.1.2, but not yet used by spring boot.

https://github.com/spring-projects/spring-security-oauth/issues/457 