### PR TITLE
move env configuration to mvn profiles

### DIFF
--- a/orcid-nodejs/pom.xml
+++ b/orcid-nodejs/pom.xml
@@ -6,17 +6,17 @@
         <version>1.1.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <main.basedir>${project.parent.basedir}</main.basedir>
-        <nodejs.workingDirectory>~/git/ORCID-Source/orcid-web/static/javascript/ng1Orcid</nodejs.workingDirectory>
-        <webpackConfig>localhost</webpackConfig>
-    </properties>
     <artifactId>orcid-nodejs</artifactId>
     <name>ORCID - NodeJS</name>
     <description>NodeJS Environment Setup and Webpack Conf</description>
     <dependencies>     
     </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+        <nodejs.workingDirectory>${env.HOME}/git/ORCID-Source/orcid-web/static/javascript/ng1Orcid</nodejs.workingDirectory>
+        <webpackConfig>localhost</webpackConfig>
+    </properties>
     <build>
         <finalName>orcid-nodejs</finalName>
         <plugins>
@@ -55,7 +55,11 @@
                             <arguments>install</arguments>
                         </configuration>
                     </execution>
-                    <!-- keep commented to return terminal control during mvn execution -->
+                    <!-- ensure watch is set to false, or run webpack manually
+                    WORKSPACE=/home/myusername/git/ORCID-Source
+                    cd $WORKSPACE/orcid-web/src/main/webapp/static/javascript/ng1Orcid
+                    $WORKSPACE/orcid-nodejs/target/node/node $WORKSPACE/orcid-web/src/main/webapp/static/javascript/ng1Orcid/node_modules/webpack/bin/webpack.js  - -config $WORKSPACE/orcid-web/src/main/webapp/static/javascript/ng1Orcid/qa.webpack.config.js
+                    -->
                     <execution>
                         <id>webpack build</id>
                         <goals>
@@ -72,7 +76,7 @@
     </build>
     <profiles>
         <profile>
-            <id>env-qa-nodejs</id>
+            <id>qa</id>
             <activation>
                 <property>
                     <name>env</name>
@@ -80,6 +84,34 @@
                 </property>
             </activation>
             <properties>
+                <nodejs.workingDirectory>/home/orcid_tomcat/git/ORCID-Source/orcid-web/src/main/webapp/static/javascript/ng1Orcid</nodejs.workingDirectory>
+                <webpackConfig>qa</webpackConfig>
+            </properties>
+        </profile>
+        <profile>
+            <id>localhost</id>
+            <activation>
+                <property>
+                    <name>env</name>
+                    <value>local-nodejs</value>
+                </property>
+            </activation>
+            <properties>
+                <nodejs.workingDirectory>${env.HOME}/git/ORCID-Source/orcid-web/src/main/webapp/static/javascript/ng1Orcid</nodejs.workingDirectory>
+                <webpackConfig>localhost</webpackConfig>
+            </properties>
+        </profile>
+        <profile>
+            <id>ci</id>
+            <activation>
+                <property>
+                    <name>env</name>
+                    <value>ci-nodejs</value>
+                </property>
+            </activation>
+            <properties>
+                <nodejs.workingDirectory>/home/orcid_tomcat/git/ORCID-Source/orcid-web/src/main/webapp/static/javascript/ng1Orcid</nodejs.workingDirectory>
+                <webpackConfig>ci</webpackConfig>
             </properties>
         </profile>
     </profiles>

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/ci.webpack.config.js
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/ci.webpack.config.js
@@ -27,9 +27,9 @@ module.exports = {
             });
         },
         new webpack.DefinePlugin({
-            'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+            'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
             'process.env':{
-                'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+                'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
             }
         })        
     ],

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/qa.webpack.config.js
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/qa.webpack.config.js
@@ -16,9 +16,9 @@ module.exports = {
     },
     plugins: [
         new webpack.DefinePlugin({
-            'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+            'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
             'process.env':{
-                'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+                'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
             }
         })
     ],

--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/webpack.config.js
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/webpack.config.js
@@ -16,9 +16,9 @@ module.exports = {
     },
     plugins: [
         new webpack.DefinePlugin({
-            'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+            'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
             'process.env':{
-                'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+                'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
             }
         })
     ],
@@ -28,5 +28,4 @@ module.exports = {
         }
     },
     watch: false
-};
-//console.log("CONFIG SET TO " + process.env.NODE_ENV)
+}


### PR DESCRIPTION
simplify maven module usage from

`mvn -f orcid-nodejs/pom.xml -Dnodejs.workingDirectory='${project.parent.basedir}/orcid-web/src/main/webapp/static/javascript/ng1Orcid' -DwebpackConfig=localhost clean install`

to use profiles as next

`mvn -P localhost clean install`

fyi @rcpeters @amontenegro @wjrsimpson @lizkrznarich 