### PR TITLE
don't show commas in disambiguated org details before empty fields

### DIFF
--- a/orcid-web/src/main/resources/freemarker/includes/affiliate/add_affiliate_inc.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/affiliate/add_affiliate_inc.ftl
@@ -58,7 +58,7 @@
                     <div class="relative" style="font-weight: strong;">
                         <span ng-bind="disambiguatedAffiliation.value"></span> <br />
                         <div>
-                            <span ng-bind="disambiguatedAffiliation.city"></span><span ng-show="disambiguatedAffiliation.region"> (<span ng-bind="disambiguatedAffiliation.region"></span>)</span>, <span ng-bind="disambiguatedAffiliation.orgType"></span>
+                            <span ng-bind="disambiguatedAffiliation.city"></span><span ng-show="disambiguatedAffiliation.region"> (<span ng-bind="disambiguatedAffiliation.region"></span>)</span><span ng-show="disambiguatedAffiliation.orgType">, <span ng-bind="disambiguatedAffiliation.orgType"></span></span>
                         </div>
                     </div>
                 </div>

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/AffiliationCtrl.ts
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/AffiliationCtrl.ts
@@ -175,8 +175,7 @@ export const AffiliationCtrl = angular.module('orcidApp').controller(
                             if(datum.city || datum.region){
                                 forDisplay += ", ";
                             }
-                            forDisplay += datum.region;
-                            forDisplay += ", " + datum.orgType;
+                            forDisplay += datum.orgType;
                         }
                         forDisplay += '</span><hr />';
                         return forDisplay;

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/AffiliationCtrl.ts
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/AffiliationCtrl.ts
@@ -161,11 +161,21 @@ export const AffiliationCtrl = angular.module('orcidApp').controller(
                         var forDisplay =
                             '<span style=\'white-space: nowrap; font-weight: bold;\'>' + datum.value+ '</span>'
                             +'<span style=\'font-size: 80%;\'>'
-                            + ' <br />' + datum.city;
+                            + ' <br />';
+                        if(datum.city){
+                            forDisplay += datum.city;
+                        }
                         if(datum.region){
-                            forDisplay += ", " + datum.region;
+                            if(datum.city){
+                                forDisplay += ", ";
+                            }
+                            forDisplay += datum.region;
                         }
                         if (datum.orgType != null && datum.orgType.trim() != ''){
+                            if(datum.city || datum.region){
+                                forDisplay += ", ";
+                            }
+                            forDisplay += datum.region;
                             forDisplay += ", " + datum.orgType;
                         }
                         forDisplay += '</span><hr />';

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/FundingCtrl.ts
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/FundingCtrl.ts
@@ -160,11 +160,9 @@ export const FundingCtrl = angular.module('orcidApp').controller(
                             if(datum.city || datum.region){
                                 forDisplay += ", ";
                             }
-                            forDisplay += datum.region;
-                            forDisplay += ", " + datum.orgType;
+                            forDisplay += datum.orgType;
                         }
                         forDisplay += '</span><hr />';
-
                         return forDisplay;
                     }
                 });

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/FundingCtrl.ts
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/app/controllers/FundingCtrl.ts
@@ -151,9 +151,16 @@ export const FundingCtrl = angular.module('orcidApp').controller(
                             forDisplay += datum.city;
                         }
                         if(datum.region){
-                            forDisplay += ", " + datum.region;
+                            if(datum.city){
+                                forDisplay += ", ";
+                            }
+                            forDisplay += datum.region;
                         }
                         if (datum.orgType != null && datum.orgType.trim() != ''){
+                            if(datum.city || datum.region){
+                                forDisplay += ", ";
+                            }
+                            forDisplay += datum.region;
                             forDisplay += ", " + datum.orgType;
                         }
                         forDisplay += '</span><hr />';


### PR DESCRIPTION
don't show commas in edit UI disambiguated org details when fields are empty