### PR TITLE
fix so that implicit tokens work with the persistence flag & prompt none

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/oauth/OrcidTokenEnhancer.java
+++ b/orcid-core/src/main/java/org/orcid/core/oauth/OrcidTokenEnhancer.java
@@ -103,6 +103,11 @@ public class OrcidTokenEnhancer implements TokenEnhancer {
                             return true;
                         }
                     }
+                } else if (params.get(OrcidOauth2Constants.RESPONSE_TYPE_PARAM) != null 
+                        && params.get(OrcidOauth2Constants.RESPONSE_TYPE_PARAM).contains(OrcidOauth2Constants.IMPLICIT_TOKEN_RESPONSE_TYPE) 
+                        && "true".equals(params.get(OrcidOauth2Constants.GRANT_PERSISTENT_TOKEN))){
+                    //for implicit generation, use the query string parameter.
+                    return true;
                 }
             }
         }

--- a/orcid-core/src/main/java/org/orcid/core/oauth/service/OrcidRandomValueTokenServicesImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/oauth/service/OrcidRandomValueTokenServicesImpl.java
@@ -280,7 +280,7 @@ public class OrcidRandomValueTokenServicesImpl extends DefaultTokenServices impl
         }
         
         for(OAuth2AccessToken token : existingTokens) {
-            if(!token.isExpired() && token.getExpiration().after(java.sql.Timestamp.valueOf(LocalDateTime.now().plusHours(1)))) {
+            if (token.getAdditionalInformation().get("persistent") != null && Boolean.valueOf((token.getAdditionalInformation().get("persistent").toString()))){
                 if(token.getScope().containsAll(scopes) && scopes.containsAll(token.getScope())) {
                     return true;
                 }

--- a/orcid-core/src/main/java/org/orcid/core/oauth/service/OrcidRandomValueTokenServicesImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/oauth/service/OrcidRandomValueTokenServicesImpl.java
@@ -280,7 +280,7 @@ public class OrcidRandomValueTokenServicesImpl extends DefaultTokenServices impl
         }
         
         for(OAuth2AccessToken token : existingTokens) {
-            if (token.getAdditionalInformation().get("persistent") != null && Boolean.valueOf((token.getAdditionalInformation().get("persistent").toString()))){
+            if (token.getAdditionalInformation().get(OrcidOauth2Constants.PERSISTENT) != null && Boolean.valueOf((token.getAdditionalInformation().get("persistent").toString()))){
                 if(token.getScope().containsAll(scopes) && scopes.containsAll(token.getScope())) {
                     return true;
                 }

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/OauthAuthorizeController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/OauthAuthorizeController.java
@@ -153,13 +153,17 @@ public class OauthAuthorizeController extends OauthControllerBase {
 
                 requestParams.put(OrcidOauth2Constants.TOKEN_VERSION, OrcidOauth2Constants.PERSISTENT_TOKEN);
 
-                // Check if the client have persistent tokens enabled
-                if (requestParams.get(OrcidOauth2Constants.GRANT_PERSISTENT_TOKEN) == null){
+                boolean hasPersistent = hasPersistenTokensEnabled(requestInfoForm.getClientId());
+                // Don't let non persistent clients persist
+                if (!hasPersistent && "true".equals(requestParams.get(OrcidOauth2Constants.GRANT_PERSISTENT_TOKEN))){
                     requestParams.put(OrcidOauth2Constants.GRANT_PERSISTENT_TOKEN, "false");
-                    if (hasPersistenTokensEnabled(requestInfoForm.getClientId())) {
-                        // Then check if the client granted the persistent token
+                }
+                //default to client default if not set
+                if (requestParams.get(OrcidOauth2Constants.GRANT_PERSISTENT_TOKEN) == null) {
+                    if (hasPersistent)
                         requestParams.put(OrcidOauth2Constants.GRANT_PERSISTENT_TOKEN, "true");
-                    }                    
+                    else
+                        requestParams.put(OrcidOauth2Constants.GRANT_PERSISTENT_TOKEN, "false");
                 }
 
                 // Session status


### PR DESCRIPTION
Fixes another bug whereby we were checking expiry of tokens instead of persistence flag to see if user had valid permissions for a given client.  THIS IS A CHANGE IN BEHAVIOUR.

Add if clause in OrcidTokenEnhancerisPersistentTokenEnabled to deal with case where request_type contains "token" and grantPersistentToken = true.
Modify OrcidRandomValueTokenServicesImpl.longLifeTokenExist to not care if token is expired. Made it use persistent flag instead.
Move check for prompt=none to after we check to see if a token already exists in OauthAuthorizeController.loginGetHandler