### PR TITLE
added re-usable transient error messages to v3 API 

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/jsonidentifier/converter/JSONWorkExternalIdentifiersConverterV3.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/jsonidentifier/converter/JSONWorkExternalIdentifiersConverterV3.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang.StringUtils;
 import org.orcid.core.adapter.jsonidentifier.JSONUrl;
 import org.orcid.core.adapter.jsonidentifier.JSONWorkExternalIdentifier;
 import org.orcid.core.adapter.jsonidentifier.JSONWorkExternalIdentifiers;
+import org.orcid.core.locale.LocaleManager;
 import org.orcid.core.utils.JsonUtils;
 import org.orcid.core.utils.v3.identifiers.NormalizationService;
 import org.orcid.jaxb.model.message.WorkExternalIdentifierType;
@@ -38,9 +39,11 @@ import ma.glasnost.orika.metadata.Type;
 public class JSONWorkExternalIdentifiersConverterV3 extends BidirectionalConverter<ExternalIDs, String> {
 
     private NormalizationService norm;
+    private LocaleManager localeManager;
     
-    public JSONWorkExternalIdentifiersConverterV3(NormalizationService norm){
+    public JSONWorkExternalIdentifiersConverterV3(NormalizationService norm, LocaleManager localeManager){
         this.norm=norm;
+        this.localeManager=localeManager;
     }
     
     private ExternalIdentifierTypeConverter conv = new ExternalIdentifierTypeConverter();
@@ -86,7 +89,7 @@ public class JSONWorkExternalIdentifiersConverterV3 extends BidirectionalConvert
                 //note, uses API type name.
                 id.setNormalized(new TransientNonEmptyString(norm.normalise(id.getType(), workExternalIdentifier.getWorkExternalIdentifierId().content)));
                 if (StringUtils.isEmpty(id.getNormalized().getValue())){
-                    id.setNormalizedError(new TransientError("E1","error message!"));
+                    id.setNormalizedError(new TransientError(localeManager.resolveMessage("transientError.normalization_failed.code"),localeManager.resolveMessage("transientError.normalization_failed.message",id.getType(),workExternalIdentifier.getWorkExternalIdentifierId().content )));
                 }
             }
             if (workExternalIdentifier.getUrl() != null) {
@@ -94,10 +97,7 @@ public class JSONWorkExternalIdentifiersConverterV3 extends BidirectionalConvert
             }
             if (workExternalIdentifier.getRelationship() != null) {
                 id.setRelationship(Relationship.fromValue(conv.convertFrom(workExternalIdentifier.getRelationship(), null)));
-            }
-            
-            //create normalized value
-            
+            }            
             externalIDs.getExternalIdentifier().add(id);
         }
         return externalIDs;

--- a/orcid-core/src/main/java/org/orcid/core/adapter/jsonidentifier/converter/JSONWorkExternalIdentifiersConverterV3.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/jsonidentifier/converter/JSONWorkExternalIdentifiersConverterV3.java
@@ -17,13 +17,14 @@
 package org.orcid.core.adapter.jsonidentifier.converter;
 
 import org.orcid.core.adapter.jsonidentifier.JSONWorkExternalIdentifier.WorkExternalIdentifierId;
-
+import org.apache.commons.lang.StringUtils;
 import org.orcid.core.adapter.jsonidentifier.JSONUrl;
 import org.orcid.core.adapter.jsonidentifier.JSONWorkExternalIdentifier;
 import org.orcid.core.adapter.jsonidentifier.JSONWorkExternalIdentifiers;
 import org.orcid.core.utils.JsonUtils;
 import org.orcid.core.utils.v3.identifiers.NormalizationService;
 import org.orcid.jaxb.model.message.WorkExternalIdentifierType;
+import org.orcid.jaxb.model.v3.dev1.common.TransientError;
 import org.orcid.jaxb.model.v3.dev1.common.TransientNonEmptyString;
 import org.orcid.jaxb.model.v3.dev1.common.Url;
 import org.orcid.jaxb.model.v3.dev1.record.ExternalID;
@@ -84,6 +85,9 @@ public class JSONWorkExternalIdentifiersConverterV3 extends BidirectionalConvert
                 id.setValue(workExternalIdentifier.getWorkExternalIdentifierId().content);
                 //note, uses API type name.
                 id.setNormalized(new TransientNonEmptyString(norm.normalise(id.getType(), workExternalIdentifier.getWorkExternalIdentifierId().content)));
+                if (StringUtils.isEmpty(id.getNormalized().getValue())){
+                    id.setNormalizedError(new TransientError("E1","error message!"));
+                }
             }
             if (workExternalIdentifier.getUrl() != null) {
                 id.setUrl(new Url(workExternalIdentifier.getUrl().getValue()));

--- a/orcid-core/src/main/java/org/orcid/core/adapter/v3/impl/MapperFacadeFactory.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/v3/impl/MapperFacadeFactory.java
@@ -35,6 +35,7 @@ import org.orcid.core.adapter.jsonidentifier.converter.JSONFundingExternalIdenti
 import org.orcid.core.adapter.jsonidentifier.converter.JSONPeerReviewWorkExternalIdentifierConverterV3;
 import org.orcid.core.adapter.jsonidentifier.converter.JSONWorkExternalIdentifiersConverterV3;
 import org.orcid.core.exception.OrcidValidationException;
+import org.orcid.core.locale.LocaleManager;
 import org.orcid.core.manager.ClientDetailsEntityCacheManager;
 import org.orcid.core.manager.EncryptionManager;
 import org.orcid.core.manager.IdentityProviderManager;
@@ -168,6 +169,9 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     
     @Resource
     private NormalizationService norm;
+    
+    @Resource
+    private LocaleManager localeManager;
     
     @Override
     public MapperFacade getObject() throws Exception {
@@ -425,7 +429,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
         MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
 
         ConverterFactory converterFactory = mapperFactory.getConverterFactory();
-        converterFactory.registerConverter("workExternalIdentifiersConverterId", new JSONWorkExternalIdentifiersConverterV3(norm));
+        converterFactory.registerConverter("workExternalIdentifiersConverterId", new JSONWorkExternalIdentifiersConverterV3(norm,localeManager));
         converterFactory.registerConverter("workContributorsConverterId", new JsonOrikaConverter<WorkContributors>());
         
         ClassMapBuilder<Work, WorkEntity> workClassMap = mapperFactory.classMap(Work.class, WorkEntity.class);
@@ -681,7 +685,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
         MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
 
         ConverterFactory converterFactory = mapperFactory.getConverterFactory();
-        converterFactory.registerConverter("workExternalIdentifiersConverterId", new JSONWorkExternalIdentifiersConverterV3(norm));
+        converterFactory.registerConverter("workExternalIdentifiersConverterId", new JSONWorkExternalIdentifiersConverterV3(norm,localeManager));
         converterFactory.registerConverter("workExternalIdentifierConverterId", new JSONPeerReviewWorkExternalIdentifierConverterV3());
         //do same as work
         

--- a/orcid-core/src/main/resources/i18n/api_en.properties
+++ b/orcid-core/src/main/resources/i18n/api_en.properties
@@ -210,3 +210,6 @@ apiError.validation_lastmodifieddate.exception=Last modified date should not be 
 apiError.validation_invalidmessage.exception=Invalid incoming message: {0}
 apiError.validation_invalidmessage_email.exception=Invalid incoming message: Email {0} belongs to other user
 apiError.validation_too_many_elements_in_bulk.exception=You are allowed to add up to {0} elements per request.
+
+transientError.normalization_failed.code = 8001
+transientError.normalization_failed.message = Cannot normalize identifier value {0}:{1}

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/v3/dev1/common/TransientError.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/v3/dev1/common/TransientError.java
@@ -1,0 +1,109 @@
+/**
+ * =============================================================================
+ *
+ * ORCID (R) Open Source
+ * http://orcid.org
+ *
+ * Copyright (c) 2012-2014 ORCID, Inc.
+ * Licensed under an MIT-Style License (MIT)
+ * http://orcid.org/open-source-license
+ *
+ * This copyright and license information (including a link to the full license)
+ * shall be included in its entirety in all copies or substantial portion of
+ * the software.
+ *
+ * =============================================================================
+ */
+package org.orcid.jaxb.model.v3.dev1.common;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(propOrder = { "errorCode", "errorMessage"})
+public class TransientError implements Serializable {
+    
+    private static final long serialVersionUID = 1L;
+
+    @XmlElement(name = "error-code", namespace = "http://www.orcid.org/ns/common", required = true)
+    private String errorCode;
+    @XmlElement(name = "error-message", namespace = "http://www.orcid.org/ns/common", required = true)
+    private String errorMessage;
+    @XmlAttribute(name = "transient", required = true)
+    private final boolean transientValue = true;
+
+    public TransientError() {
+
+    }
+
+    public TransientError(String code, String message) {
+        setErrorCode(code);
+        setErrorMessage(message);
+    }
+
+    public boolean getTransient() {
+        return transientValue;
+    }
+
+    public void setTransient(boolean value) {
+        // nothing
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String code) {
+        this.errorCode = code;
+    }
+    
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String message) {
+        this.errorMessage = message;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((errorCode == null) ? 0 : errorCode.hashCode());
+        result = prime * result + ((errorMessage == null) ? 0 : errorMessage.hashCode());
+        result = prime * result + (transientValue ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TransientError other = (TransientError) obj;
+        if (errorCode == null) {
+            if (other.errorCode != null)
+                return false;
+        } else if (!errorCode.equals(other.errorCode))
+            return false;
+        if (errorMessage == null) {
+            if (other.errorMessage != null)
+                return false;
+        } else if (!errorMessage.equals(other.errorMessage))
+            return false;
+        if (transientValue != other.transientValue)
+            return false;
+        return true;
+    }
+
+
+}

--- a/orcid-model/src/main/java/org/orcid/jaxb/model/v3/dev1/record/ExternalID.java
+++ b/orcid-model/src/main/java/org/orcid/jaxb/model/v3/dev1/record/ExternalID.java
@@ -24,6 +24,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
 import org.apache.commons.lang.StringUtils;
+import org.orcid.jaxb.model.v3.dev1.common.TransientError;
 import org.orcid.jaxb.model.v3.dev1.common.TransientNonEmptyString;
 import org.orcid.jaxb.model.v3.dev1.common.Url;
 
@@ -33,10 +34,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * New external identifier class
  * 
  * @author tom
- *
+ * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "type", "value", "normalized", "url", "relationship" })
+@XmlType(propOrder = { "type", "value", "normalized", "normalizedError", "url", "relationship" })
 public class ExternalID implements GroupAble, Cloneable, Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -46,6 +47,8 @@ public class ExternalID implements GroupAble, Cloneable, Serializable {
     protected String value;
     @XmlElement(name = "external-id-normalized", namespace = "http://www.orcid.org/ns/common")
     protected TransientNonEmptyString normalized;
+    @XmlElement(name = "external-id-normalized-error", namespace = "http://www.orcid.org/ns/common")
+    protected TransientError normalizedError;    
     @XmlElement(name = "external-id-url", namespace = "http://www.orcid.org/ns/common")
     protected Url url;
     @XmlElement(name = "external-id-relationship", namespace = "http://www.orcid.org/ns/common")
@@ -73,6 +76,14 @@ public class ExternalID implements GroupAble, Cloneable, Serializable {
 
     public void setNormalized(TransientNonEmptyString normalized) {
         this.normalized = normalized;
+    }
+
+    public TransientError getNormalizedError() {
+        return normalizedError;
+    }
+    
+    public void setNormalizedError(TransientError normalizeError) {
+        this.normalizedError = normalizeError;
     }
 
     public Relationship getRelationship() {
@@ -138,6 +149,7 @@ public class ExternalID implements GroupAble, Cloneable, Serializable {
         } else {
             result = prime * result + ((value == null) ? 0 : value.hashCode());
         }
+        //ignore normalizedError for equality checking/hash
         return result;
     }
 
@@ -167,6 +179,7 @@ public class ExternalID implements GroupAble, Cloneable, Serializable {
             } else if (!value.equals(other.value))
                 return false;
         }
+        //ignore normalizedError for equality checking/hash
         return true;
     }
 
@@ -176,6 +189,8 @@ public class ExternalID implements GroupAble, Cloneable, Serializable {
         id.value = this.getValue();
         if (this.getNormalized() != null)
             id.setNormalized(this.getNormalized());
+        if (this.getNormalizedError() != null)
+            id.setNormalizedError(this.getNormalizedError());
         if (this.getUrl() != null)
             id.url = new Url(this.getUrl().getValue());
         if (this.getRelationship() != null)

--- a/orcid-model/src/main/resources/common_3.0_dev1/common-3.0_dev1.xsd
+++ b/orcid-model/src/main/resources/common_3.0_dev1/common-3.0_dev1.xsd
@@ -266,6 +266,24 @@
            </xs:extension>
        </xs:simpleContent>
    </xs:complexType>
+   
+   	<xs:complexType name="transient-error">
+		<xs:annotation>
+			<xs:documentation>An error that populated by ORCID when record is read
+			</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="error-code" type="common:non-empty-string" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="error-message" type="common:non-empty-string" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+		<xs:attribute name="transient" use="required">
+		   <xs:simpleType>
+		   <xs:restriction base="xs:boolean">
+		          <xs:pattern value="true" />
+		   </xs:restriction>
+		   </xs:simpleType>
+		 </xs:attribute>
+   </xs:complexType>
 		
 	<xs:complexType name="amount">
 		<xs:annotation>
@@ -1673,7 +1691,8 @@
 				<xs:sequence>
 					<xs:element name="external-id-type" type="common:non-empty-string" minOccurs="1" maxOccurs="1" />
 					<xs:element name="external-id-value" type="common:non-empty-string" minOccurs="1" maxOccurs="1" />	
-					<xs:element name="external-id-normalized" type="common:transient-non-empty-string" minOccurs="0" maxOccurs="1" />		
+					<xs:element name="external-id-normalized" type="common:transient-non-empty-string" minOccurs="0" maxOccurs="1" />
+					<xs:element name="external-id-normalized-error" type="common:transient-error" minOccurs="0" maxOccurs="1" />		
 					<xs:element name="external-id-url" type="xs:anyURI" minOccurs="0" maxOccurs="1" />
 					<xs:element name="external-id-relationship" minOccurs="0" maxOccurs="1" type="common:relationship-type" />
 				</xs:sequence>


### PR DESCRIPTION
(see TransientError.class).  Examples:

	{
            "external-id-type":"doi",
            "external-id-value":"xxx",
            "external-id-normalized":{
               "value":"",
               "transient":true
            },
            "external-id-normalized-error":{
               "error-code":"E1",
               "error-message":"error message!",
               "transient":true
            },
            "external-id-url":{
               "value":"https://doi.org/xxx"
            },
            "external-id-relationship":"SELF"
         }

        <common:external-id>
            <common:external-id-type>doi</common:external-id-type>
            <common:external-id-value>xxx</common:external-id-value>
            <common:external-id-normalized transient="true"></common:external-id-normalized>
            <common:external-id-normalized-error transient="true">
                <common:error-code>E1</common:error-code>
                <common:error-message>error message!</common:error-message>
            </common:external-id-normalized-error>
            <common:external-id-url>https://doi.org/xxx</common:external-id-url>
            <common:external-id-relationship>self</common:external-id-relationship>
        </common:external-id>