### PR TITLE
Some improvements in the OrcidAccessDeniedHandler

### DIFF
--- a/orcid-web/src/main/webapp/static/javascript/script.js
+++ b/orcid-web/src/main/webapp/static/javascript/script.js
@@ -349,7 +349,7 @@ function checkOrcidLoggedIn() {
                     if (data.loggedIn == false
                             && (basePath.startsWith(baseUrl
                                     + 'my-orcid') || basePath
-                                    .startsWith(baseUrl + 'account'))) {
+                                    .startsWith(baseUrl + 'account') || basePath.startsWith(baseUrl + 'inbox'))) {
                         console.log("loggedOutRedir " + data);
                         window.location.href = baseUrl + "signin";
                     }


### PR DESCRIPTION
Hi @wjrsimpson, @rcpeters,

Please take a quick look at this PR, it changes the behavior for csrf errors that happens while calling userStatus.json, currently we return the 403; with this change we will return 205 (RESET_CONTENT) with {"loggedIn":false} to indicate that that user is no longer active so the user can be redirected to the sign in page.


Thanks  