### PR TITLE
Corrected category field for v3 record calls where no category specif…

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/analytics/APIEndpointParser.java
+++ b/orcid-core/src/main/java/org/orcid/core/analytics/APIEndpointParser.java
@@ -29,6 +29,8 @@ public class APIEndpointParser {
     private static final String API_VERSION_REGEX = "v\\d{1,}.*";
 
     private static final String API_VERSION_2X_REGEX = "v2.*";
+    
+    private static final String API_VERSION_3X_REGEX = "v3.*";
 
     private static final String RECORD_CATEGORY = "record";
 
@@ -72,6 +74,9 @@ public class APIEndpointParser {
             category = path.get(categoryIndex).toString();
         } else if (apiVersion != null && apiVersion.matches(API_VERSION_2X_REGEX)) {
             // no category in URL: version 2.x so category is record
+            category = RECORD_CATEGORY;
+        } else if (apiVersion != null && apiVersion.matches(API_VERSION_3X_REGEX)) {
+            // same rule applies for v3
             category = RECORD_CATEGORY;
         } else {
             // no category in URL: version 1.x so category is orcid-bio

--- a/orcid-core/src/test/java/org/orcid/core/analytics/APIEndpointParserTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/analytics/APIEndpointParserTest.java
@@ -80,6 +80,15 @@ public class APIEndpointParserTest {
     }
     
     @Test
+    public void testAPIEndpointParserNoCategoryV3() {
+        ContainerRequest request = getRequest("https://localhost:8443/orcid-api-web/v3.0_dev1/1234-4321-1234-4321");
+        APIEndpointParser parser = new APIEndpointParser(request);
+        assertEquals("v3.0_dev1", parser.getApiVersion());
+        assertEquals("record", parser.getCategory());
+        assertEquals("1234-4321-1234-4321", parser.getOrcidId());
+    }
+    
+    @Test
     public void testAPIEndpointParserNoCategoryV1() {
         ContainerRequest request = getRequest("https://localhost:8443/orcid-api-web/v1.2/1234-4321-1234-4321");
         APIEndpointParser parser = new APIEndpointParser(request);


### PR DESCRIPTION
…ied (ie just orcid id), now behaves as v2