### PR TITLE
Togglz config still uses the V2 OrcidType enum, however, the authenti…

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/togglz/OrcidTogglzConfiguration.java
+++ b/orcid-core/src/main/java/org/orcid/core/togglz/OrcidTogglzConfiguration.java
@@ -20,7 +20,7 @@ import javax.annotation.Resource;
 import javax.sql.DataSource;
 
 import org.orcid.core.oauth.OrcidProfileUserDetails;
-import org.orcid.jaxb.model.common_v2.OrcidType;
+import org.orcid.jaxb.model.v3.dev1.common.OrcidType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;


### PR DESCRIPTION
…cation object contains a V3 OrcidType, so, the validation fails