### PR TITLE
default API filter ignores LOD content types

### DIFF
--- a/orcid-api-common/src/main/java/org/orcid/api/common/filter/DefaultApiVersionFilter.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/filter/DefaultApiVersionFilter.java
@@ -38,29 +38,28 @@ public class DefaultApiVersionFilter extends OncePerRequestFilter {
 
     private static final Pattern VERSION_PATTERN = Pattern.compile("/v(\\d.*?)/");
 
-    private static final List<String> IGNORE_LIST = Arrays.asList("/resources/","/search/","/oauth/token","/experimental_rdf_v1/","/static/");
-    
+    private static final List<String> IGNORE_LIST = Arrays.asList("/resources/", "/search/", "/oauth/token", "/experimental_rdf_v1/", "/static/");
+
     private static final String WEBHOOK_PATH_REGEX = "^/" + OrcidStringUtils.ORCID_STRING + "/webhook/.+";
-    
-    public static final Pattern webhookPattern = Pattern
-            .compile(WEBHOOK_PATH_REGEX);
-    
+
+    public static final Pattern webhookPattern = Pattern.compile(WEBHOOK_PATH_REGEX);
+
     @Resource
     protected OrcidUrlManager orcidUrlManager;
-    
+
     protected Features feature;
-    
+
     public void setFeature(Features f) {
         this.feature = f;
     }
-    
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         String path = httpRequest.getServletPath();
         if (IGNORE_LIST.stream().anyMatch(path::startsWith)) {
             filterChain.doFilter(request, response);
-        } else if(webhookPattern.matcher(path).matches()) {
+        } else if (webhookPattern.matcher(path).matches()) {
             filterChain.doFilter(request, response);
         } else {
             Matcher matcher = VERSION_PATTERN.matcher(path);
@@ -70,16 +69,22 @@ public class DefaultApiVersionFilter extends OncePerRequestFilter {
             }
 
             if (PojoUtil.isEmpty(version)) {
-                if (feature.isActive()) {
-                    String baseUrl = Features.PUB_API_2_0_BY_DEFAULT.equals(feature) ? orcidUrlManager.getPubBaseUrl() : orcidUrlManager.getApiBaseUrl();                
+                if (feature.isActive() && !isLOD(request.getHeader("Accept"))) {
+                    String baseUrl = Features.PUB_API_2_0_BY_DEFAULT.equals(feature) ? orcidUrlManager.getPubBaseUrl() : orcidUrlManager.getApiBaseUrl();
                     String redirectUri = baseUrl + "/v2.0" + path;
                     response.sendRedirect(redirectUri);
                 } else {
                     filterChain.doFilter(request, response);
-                }                                
+                }
             } else {
                 filterChain.doFilter(request, response);
             }
         }
+    }
+
+    private boolean isLOD(String accept) {
+        if (accept == null)
+            return false;
+        return (accept.contains("n3") || accept.contains("rdf") || accept.contains("n-triples") || accept.contains("turtle"));
     }
 }


### PR DESCRIPTION
Now does this:

curl -X GET --header 'Accept: application/rdf+xml' 'https://localhost:8443/orcid-pub-web/0000-0002-2601-8132' --insecure -v

< HTTP/1.1 303 See Other
< Location: https://localhost:8443/orcid-pub-web/experimental_rdf_v1/0000-0002-2601-8132