### PR TITLE
Schema org endpoint

### DIFF
--- a/orcid-api-common/src/main/java/org/orcid/api/common/filter/DefaultApiVersionFilter.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/filter/DefaultApiVersionFilter.java
@@ -54,7 +54,7 @@ public class DefaultApiVersionFilter extends OncePerRequestFilter {
             }
 
             if (PojoUtil.isEmpty(version)) {
-                if (isLOD(request.getHeader("Accept"))) {
+                if (isLODButNotJSONLD(request.getHeader("Accept"))) {
                     String redirectUri = orcidUrlManager.getPubBaseUrl() + OrcidApiConstants.EXPERIMENTAL_RDF_V1 + path;
                     response.sendRedirect(redirectUri);
                 }
@@ -71,9 +71,9 @@ public class DefaultApiVersionFilter extends OncePerRequestFilter {
         }
     }
     
-    private boolean isLOD(String accept) {
+    private boolean isLODButNotJSONLD(String accept) {
         if (accept == null)
             return false;
-        return (accept.contains("n3") || accept.contains("rdf") || accept.contains("n-triples") || accept.contains("turtle") || accept.contains("json-ld"));
+        return (accept.contains("n3") || accept.contains("rdf") || accept.contains("n-triples") || accept.contains("turtle"));
     }
 }

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/rdf/RDFMessageBodyWriterV2.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/rdf/RDFMessageBodyWriterV2.java
@@ -49,7 +49,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 //Record
 @Provider
-@Produces({ APPLICATION_RDFXML, TEXT_TURTLE, TEXT_N3, JSON_LD, N_TRIPLES })
+@Produces({ APPLICATION_RDFXML, TEXT_TURTLE, TEXT_N3, N_TRIPLES })
 public class RDFMessageBodyWriterV2 implements MessageBodyWriter<Record>{
     
     /**

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgDocument.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgDocument.java
@@ -1,0 +1,472 @@
+package org.orcid.api.common.writer.schemaorg;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.jena.ext.com.google.common.collect.Lists;
+import org.apache.jena.ext.com.google.common.collect.Sets;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder({ "context", "type", "id", "mainEntityOfPage", "name", "givenName", "familyName", "alternateName", "address", "alumniOf", "affiliation",
+        "worksAndFunding", "url", "identifier" })
+public class SchemaOrgDocument {
+
+    @JsonProperty("@context")
+    public String context = "http://schema.org";
+    @JsonProperty("@type")
+    public String type = "Person";
+    @JsonProperty("@id")
+    public String id;
+    public List<SchemaOrgExternalID> identifier = Lists.newArrayList();
+    public String mainEntityOfPage;// same as ID;
+    public String name;
+    public String givenName;
+    public String familyName;
+    public List<String> alternateName = Lists.newArrayList();
+    public List<SchemaOrgAddress> address = Lists.newArrayList();
+    public Set<SchemaOrgAffiliation> alumniOf = Sets.newLinkedHashSet();
+    public Set<SchemaOrgAffiliation> affiliation = Sets.newLinkedHashSet(); // non-education
+    public List<String> url = Lists.newArrayList(); // webpages
+    @JsonProperty("@reverse")
+    public SchemaOrgReverse worksAndFunding = new SchemaOrgReverse();
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((address == null) ? 0 : address.hashCode());
+        result = prime * result + ((affiliation == null) ? 0 : affiliation.hashCode());
+        result = prime * result + ((alternateName == null) ? 0 : alternateName.hashCode());
+        result = prime * result + ((alumniOf == null) ? 0 : alumniOf.hashCode());
+        result = prime * result + ((context == null) ? 0 : context.hashCode());
+        result = prime * result + ((familyName == null) ? 0 : familyName.hashCode());
+        result = prime * result + ((givenName == null) ? 0 : givenName.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((identifier == null) ? 0 : identifier.hashCode());
+        result = prime * result + ((mainEntityOfPage == null) ? 0 : mainEntityOfPage.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((url == null) ? 0 : url.hashCode());
+        result = prime * result + ((worksAndFunding == null) ? 0 : worksAndFunding.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SchemaOrgDocument other = (SchemaOrgDocument) obj;
+        if (address == null) {
+            if (other.address != null)
+                return false;
+        } else if (!address.equals(other.address))
+            return false;
+        if (affiliation == null) {
+            if (other.affiliation != null)
+                return false;
+        } else if (!affiliation.equals(other.affiliation))
+            return false;
+        if (alternateName == null) {
+            if (other.alternateName != null)
+                return false;
+        } else if (!alternateName.equals(other.alternateName))
+            return false;
+        if (alumniOf == null) {
+            if (other.alumniOf != null)
+                return false;
+        } else if (!alumniOf.equals(other.alumniOf))
+            return false;
+        if (context == null) {
+            if (other.context != null)
+                return false;
+        } else if (!context.equals(other.context))
+            return false;
+        if (familyName == null) {
+            if (other.familyName != null)
+                return false;
+        } else if (!familyName.equals(other.familyName))
+            return false;
+        if (givenName == null) {
+            if (other.givenName != null)
+                return false;
+        } else if (!givenName.equals(other.givenName))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (identifier == null) {
+            if (other.identifier != null)
+                return false;
+        } else if (!identifier.equals(other.identifier))
+            return false;
+        if (mainEntityOfPage == null) {
+            if (other.mainEntityOfPage != null)
+                return false;
+        } else if (!mainEntityOfPage.equals(other.mainEntityOfPage))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        if (url == null) {
+            if (other.url != null)
+                return false;
+        } else if (!url.equals(other.url))
+            return false;
+        if (worksAndFunding == null) {
+            if (other.worksAndFunding != null)
+                return false;
+        } else if (!worksAndFunding.equals(other.worksAndFunding))
+            return false;
+        return true;
+    }
+
+    /** Address contains a simple country code
+     * 
+     * @author tom
+     *
+     */
+    public static class SchemaOrgAddress {
+        @JsonProperty("@type")
+        public String type = "PostalAddress";
+        public String addressCountry;
+
+        public SchemaOrgAddress() {
+        }
+
+        public SchemaOrgAddress(String countryCode) {
+            this.addressCountry = countryCode;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((addressCountry == null) ? 0 : addressCountry.hashCode());
+            result = prime * result + ((type == null) ? 0 : type.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            SchemaOrgAddress other = (SchemaOrgAddress) obj;
+            if (addressCountry == null) {
+                if (other.addressCountry != null)
+                    return false;
+            } else if (!addressCountry.equals(other.addressCountry))
+                return false;
+            if (type == null) {
+                if (other.type != null)
+                    return false;
+            } else if (!type.equals(other.type))
+                return false;
+            return true;
+        }
+        
+    }
+
+    /** Container for reverse properties (created, funded)
+     * 
+     * @author tom
+     *
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyOrder({ "funder", "creator" })
+    public static class SchemaOrgReverse {
+        public List<SchemaOrgWork> creator = Lists.newArrayList();
+        public List<SchemaOrgAffiliation> funder = Lists.newArrayList();
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((creator == null) ? 0 : creator.hashCode());
+            result = prime * result + ((funder == null) ? 0 : funder.hashCode());
+            return result;
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            SchemaOrgReverse other = (SchemaOrgReverse) obj;
+            if (creator == null) {
+                if (other.creator != null)
+                    return false;
+            } else if (!creator.equals(other.creator))
+                return false;
+            if (funder == null) {
+                if (other.funder != null)
+                    return false;
+            } else if (!funder.equals(other.funder))
+                return false;
+            return true;
+        }
+        
+    }
+
+    /** A Work.  Three different places to put identifiers:
+     * - '@id' a doi URL if available
+     * - 'sameAs' other URL identifiers
+     * - 'identifiers' non-url identifiers (including non-url forms of sameAs/DOI
+     * 
+     * @author tom
+     *
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyOrder({ "type", "id", "name", "identifier" })
+    public static class SchemaOrgWork {
+        @JsonProperty("@type")
+        public String type = "CreativeWork"; // or dataset etc...
+        @JsonProperty("@id")
+        public String id;// the doi if available
+        public String name;
+        public Set<SchemaOrgExternalID> identifier;
+        public Set<String> sameAs; // for id urls
+
+        public SchemaOrgWork() {
+            identifier = Sets.newLinkedHashSet();
+            sameAs = Sets.newLinkedHashSet();
+        }
+
+        public SchemaOrgWork(String id, String name, Set<String> sameAs, SchemaOrgExternalID... identifier) {
+            super();
+            this.id = id;
+            this.name = name;
+            this.identifier = Sets.newLinkedHashSet(Lists.newArrayList(identifier));
+            this.sameAs = sameAs;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((id == null) ? 0 : id.hashCode());
+            result = prime * result + ((identifier == null) ? 0 : identifier.hashCode());
+            result = prime * result + ((name == null) ? 0 : name.hashCode());
+            result = prime * result + ((sameAs == null) ? 0 : sameAs.hashCode());
+            result = prime * result + ((type == null) ? 0 : type.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            SchemaOrgWork other = (SchemaOrgWork) obj;
+            if (id == null) {
+                if (other.id != null)
+                    return false;
+            } else if (!id.equals(other.id))
+                return false;
+            if (identifier == null) {
+                if (other.identifier != null)
+                    return false;
+            } else if (!identifier.equals(other.identifier))
+                return false;
+            if (name == null) {
+                if (other.name != null)
+                    return false;
+            } else if (!name.equals(other.name))
+                return false;
+            if (sameAs == null) {
+                if (other.sameAs != null)
+                    return false;
+            } else if (!sameAs.equals(other.sameAs))
+                return false;
+            if (type == null) {
+                if (other.type != null)
+                    return false;
+            } else if (!type.equals(other.type))
+                return false;
+            return true;
+        }
+        
+    }
+
+    /** An affiliation (link to an org)
+     * - '@id' a lei/grid/fundref URL if available
+     * - 'sameAs' other URL identifiers
+     * - 'identifiers' non-url identifiers (ringgold)
+     * 
+     * @author tom
+     *
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyOrder({ "type", "id", "leiCode", "name", "alternateName", "identifier" })
+    public static class SchemaOrgAffiliation {
+        @JsonProperty("@type")
+        public final String type = "Organization";
+        @JsonProperty("@id")
+        public String id;// the grid/lei/fundref if available
+        public String name; // the org
+        public String alternateName; // the specific grant/job/degree
+        public Set<SchemaOrgExternalID> identifier = Sets.newLinkedHashSet();
+        public String leiCode;
+        public Set<String> sameAs = Sets.newLinkedHashSet(); // id are urls
+
+        public SchemaOrgAffiliation() {
+        }
+
+        public SchemaOrgAffiliation(String resolvableID, String name, String alternateName, String leiCode, SchemaOrgExternalID... otherIdentifiers) {
+            this.id = resolvableID;
+            this.leiCode = leiCode;
+            this.name = name;
+            this.alternateName = alternateName;
+            for (SchemaOrgExternalID id : otherIdentifiers) {
+                if (id.value.startsWith("http"))
+                    sameAs.add(id.value);
+                else
+                    this.identifier.add(id);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((alternateName == null) ? 0 : alternateName.hashCode());
+            result = prime * result + ((id == null) ? 0 : id.hashCode());
+            result = prime * result + ((identifier == null) ? 0 : identifier.hashCode());
+            result = prime * result + ((leiCode == null) ? 0 : leiCode.hashCode());
+            result = prime * result + ((name == null) ? 0 : name.hashCode());
+            result = prime * result + ((sameAs == null) ? 0 : sameAs.hashCode());
+            result = prime * result + ((type == null) ? 0 : type.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            SchemaOrgAffiliation other = (SchemaOrgAffiliation) obj;
+            if (alternateName == null) {
+                if (other.alternateName != null)
+                    return false;
+            } else if (!alternateName.equals(other.alternateName))
+                return false;
+            if (id == null) {
+                if (other.id != null)
+                    return false;
+            } else if (!id.equals(other.id))
+                return false;
+            if (identifier == null) {
+                if (other.identifier != null)
+                    return false;
+            } else if (!identifier.equals(other.identifier))
+                return false;
+            if (leiCode == null) {
+                if (other.leiCode != null)
+                    return false;
+            } else if (!leiCode.equals(other.leiCode))
+                return false;
+            if (name == null) {
+                if (other.name != null)
+                    return false;
+            } else if (!name.equals(other.name))
+                return false;
+            if (sameAs == null) {
+                if (other.sameAs != null)
+                    return false;
+            } else if (!sameAs.equals(other.sameAs))
+                return false;
+            if (type == null) {
+                if (other.type != null)
+                    return false;
+            } else if (!type.equals(other.type))
+                return false;
+            return true;
+        }
+
+    }
+
+    /** An ID (non-url)
+     * 
+     * @author tom
+     *
+     */
+    @JsonPropertyOrder({ "type", "propertyID", "value" })
+    public static class SchemaOrgExternalID {
+        @JsonProperty("@type")
+        public final String type = "PropertyValue";
+        public String propertyID;
+        public String value;
+
+        public SchemaOrgExternalID() {
+        }
+
+        public SchemaOrgExternalID(String propertyID, String value) {
+            this.propertyID = propertyID;
+            this.value = value;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((propertyID == null) ? 0 : propertyID.hashCode());
+            result = prime * result + ((type == null) ? 0 : type.hashCode());
+            result = prime * result + ((value == null) ? 0 : value.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            SchemaOrgExternalID other = (SchemaOrgExternalID) obj;
+            if (propertyID == null) {
+                if (other.propertyID != null)
+                    return false;
+            } else if (!propertyID.equals(other.propertyID))
+                return false;
+            if (type == null) {
+                if (other.type != null)
+                    return false;
+            } else if (!type.equals(other.type))
+                return false;
+            if (value == null) {
+                if (other.value != null)
+                    return false;
+            } else if (!value.equals(other.value))
+                return false;
+            return true;
+        }
+    }
+}

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV2.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV2.java
@@ -164,17 +164,20 @@ public class SchemaOrgMBWriterV2 implements MessageBodyWriter<Record> {
 
                     if (wg.getIdentifiers() != null && wg.getIdentifiers().getExternalIdentifier() != null)
                         for (ExternalID id : wg.getIdentifiers().getExternalIdentifier()) {
-                            // add all ids (inc doi non-url if available)
-                            sw.identifier.add(new SchemaOrgExternalID(id.getType(), norm.normalise(id.getType(), id.getValue())));
-                            // sameAs for id URLs.
-                            String url = norm.generateNormalisedURL(id.getType(), id.getValue());
-                            if (StringUtils.isEmpty(url) && id.getUrl() != null)
-                                url = id.getUrl().getValue();                            
-                            //add first DOI as @id
-                            if (id.getType().equals("doi") && !StringUtils.isEmpty(url) && sw.id == null)
-                                sw.id = url;
-                            else if (!StringUtils.isEmpty(url))
-                                sw.sameAs.add(url);
+                            String normed = norm.normalise(id.getType(), id.getValue());
+                            if (!StringUtils.isEmpty(normed)){
+                                // add all ids (inc doi non-url if available)
+                                sw.identifier.add(new SchemaOrgExternalID(id.getType(), normed));
+                                // sameAs for id URLs.
+                                String url = norm.generateNormalisedURL(id.getType(), id.getValue());
+                                if (StringUtils.isEmpty(url) && id.getUrl() != null)
+                                    url = id.getUrl().getValue();
+                                //add first DOI as @id
+                                if (id.getType().equals("doi") && !StringUtils.isEmpty(url) && sw.id == null)
+                                    sw.id = url;
+                                else if (!StringUtils.isEmpty(url))
+                                    sw.sameAs.add(url);
+                            }
                         }
                     doc.worksAndFunding.creator.add(sw);
                 }

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV2.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV2.java
@@ -1,0 +1,230 @@
+package org.orcid.api.common.writer.schemaorg;
+
+import static org.orcid.core.api.OrcidApiConstants.JSON_LD;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.commons.lang3.StringUtils;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgAddress;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgAffiliation;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgExternalID;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgWork;
+import org.orcid.core.utils.v3.identifiers.NormalizationService;
+import org.orcid.jaxb.model.common_v2.DisambiguatedOrganizationExternalIdentifier;
+import org.orcid.jaxb.model.record.summary_v2.EducationSummary;
+import org.orcid.jaxb.model.record.summary_v2.EmploymentSummary;
+import org.orcid.jaxb.model.record.summary_v2.FundingGroup;
+import org.orcid.jaxb.model.record.summary_v2.WorkGroup;
+import org.orcid.jaxb.model.record_v2.Address;
+import org.orcid.jaxb.model.record_v2.ExternalID;
+import org.orcid.jaxb.model.record_v2.OtherName;
+import org.orcid.jaxb.model.record_v2.PersonExternalIdentifier;
+import org.orcid.jaxb.model.record_v2.Record;
+import org.orcid.jaxb.model.record_v2.ResearcherUrl;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+@Provider
+@Produces({ JSON_LD })
+@Component
+public class SchemaOrgMBWriterV2 implements MessageBodyWriter<Record> {
+
+    @Resource
+    NormalizationService norm;
+
+    private ObjectMapper objectMapper;
+
+    public SchemaOrgMBWriterV2() {
+        objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED, true);
+        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return Record.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public long getSize(Record t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return -1;
+    }
+
+    /** Converts a v2Record into a SchemaOrgDocument 
+     * requires lots of tedious null checking but logic is simple.
+     * For works, 
+     * - uses DOI for '@id' if available.  
+     * - Puts all ExternalIDs into 'identifiers', normalizing if possible.
+     * - Puts all ExternalID urls into 'sameAs', normalizing if possible.
+     * For Orgs
+     * - Uses first found LEI, GRID or Fundref for '@id'
+     * - Puts other LEI, GRID or Fundref URLs into 'sameAs'
+     * - Puts RINGGOLD into 'identifiers'.
+     * 
+     */
+    @Override
+    public void writeTo(Record r, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+            OutputStream entityStream) throws IOException, WebApplicationException {
+
+        SchemaOrgDocument doc = new SchemaOrgDocument();
+        doc.id = r.getOrcidIdentifier().getUri();
+        doc.mainEntityOfPage = doc.id;
+
+        // names
+        if (r.getPerson().getName() != null) {
+            if (r.getPerson().getName().getCreditName() != null)
+                doc.name = r.getPerson().getName().getCreditName().getContent();
+            if (r.getPerson().getName().getGivenNames() != null)
+                doc.givenName = r.getPerson().getName().getGivenNames().getContent();
+            if (r.getPerson().getName().getFamilyName() != null)
+                doc.familyName = r.getPerson().getName().getFamilyName().getContent();
+        }
+
+        if (r.getPerson().getOtherNames() != null && r.getPerson().getOtherNames().getOtherNames() != null)
+            for (OtherName n : r.getPerson().getOtherNames().getOtherNames()) {
+                doc.alternateName.add(n.getContent());
+            }
+
+        // country
+        if (r.getPerson().getAddresses() != null && r.getPerson().getAddresses().getAddress() != null)
+            for (Address a : r.getPerson().getAddresses().getAddress()) {
+                doc.address.add(new SchemaOrgAddress(a.getCountry().toString()));
+            }
+
+        // activities
+        if (r.getActivitiesSummary() != null) {
+
+            //educations
+            if (r.getActivitiesSummary().getEducations() != null && r.getActivitiesSummary().getEducations().getSummaries() != null)
+                for (EducationSummary e : r.getActivitiesSummary().getEducations().getSummaries()) {
+                    if (e.getOrganization() != null && e.getOrganization().getDisambiguatedOrganization() != null)
+                        doc.alumniOf.add(createOrg(
+                                e.getOrganization().getName(), 
+                                e.getDepartmentName(),
+                                e.getOrganization().getDisambiguatedOrganization().getDisambiguationSource(),
+                                e.getOrganization().getDisambiguatedOrganization().getDisambiguatedOrganizationIdentifier(),
+                                e.getOrganization().getDisambiguatedOrganization().getExternalIdentifiers()
+                                ));
+                }
+
+            //empoyments
+            if (r.getActivitiesSummary().getEmployments() != null && r.getActivitiesSummary().getEmployments().getSummaries() != null)
+                for (EmploymentSummary e : r.getActivitiesSummary().getEmployments().getSummaries()) {
+                    if (e.getOrganization() != null && e.getOrganization().getDisambiguatedOrganization() != null)
+                        doc.affiliation.add(createOrg(
+                                e.getOrganization().getName(), 
+                                e.getDepartmentName(),
+                                e.getOrganization().getDisambiguatedOrganization().getDisambiguationSource(),
+                                e.getOrganization().getDisambiguatedOrganization().getDisambiguatedOrganizationIdentifier(),
+                                e.getOrganization().getDisambiguatedOrganization().getExternalIdentifiers()
+                                ));
+                }
+
+            //funding
+            if (r.getActivitiesSummary().getFundings() != null && r.getActivitiesSummary().getFundings().getFundingGroup() != null)
+                for (FundingGroup e : r.getActivitiesSummary().getFundings().getFundingGroup()) {
+                    // funding includes org ids and grant_ids
+                    if (e.getFundingSummary().get(0) != null && e.getFundingSummary().get(0).getOrganization() != null
+                            && e.getFundingSummary().get(0).getOrganization().getDisambiguatedOrganization() != null) {
+                        SchemaOrgAffiliation a = createOrg(
+                                e.getFundingSummary().get(0).getOrganization().getName(),
+                                e.getFundingSummary().get(0).getTitle().getTitle().getContent(),
+                                e.getFundingSummary().get(0).getOrganization().getDisambiguatedOrganization().getDisambiguationSource(),
+                                e.getFundingSummary().get(0).getOrganization().getDisambiguatedOrganization().getDisambiguatedOrganizationIdentifier(),
+                                e.getFundingSummary().get(0).getOrganization().getDisambiguatedOrganization().getExternalIdentifiers());
+                        if (e.getIdentifiers() != null && e.getIdentifiers().getExternalIdentifier() != null)
+                            for (ExternalID id : e.getIdentifiers().getExternalIdentifier()) {
+                                a.identifier.add(new SchemaOrgExternalID(id.getType(), id.getValue()));
+                            }
+                        doc.worksAndFunding.funder.add(a);
+                    }
+                }
+
+            //works
+            if (r.getActivitiesSummary().getWorks() != null && r.getActivitiesSummary().getWorks().getWorkGroup() != null)
+                for (WorkGroup wg : r.getActivitiesSummary().getWorks().getWorkGroup()) {
+                    SchemaOrgWork sw = new SchemaOrgWork();
+                    if (wg.getWorkSummary().get(0) != null && wg.getWorkSummary().get(0).getTitle() != null && wg.getWorkSummary().get(0).getTitle().getTitle() != null)
+                        sw.name = wg.getWorkSummary().get(0).getTitle().getTitle().getContent();
+
+                    if (wg.getIdentifiers() != null && wg.getIdentifiers().getExternalIdentifier() != null)
+                        for (ExternalID id : wg.getIdentifiers().getExternalIdentifier()) {
+                            // add all ids (inc doi non-url if available)
+                            sw.identifier.add(new SchemaOrgExternalID(id.getType(), norm.normalise(id.getType(), id.getValue())));
+                            // sameAs for id URLs.
+                            String url = norm.generateNormalisedURL(id.getType(), id.getValue());
+                            if (StringUtils.isEmpty(url) && id.getUrl() != null)
+                                url = id.getUrl().getValue();                            
+                            //add first DOI as @id
+                            if (id.getType().equals("doi") && !StringUtils.isEmpty(url) && sw.id == null)
+                                sw.id = url;
+                            else if (!StringUtils.isEmpty(url))
+                                sw.sameAs.add(url);
+                        }
+                    doc.worksAndFunding.creator.add(sw);
+                }
+        }
+
+        if (r.getPerson().getResearcherUrls() != null && r.getPerson().getResearcherUrls().getResearcherUrls() != null)
+            for (ResearcherUrl u : r.getPerson().getResearcherUrls().getResearcherUrls()) {
+                doc.url.add(u.getUrl().getValue());
+            }
+
+        if (r.getPerson().getExternalIdentifiers() != null && r.getPerson().getExternalIdentifiers().getExternalIdentifiers() != null)
+            for (PersonExternalIdentifier i : r.getPerson().getExternalIdentifiers().getExternalIdentifiers()) {
+                doc.identifier.add(new SchemaOrgExternalID(i.getType(), i.getValue()));
+            }
+        
+        objectMapper.writer().writeValue(entityStream, doc);
+    }
+
+    private SchemaOrgAffiliation createOrg(String name, String alternateName, String mainIdSource, String mainIdValue, List<DisambiguatedOrganizationExternalIdentifier> ids) {
+        SchemaOrgAffiliation a = new SchemaOrgAffiliation();
+        a.name = name;
+        a.alternateName = alternateName;
+        if (!StringUtils.isEmpty(mainIdSource) && !StringUtils.isEmpty(mainIdValue))
+            addIdToAffiliation(mainIdSource,mainIdValue,a);
+        if (ids != null)
+            for (DisambiguatedOrganizationExternalIdentifier i : ids) {
+                addIdToAffiliation(i.getIdentifierType(),i.getIdentifier(),a);
+            }
+        return a;
+    }
+    
+    private void addIdToAffiliation(String type, String value, SchemaOrgAffiliation a){
+        if (type.equals("LEI")) {
+            a.leiCode = value;
+            if (a.id == null)
+                a.id = "https://www.gleif.org/lei/" + value;
+            else
+                a.sameAs.add("https://www.gleif.org/lei/" + value);
+        } else if (type.equals("FUNDREF")) {
+            if (a.id == null)
+                a.id = norm.generateNormalisedURL("doi", value);
+            else
+                a.sameAs.add(norm.generateNormalisedURL("doi", value));
+        } else if (type.equals("GRID")) {
+            if (a.id == null)
+                a.id = value;
+            else
+                a.sameAs.add(value);
+        } else {
+            a.identifier.add(new SchemaOrgExternalID(type,value));
+        }
+    }
+
+}

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV2.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV2.java
@@ -102,7 +102,8 @@ public class SchemaOrgMBWriterV2 implements MessageBodyWriter<Record> {
         // country
         if (r.getPerson().getAddresses() != null && r.getPerson().getAddresses().getAddress() != null)
             for (Address a : r.getPerson().getAddresses().getAddress()) {
-                doc.address.add(new SchemaOrgAddress(a.getCountry().toString()));
+                if (a.getCountry() != null && a.getCountry().getValue() !=null)
+                    doc.address.add(new SchemaOrgAddress(a.getCountry().getValue().toString()));
             }
 
         // activities

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV3.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV3.java
@@ -104,9 +104,10 @@ public class SchemaOrgMBWriterV3 implements MessageBodyWriter<Record> {
         // country
         if (r.getPerson().getAddresses() != null && r.getPerson().getAddresses().getAddress() != null)
             for (Address a : r.getPerson().getAddresses().getAddress()) {
-                doc.address.add(new SchemaOrgAddress(a.getCountry().toString()));
+                if (a.getCountry() != null && a.getCountry().getValue() !=null)
+                    doc.address.add(new SchemaOrgAddress(a.getCountry().getValue().toString()));
             }
-
+        
         // activities
         if (r.getActivitiesSummary() != null) {
 

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV3.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV3.java
@@ -1,0 +1,252 @@
+package org.orcid.api.common.writer.schemaorg;
+
+import static org.orcid.core.api.OrcidApiConstants.JSON_LD;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.commons.lang3.StringUtils;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgAddress;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgAffiliation;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgExternalID;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgWork;
+import org.orcid.core.utils.v3.identifiers.NormalizationService;
+import org.orcid.jaxb.model.common_v2.DisambiguatedOrganizationExternalIdentifier;
+import org.orcid.jaxb.model.v3.dev1.record.Address;
+import org.orcid.jaxb.model.v3.dev1.record.ExternalID;
+import org.orcid.jaxb.model.v3.dev1.record.OtherName;
+import org.orcid.jaxb.model.v3.dev1.record.PersonExternalIdentifier;
+import org.orcid.jaxb.model.v3.dev1.record.Record;
+import org.orcid.jaxb.model.v3.dev1.record.ResearcherUrl;
+import org.orcid.jaxb.model.v3.dev1.record.summary.AffiliationSummary;
+import org.orcid.jaxb.model.v3.dev1.record.summary.FundingGroup;
+import org.orcid.jaxb.model.v3.dev1.record.summary.FundingSummary;
+import org.orcid.jaxb.model.v3.dev1.record.summary.WorkGroup;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.collect.Lists;
+
+//redirect don't resolve directly.
+@Provider
+@Produces({ JSON_LD })
+@Component
+public class SchemaOrgMBWriterV3 implements MessageBodyWriter<Record> {
+
+    @Resource
+    NormalizationService norm;
+
+    private ObjectMapper objectMapper;
+
+    public SchemaOrgMBWriterV3() {
+        objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED, true);
+        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return Record.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public long getSize(Record t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return -1;
+    }
+
+    /** Converts a v2Record into a SchemaOrgDocument 
+     * requires lots of tedious null checking but logic is simple.
+     * For works, 
+     * - uses DOI for '@id' if available.  
+     * - Puts all ExternalIDs into 'identifiers', normalizing if possible.
+     * - Puts all ExternalID urls into 'sameAs', normalizing if possible.
+     * For Orgs
+     * - Uses first found LEI, GRID or Fundref for '@id'
+     * - Puts other LEI, GRID or Fundref URLs into 'sameAs'
+     * - Puts RINGGOLD into 'identifiers'.
+     * 
+     */
+    @Override
+    public void writeTo(Record r, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+            OutputStream entityStream) throws IOException, WebApplicationException {
+
+        SchemaOrgDocument doc = new SchemaOrgDocument();
+        doc.id = r.getOrcidIdentifier().getUri();
+        doc.mainEntityOfPage = doc.id;
+
+        // names
+        if (r.getPerson().getName() != null) {
+            if (r.getPerson().getName().getCreditName() != null)
+                doc.name = r.getPerson().getName().getCreditName().getContent();
+            if (r.getPerson().getName().getGivenNames() != null)
+                doc.givenName = r.getPerson().getName().getGivenNames().getContent();
+            if (r.getPerson().getName().getFamilyName() != null)
+                doc.familyName = r.getPerson().getName().getFamilyName().getContent();
+        }
+
+        if (r.getPerson().getOtherNames() != null && r.getPerson().getOtherNames().getOtherNames() != null)
+            for (OtherName n : r.getPerson().getOtherNames().getOtherNames()) {
+                doc.alternateName.add(n.getContent());
+            }
+
+        // country
+        if (r.getPerson().getAddresses() != null && r.getPerson().getAddresses().getAddress() != null)
+            for (Address a : r.getPerson().getAddresses().getAddress()) {
+                doc.address.add(new SchemaOrgAddress(a.getCountry().toString()));
+            }
+
+        // activities
+        if (r.getActivitiesSummary() != null) {
+
+            //education & qualification
+            List<AffiliationSummary> alumniOf = Lists.newArrayList();
+            if (r.getActivitiesSummary().getEducations() != null && r.getActivitiesSummary().getEducations().getSummaries() != null)
+                alumniOf.addAll(r.getActivitiesSummary().getEducations().getSummaries());
+            if (r.getActivitiesSummary().getQualifications() != null && r.getActivitiesSummary().getQualifications().getSummaries() != null)
+                alumniOf.addAll(r.getActivitiesSummary().getQualifications().getSummaries());            
+            for (AffiliationSummary e : alumniOf) {
+                if (e.getOrganization() != null && e.getOrganization().getDisambiguatedOrganization() != null)
+                    doc.alumniOf.add(createOrg(e));
+            }
+
+            //affiliations
+            List<AffiliationSummary> affiliations = Lists.newArrayList();
+            if (r.getActivitiesSummary().getEmployments() != null && r.getActivitiesSummary().getEmployments().getSummaries() != null)
+                affiliations.addAll(r.getActivitiesSummary().getEmployments().getSummaries());
+            if (r.getActivitiesSummary().getDistinctions() != null && r.getActivitiesSummary().getDistinctions().getSummaries() != null)
+                affiliations.addAll(r.getActivitiesSummary().getDistinctions().getSummaries());
+            if (r.getActivitiesSummary().getInvitedPositions() != null && r.getActivitiesSummary().getInvitedPositions().getSummaries() != null)
+                affiliations.addAll(r.getActivitiesSummary().getInvitedPositions().getSummaries());
+            if (r.getActivitiesSummary().getMemberships() != null && r.getActivitiesSummary().getMemberships().getSummaries() != null)
+                affiliations.addAll(r.getActivitiesSummary().getMemberships().getSummaries());
+            if (r.getActivitiesSummary().getServices() != null && r.getActivitiesSummary().getServices().getSummaries() != null)
+                affiliations.addAll(r.getActivitiesSummary().getServices().getSummaries());                        
+            for (AffiliationSummary a: affiliations){
+                if (a.getOrganization() != null && a.getOrganization().getDisambiguatedOrganization() != null)
+                    doc.affiliation.add(createOrg(a));
+            }
+
+            //funding
+            if (r.getActivitiesSummary().getFundings() != null && r.getActivitiesSummary().getFundings().getFundingGroup() != null)
+                for (FundingGroup e : r.getActivitiesSummary().getFundings().getFundingGroup()) {
+                    // funding includes org ids and grant_ids
+                    if (e.getFundingSummary().get(0) != null && e.getFundingSummary().get(0).getOrganization() != null
+                            && e.getFundingSummary().get(0).getOrganization().getDisambiguatedOrganization() != null) {
+                        doc.worksAndFunding.funder.add(createFundingOrg(e));
+                    }
+                }
+
+            //work
+            if (r.getActivitiesSummary().getWorks() != null && r.getActivitiesSummary().getWorks().getWorkGroup() != null)
+                for (WorkGroup wg : r.getActivitiesSummary().getWorks().getWorkGroup()) {
+                    SchemaOrgWork sw = new SchemaOrgWork();
+                    if (wg.getWorkSummary().get(0) != null && wg.getWorkSummary().get(0).getTitle() != null && wg.getWorkSummary().get(0).getTitle().getTitle() != null)
+                        sw.name = wg.getWorkSummary().get(0).getTitle().getTitle().getContent();
+
+                    if (wg.getIdentifiers() != null && wg.getIdentifiers().getExternalIdentifier() != null)
+                        for (ExternalID id : wg.getIdentifiers().getExternalIdentifier()) {
+                            // add all ids (inc doi non-url if available)
+                            sw.identifier.add(new SchemaOrgExternalID(id.getType(), norm.normalise(id.getType(), id.getValue())));
+                            // sameAs for id URLs.
+                            String url = norm.generateNormalisedURL(id.getType(), id.getValue());
+                            if (StringUtils.isEmpty(url) && id.getUrl() != null)
+                                url = id.getUrl().getValue();
+                            //add first DOI as @id
+                            if (id.getType().equals("doi") && !StringUtils.isEmpty(url) && sw.id == null)
+                                sw.id = url;
+                            else if (!StringUtils.isEmpty(url))
+                                sw.sameAs.add(url);
+                        }
+                    doc.worksAndFunding.creator.add(sw);
+                }
+        }
+
+        if (r.getPerson().getResearcherUrls() != null && r.getPerson().getResearcherUrls().getResearcherUrls() != null)
+            for (ResearcherUrl u : r.getPerson().getResearcherUrls().getResearcherUrls()) {
+                doc.url.add(u.getUrl().getValue());
+            }
+
+        if (r.getPerson().getExternalIdentifiers() != null && r.getPerson().getExternalIdentifiers().getExternalIdentifiers() != null)
+            for (PersonExternalIdentifier i : r.getPerson().getExternalIdentifiers().getExternalIdentifiers()) {
+                doc.identifier.add(new SchemaOrgExternalID(i.getType(), i.getValue()));
+            }
+        
+        objectMapper.writer().writeValue(entityStream, doc);
+    }
+
+    private SchemaOrgAffiliation createFundingOrg(FundingGroup fundingGroup) {
+        SchemaOrgAffiliation a = new SchemaOrgAffiliation();
+        a.name = fundingGroup.getFundingSummary().get(0).getOrganization().getName();
+        a.alternateName = fundingGroup.getFundingSummary().get(0).getTitle().getTitle().getContent();
+        
+        //add org ids
+        for (FundingSummary s : fundingGroup.getFundingSummary()){
+            if (s.getOrganization().getDisambiguatedOrganization() !=null){
+                if (!StringUtils.isEmpty(s.getOrganization().getDisambiguatedOrganization().getDisambiguationSource()) && !StringUtils.isEmpty(s.getOrganization().getDisambiguatedOrganization().getDisambiguatedOrganizationIdentifier()))
+                    addIdToAffiliation(s.getOrganization().getDisambiguatedOrganization().getDisambiguationSource(),s.getOrganization().getDisambiguatedOrganization().getDisambiguatedOrganizationIdentifier(), a);            
+                if (s.getOrganization().getDisambiguatedOrganization().getExternalIdentifiers() != null)
+                    for (DisambiguatedOrganizationExternalIdentifier i : s.getOrganization().getDisambiguatedOrganization().getExternalIdentifiers()) {
+                        addIdToAffiliation(i.getIdentifierType(),i.getIdentifier(), a);
+                }
+            }
+        }
+
+       //add grant ids
+       if (fundingGroup.getIdentifiers() != null && fundingGroup.getIdentifiers().getExternalIdentifier() != null)
+           for (ExternalID id : fundingGroup.getIdentifiers().getExternalIdentifier())
+               a.identifier.add(new SchemaOrgExternalID(id.getType(), norm.normalise(id.getType(), id.getValue())));
+       
+        return a;
+    }
+
+    private SchemaOrgAffiliation createOrg(AffiliationSummary e) {
+        SchemaOrgAffiliation a = new SchemaOrgAffiliation();
+        a.name = e.getOrganization().getName();
+        a.alternateName = e.getDepartmentName();
+        if (e.getOrganization().getDisambiguatedOrganization() !=null){
+            if (!StringUtils.isEmpty(e.getOrganization().getDisambiguatedOrganization().getDisambiguationSource()) && !StringUtils.isEmpty(e.getOrganization().getDisambiguatedOrganization().getDisambiguatedOrganizationIdentifier())){
+                addIdToAffiliation(e.getOrganization().getDisambiguatedOrganization().getDisambiguationSource(),e.getOrganization().getDisambiguatedOrganization().getDisambiguatedOrganizationIdentifier(), a);
+            }   
+            if (e.getOrganization().getDisambiguatedOrganization().getExternalIdentifiers() != null)
+                for (DisambiguatedOrganizationExternalIdentifier i : e.getOrganization().getDisambiguatedOrganization().getExternalIdentifiers()) {
+                    addIdToAffiliation(i.getIdentifierType(),i.getIdentifier(), a);
+            }
+        }
+        return a;
+    }
+    
+    private void addIdToAffiliation(String type, String value, SchemaOrgAffiliation a){
+        if (type.equals("LEI")) {
+            a.leiCode = value;
+            if (a.id == null)
+                a.id = "https://www.gleif.org/lei/" + value;
+            else
+                a.sameAs.add("https://www.gleif.org/lei/" + value);
+        } else if (type.equals("FUNDREF")) {
+            if (a.id == null)
+                a.id = norm.generateNormalisedURL("doi", value);
+            else
+                a.sameAs.add(norm.generateNormalisedURL("doi", value));
+        } else if (type.equals("GRID")) {
+            if (a.id == null)
+                a.id = value;
+            else
+                a.sameAs.add(value);
+        } else {
+            a.identifier.add(new SchemaOrgExternalID(type,value));
+        }
+    }
+
+}

--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV3.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/schemaorg/SchemaOrgMBWriterV3.java
@@ -158,17 +158,20 @@ public class SchemaOrgMBWriterV3 implements MessageBodyWriter<Record> {
 
                     if (wg.getIdentifiers() != null && wg.getIdentifiers().getExternalIdentifier() != null)
                         for (ExternalID id : wg.getIdentifiers().getExternalIdentifier()) {
-                            // add all ids (inc doi non-url if available)
-                            sw.identifier.add(new SchemaOrgExternalID(id.getType(), norm.normalise(id.getType(), id.getValue())));
-                            // sameAs for id URLs.
-                            String url = norm.generateNormalisedURL(id.getType(), id.getValue());
-                            if (StringUtils.isEmpty(url) && id.getUrl() != null)
-                                url = id.getUrl().getValue();
-                            //add first DOI as @id
-                            if (id.getType().equals("doi") && !StringUtils.isEmpty(url) && sw.id == null)
-                                sw.id = url;
-                            else if (!StringUtils.isEmpty(url))
-                                sw.sameAs.add(url);
+                            String normed = norm.normalise(id.getType(), id.getValue());
+                            if (!StringUtils.isEmpty(normed)){
+                                // add all ids (inc doi non-url if available)
+                                sw.identifier.add(new SchemaOrgExternalID(id.getType(), normed));
+                                // sameAs for id URLs.
+                                String url = norm.generateNormalisedURL(id.getType(), id.getValue());
+                                if (StringUtils.isEmpty(url) && id.getUrl() != null)
+                                    url = id.getUrl().getValue();
+                                //add first DOI as @id
+                                if (id.getType().equals("doi") && !StringUtils.isEmpty(url) && sw.id == null)
+                                    sw.id = url;
+                                else if (!StringUtils.isEmpty(url))
+                                    sw.sameAs.add(url);
+                            }
                         }
                     doc.worksAndFunding.creator.add(sw);
                 }

--- a/orcid-api-common/src/test/java/org/orcid/api/common/writer/SchemaOrgDocumentTest.java
+++ b/orcid-api-common/src/test/java/org/orcid/api/common/writer/SchemaOrgDocumentTest.java
@@ -1,0 +1,170 @@
+package org.orcid.api.common.writer;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.apache.jena.ext.com.google.common.collect.Sets;
+import org.junit.Test;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgAddress;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgAffiliation;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgExternalID;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgWork;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.collect.Lists;
+
+public class SchemaOrgDocumentTest {
+
+    // annoying. With reverse google sees two funders with one fundee each, and
+    // two works with one author each.
+    // without the works and funding, it looks like a person.
+
+    public static final String expectedDoc = "{\n" +
+            "  \"@context\" : \"http://schema.org\",\n" +
+            "  \"@type\" : \"Person\",\n" +
+            "  \"@id\" : \"https://orcid.org/0000-0000-0000-000X\",\n" +
+            "  \"mainEntityOfPage\" : \"https://orcid.org/0000-0000-0000-000X\",\n" +
+            "  \"name\" : \"Joe McJoeface\",\n" +
+            "  \"givenName\" : \"Joseph\",\n" +
+            "  \"familyName\" : \"McJoeFace\",\n" +
+            "  \"alternateName\" : \"Face\",\n" +
+            "  \"address\" : [ {\n" +
+            "    \"addressCountry\" : \"UK\",\n" +
+            "    \"@type\" : \"PostalAddress\"\n" +
+            "  }, {\n" +
+            "    \"addressCountry\" : \"US\",\n" +
+            "    \"@type\" : \"PostalAddress\"\n" +
+            "  } ],\n" +
+            "  \"alumniOf\" : [ {\n" +
+            "    \"@type\" : \"Organization\",\n" +
+            "    \"@id\" : \"https://grid.ac.uk/1\",\n" +
+            "    \"name\" : \"Org1\",\n" +
+            "    \"alternateName\" : \"DegreeTitle1\"\n" +
+            "  }, {\n" +
+            "    \"@type\" : \"Organization\",\n" +
+            "    \"@id\" : \"https://lei.org/2222\",\n" +
+            "    \"leiCode\" : \"2222\",\n" +
+            "    \"name\" : \"Org2\",\n" +
+            "    \"alternateName\" : \"DegreeTitle2\",\n" +
+            "    \"identifier\" : {\n" +
+            "      \"@type\" : \"PropertyValue\",\n" +
+            "      \"propertyID\" : \"RINGGGOLD\",\n" +
+            "      \"value\" : \"A\"\n" +
+            "    },\n" +
+            "    \"sameAs\" : \"http://grid.ac/B\"\n" +
+            "  } ],\n" +
+            "  \"affiliation\" : [ {\n" +
+            "    \"@type\" : \"Organization\",\n" +
+            "    \"@id\" : \"https://grid.ac.uk/3\",\n" +
+            "    \"name\" : \"Org3\",\n" +
+            "    \"alternateName\" : \"JobTitle1\"\n" +
+            "  }, {\n" +
+            "    \"@type\" : \"Organization\",\n" +
+            "    \"name\" : \"Org4\",\n" +
+            "    \"alternateName\" : \"JobTitle2\",\n" +
+            "    \"identifier\" : {\n" +
+            "      \"@type\" : \"PropertyValue\",\n" +
+            "      \"propertyID\" : \"RINGGGOLD\",\n" +
+            "      \"value\" : \"C\"\n" +
+            "    }\n" +
+            "  } ],\n" +
+            "  \"@reverse\" : {\n" +
+            "    \"funder\" : [ {\n" +
+            "      \"@type\" : \"Organization\",\n" +
+            "      \"@id\" : \"https://doi.org/5\",\n" +
+            "      \"name\" : \"Org5\",\n" +
+            "      \"alternateName\" : \"GrantTitle1\"\n" +
+            "    }, {\n" +
+            "      \"@type\" : \"Organization\",\n" +
+            "      \"@id\" : \"https://doi.org/6\",\n" +
+            "      \"leiCode\" : \"2222\",\n" +
+            "      \"name\" : \"Org6\",\n" +
+            "      \"alternateName\" : \"GrantTitle2\",\n" +
+            "      \"identifier\" : {\n" +
+            "        \"@type\" : \"PropertyValue\",\n" +
+            "        \"propertyID\" : \"grant_number\",\n" +
+            "        \"value\" : \"abcd\"\n" +
+            "      }\n" +
+            "    } ],\n" +
+            "    \"creator\" : [ {\n" +
+            "      \"@type\" : \"CreativeWork\",\n" +
+            "      \"@id\" : \"https://doi.org/1\",\n" +
+            "      \"name\" : \"WorkTitle1\"\n" +
+            "    }, {\n" +
+            "      \"@type\" : \"CreativeWork\",\n" +
+            "      \"@id\" : \"https://doi.org/2\",\n" +
+            "      \"name\" : \"WorkTitle2\",\n" +
+            "      \"identifier\" : [ {\n" +
+            "        \"@type\" : \"PropertyValue\",\n" +
+            "        \"propertyID\" : \"isbn\",\n" +
+            "        \"value\" : \"1234567890\"\n" +
+            "      }, {\n" +
+            "        \"@type\" : \"PropertyValue\",\n" +
+            "        \"propertyID\" : \"pmc\",\n" +
+            "        \"value\" : \"12345678\"\n" +
+            "      } ],\n" +
+            "      \"sameAs\" : \"http://worldcat.org/isbn/1234567890\"\n" +
+            "    } ]\n" +
+            "  },\n" +
+            "  \"url\" : \"http://joe.com\",\n" +
+            "  \"identifier\" : [ {\n" +
+            "    \"@type\" : \"PropertyValue\",\n" +
+            "    \"propertyID\" : \"scopusID\",\n" +
+            "    \"value\" : \"123\"\n" +
+            "  }, {\n" +
+            "    \"@type\" : \"PropertyValue\",\n" +
+            "    \"propertyID\" : \"researcherID\",\n" +
+            "    \"value\" : \"456\"\n" +
+            "  } ]\n" +
+            "}";
+    @Test
+    public void testSerialisation() throws JsonGenerationException, JsonMappingException, IOException {
+        SchemaOrgDocument doc = new SchemaOrgDocument();
+        doc.id = "https://orcid.org/0000-0000-0000-000X";
+        doc.mainEntityOfPage = doc.id;
+        doc.name = "Joe McJoeface";
+        doc.givenName = "Joseph";
+        doc.familyName = "McJoeFace";
+        doc.alternateName = Lists.newArrayList("Face");
+
+        doc.address.add(new SchemaOrgAddress("UK"));
+        doc.address.add(new SchemaOrgAddress("US"));
+
+        doc.alumniOf.add(new SchemaOrgAffiliation("https://grid.ac.uk/1", "Org1", "DegreeTitle1", null));
+        doc.alumniOf.add(new SchemaOrgAffiliation("https://lei.org/2222", "Org2", "DegreeTitle2", "2222", new SchemaOrgExternalID("RINGGGOLD", "A"),
+                new SchemaOrgExternalID("grid", "http://grid.ac/B")));
+        //add twice, second should be ignored
+        doc.alumniOf.add(new SchemaOrgAffiliation("https://lei.org/2222", "Org2", "DegreeTitle2", "2222", new SchemaOrgExternalID("RINGGGOLD", "A"),
+                new SchemaOrgExternalID("grid", "http://grid.ac/B")));
+
+        doc.affiliation.add(new SchemaOrgAffiliation("https://grid.ac.uk/3", "Org3", "JobTitle1", null));
+        // just a ringgold
+        doc.affiliation.add(new SchemaOrgAffiliation(null, "Org4", "JobTitle2", null, new SchemaOrgExternalID("RINGGGOLD", "C")));
+
+        doc.worksAndFunding.creator.add(new SchemaOrgWork("https://doi.org/1", "WorkTitle1", null));
+        doc.worksAndFunding.creator.add(new SchemaOrgWork("https://doi.org/2", "WorkTitle2", Sets.newLinkedHashSet(Lists.newArrayList("http://worldcat.org/isbn/1234567890")),
+                new SchemaOrgExternalID("isbn", "1234567890"), new SchemaOrgExternalID("pmc", "12345678")));
+
+        doc.worksAndFunding.funder.add(new SchemaOrgAffiliation("https://doi.org/5", "Org5", "GrantTitle1", null));// fundref
+        // fundref and lei
+        doc.worksAndFunding.funder.add(new SchemaOrgAffiliation("https://doi.org/6", "Org6", "GrantTitle2", "2222", new SchemaOrgExternalID("grant_number", "abcd")));
+
+        doc.url.add("http://joe.com");// just one, to test unwrapped arrays
+
+        doc.identifier.add(new SchemaOrgExternalID("scopusID", "123"));
+        doc.identifier.add(new SchemaOrgExternalID("researcherID", "456"));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED, true);
+        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+        StringWriter s = new StringWriter();
+        objectMapper.writer().writeValue(s, doc);
+        assertEquals(expectedDoc, s.toString());
+    }
+}

--- a/orcid-pub-web/src/main/java/org/orcid/api/publicV2/server/PublicV2ApiServiceImplV2_0.java
+++ b/orcid-pub-web/src/main/java/org/orcid/api/publicV2/server/PublicV2ApiServiceImplV2_0.java
@@ -2,7 +2,6 @@ package org.orcid.api.publicV2.server;
 
 import static org.orcid.core.api.OrcidApiConstants.ACTIVITIES;
 import static org.orcid.core.api.OrcidApiConstants.ADDRESS;
-import static org.orcid.core.api.OrcidApiConstants.APPLICATION_RDFXML;
 import static org.orcid.core.api.OrcidApiConstants.BIOGRAPHY;
 import static org.orcid.core.api.OrcidApiConstants.BULK_WORKS;
 import static org.orcid.core.api.OrcidApiConstants.CLIENT_PATH;
@@ -19,7 +18,6 @@ import static org.orcid.core.api.OrcidApiConstants.FUNDINGS;
 import static org.orcid.core.api.OrcidApiConstants.FUNDING_SUMMARY;
 import static org.orcid.core.api.OrcidApiConstants.JSON_LD;
 import static org.orcid.core.api.OrcidApiConstants.KEYWORDS;
-import static org.orcid.core.api.OrcidApiConstants.N_TRIPLES;
 import static org.orcid.core.api.OrcidApiConstants.ORCID_JSON;
 import static org.orcid.core.api.OrcidApiConstants.ORCID_XML;
 import static org.orcid.core.api.OrcidApiConstants.OTHER_NAMES;
@@ -29,12 +27,9 @@ import static org.orcid.core.api.OrcidApiConstants.PEER_REVIEW_SUMMARY;
 import static org.orcid.core.api.OrcidApiConstants.PERSON;
 import static org.orcid.core.api.OrcidApiConstants.PERSONAL_DETAILS;
 import static org.orcid.core.api.OrcidApiConstants.PUTCODE;
-import static org.orcid.core.api.OrcidApiConstants.RECORD;
 import static org.orcid.core.api.OrcidApiConstants.RESEARCHER_URLS;
 import static org.orcid.core.api.OrcidApiConstants.SEARCH_PATH;
 import static org.orcid.core.api.OrcidApiConstants.STATUS_PATH;
-import static org.orcid.core.api.OrcidApiConstants.TEXT_N3;
-import static org.orcid.core.api.OrcidApiConstants.TEXT_TURTLE;
 import static org.orcid.core.api.OrcidApiConstants.VND_ORCID_JSON;
 import static org.orcid.core.api.OrcidApiConstants.VND_ORCID_XML;
 import static org.orcid.core.api.OrcidApiConstants.WORK;
@@ -403,7 +398,7 @@ public class PublicV2ApiServiceImplV2_0 {
     
     //Record 
     @GET
-    @Produces(value = { VND_ORCID_XML, ORCID_XML, MediaType.APPLICATION_XML, VND_ORCID_JSON, ORCID_JSON, MediaType.APPLICATION_JSON })
+    @Produces(value = { VND_ORCID_XML, ORCID_XML, MediaType.APPLICATION_XML, VND_ORCID_JSON, ORCID_JSON, MediaType.APPLICATION_JSON , JSON_LD})
     @Path(OrcidApiConstants.RECORD_SIMPLE)
     @ApiOperation(value = "Fetch record details", response = Record.class)
     @ExternalDocs(value = "Record XML Schema", url = "https://raw.githubusercontent.com/ORCID/ORCID-Source/master/orcid-model/src/main/resources/record_2.0/record-2.0.xsd")

--- a/orcid-pub-web/src/main/java/org/orcid/api/publicV2/server/PublicV2ApiServiceImplV2_1.java
+++ b/orcid-pub-web/src/main/java/org/orcid/api/publicV2/server/PublicV2ApiServiceImplV2_1.java
@@ -34,6 +34,7 @@ import static org.orcid.core.api.OrcidApiConstants.VND_ORCID_XML;
 import static org.orcid.core.api.OrcidApiConstants.WORK;
 import static org.orcid.core.api.OrcidApiConstants.WORKS;
 import static org.orcid.core.api.OrcidApiConstants.WORK_SUMMARY;
+import static org.orcid.core.api.OrcidApiConstants.JSON_LD;
 
 import java.util.List;
 import java.util.Map;
@@ -397,7 +398,7 @@ public class PublicV2ApiServiceImplV2_1 {
     
     //Record 
     @GET
-    @Produces(value = { VND_ORCID_XML, ORCID_XML, MediaType.APPLICATION_XML, VND_ORCID_JSON, ORCID_JSON, MediaType.APPLICATION_JSON })
+    @Produces(value = { VND_ORCID_XML, ORCID_XML, MediaType.APPLICATION_XML, VND_ORCID_JSON, ORCID_JSON, MediaType.APPLICATION_JSON, JSON_LD })
     @Path(OrcidApiConstants.RECORD_SIMPLE)
     @ApiOperation( nickname="viewRecordV21", response = Record.class, value = "Fetch record details")
     @ExternalDocs(value = "Record XML Schema", url = "https://raw.githubusercontent.com/ORCID/ORCID-Source/master/orcid-model/src/main/resources/record_2.0/record-2.0.xsd")

--- a/orcid-pub-web/src/main/java/org/orcid/api/publicV3/server/PublicV3ApiServiceImplV3_0_dev1.java
+++ b/orcid-pub-web/src/main/java/org/orcid/api/publicV3/server/PublicV3ApiServiceImplV3_0_dev1.java
@@ -49,6 +49,7 @@ import static org.orcid.core.api.OrcidApiConstants.VND_ORCID_XML;
 import static org.orcid.core.api.OrcidApiConstants.WORK;
 import static org.orcid.core.api.OrcidApiConstants.WORKS;
 import static org.orcid.core.api.OrcidApiConstants.WORK_SUMMARY;
+import static org.orcid.core.api.OrcidApiConstants.JSON_LD;
 
 import java.util.List;
 import java.util.Map;
@@ -413,7 +414,7 @@ public class PublicV3ApiServiceImplV3_0_dev1 {
     
     //Record 
     @GET
-    @Produces(value = { VND_ORCID_XML, ORCID_XML, MediaType.APPLICATION_XML, VND_ORCID_JSON, ORCID_JSON, MediaType.APPLICATION_JSON })
+    @Produces(value = { VND_ORCID_XML, ORCID_XML, MediaType.APPLICATION_XML, VND_ORCID_JSON, ORCID_JSON, MediaType.APPLICATION_JSON, JSON_LD })
     @Path(OrcidApiConstants.RECORD_SIMPLE)
     @ApiOperation( nickname="viewRecordV3dev", value = "Fetch record details")
     @ExternalDocs(value = "Record XML Schema", url = "https://raw.githubusercontent.com/ORCID/ORCID-Source/master/orcid-model/src/main/resources/record_2.0/record-2.0.xsd")

--- a/orcid-pub-web/src/test/java/org/orcid/api/publicV2/server/PublicV2ApiServiceDelegatorTest.java
+++ b/orcid-pub-web/src/test/java/org/orcid/api/publicV2/server/PublicV2ApiServiceDelegatorTest.java
@@ -6,15 +6,22 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Resource;
 import javax.persistence.NoResultException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import org.junit.AfterClass;
@@ -24,6 +31,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgExternalID;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgMBWriterV2;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgMBWriterV3;
 import org.orcid.api.publicV2.server.delegator.PublicV2ApiServiceDelegator;
 import org.orcid.api.publicV2.server.delegator.impl.PublicV2ApiServiceDelegatorImpl;
 import org.orcid.core.api.OrcidApiConstants;
@@ -92,6 +103,11 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.collect.Sets;
 
 @RunWith(OrcidJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:orcid-t1-web-context.xml", "classpath:orcid-t1-security-context.xml" })
@@ -1420,5 +1436,37 @@ public class PublicV2ApiServiceDelegatorTest extends DBUnitTest {
         assertNotNull(record.getOrcidIdentifier());
         OrcidIdentifier id = record.getOrcidIdentifier();
         assertEquals("0000-0000-0000-0003", id.getPath());
+    }
+    
+    @Resource
+    SchemaOrgMBWriterV2 writerV2;
+    
+    @Test
+    public void testSchemaOrgMBWriterV2() throws WebApplicationException, IOException{
+        Response response = serviceDelegator.viewRecord(ORCID);
+        Record record = (Record) response.getEntity();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writerV2.writeTo(record, record.getClass(), null, null, null, null, out);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        SchemaOrgDocument doc = objectMapper.readerFor(SchemaOrgDocument.class).readValue(out.toString());
+        assertTrue(doc.id.endsWith(ORCID));
+        assertEquals("Person",doc.type);
+        assertEquals("http://schema.org",doc.context);
+        assertEquals("Credit Name",doc.name);
+        assertEquals("Given Names",doc.givenName);
+        assertEquals("Family Name",doc.familyName);
+        assertEquals("Other Name PUBLIC",doc.alternateName.get(0));
+        assertEquals("WDB",doc.alumniOf.iterator().next().identifier.iterator().next().propertyID);
+        assertEquals("WDB",doc.affiliation.iterator().next().identifier.iterator().next().propertyID);
+        Set<String> fundingIds = Sets.newHashSet();
+        for (SchemaOrgExternalID i: doc.worksAndFunding.funder.iterator().next().identifier)
+            fundingIds.add(i.propertyID);
+        assertEquals(Sets.newHashSet("WDB","grant_number"),fundingIds);
+        assertEquals("PUBLIC",doc.worksAndFunding.creator.iterator().next().name);
+        assertEquals("doi",doc.worksAndFunding.creator.iterator().next().identifier.iterator().next().propertyID);
+        assertEquals("http://www.researcherurl.com?id=13",doc.url.get(0));
+        assertEquals("public_type",doc.identifier.get(0).propertyID);
+        assertEquals( "public_ref",doc.identifier.get(0).value);
     }
 }

--- a/orcid-pub-web/src/test/java/org/orcid/api/publicV2/server/PublicV2ApiServiceDelegatorTest.java
+++ b/orcid-pub-web/src/test/java/org/orcid/api/publicV2/server/PublicV2ApiServiceDelegatorTest.java
@@ -1464,7 +1464,6 @@ public class PublicV2ApiServiceDelegatorTest extends DBUnitTest {
             fundingIds.add(i.propertyID);
         assertEquals(Sets.newHashSet("WDB","grant_number"),fundingIds);
         assertEquals("PUBLIC",doc.worksAndFunding.creator.iterator().next().name);
-        assertEquals("doi",doc.worksAndFunding.creator.iterator().next().identifier.iterator().next().propertyID);
         assertEquals("http://www.researcherurl.com?id=13",doc.url.get(0));
         assertEquals("public_type",doc.identifier.get(0).propertyID);
         assertEquals( "public_ref",doc.identifier.get(0).value);

--- a/orcid-pub-web/src/test/java/org/orcid/api/publicV3/server/PublicV3ApiServiceDelegatorTest.java
+++ b/orcid-pub-web/src/test/java/org/orcid/api/publicV3/server/PublicV3ApiServiceDelegatorTest.java
@@ -2016,7 +2016,6 @@ public class PublicV3ApiServiceDelegatorTest extends DBUnitTest {
             fundingIds.add(i.propertyID);
         assertEquals(Sets.newHashSet("WDB","grant_number"),fundingIds);
         assertEquals("PUBLIC",doc.worksAndFunding.creator.iterator().next().name);
-        assertEquals("doi",doc.worksAndFunding.creator.iterator().next().identifier.iterator().next().propertyID);
         assertEquals("http://www.researcherurl.com?id=13",doc.url.get(0));
         assertEquals("public_type",doc.identifier.get(0).propertyID);
         assertEquals( "public_ref",doc.identifier.get(0).value);

--- a/orcid-pub-web/src/test/java/org/orcid/api/publicV3/server/PublicV3ApiServiceDelegatorTest.java
+++ b/orcid-pub-web/src/test/java/org/orcid/api/publicV3/server/PublicV3ApiServiceDelegatorTest.java
@@ -6,15 +6,19 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Resource;
 import javax.persistence.NoResultException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import org.junit.AfterClass;
@@ -24,6 +28,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgMBWriterV2;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgMBWriterV3;
+import org.orcid.api.common.writer.schemaorg.SchemaOrgDocument.SchemaOrgExternalID;
 import org.orcid.api.publicV3.server.delegator.PublicV3ApiServiceDelegator;
 import org.orcid.api.publicV3.server.delegator.impl.PublicV3ApiServiceDelegatorImpl;
 import org.orcid.core.api.OrcidApiConstants;
@@ -107,6 +115,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 
 @RunWith(OrcidJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:orcid-t1-web-context.xml", "classpath:orcid-t1-security-context.xml" })
@@ -1975,5 +1987,38 @@ public class PublicV3ApiServiceDelegatorTest extends DBUnitTest {
         assertNotNull(record.getOrcidIdentifier());
         OrcidIdentifier id = record.getOrcidIdentifier();
         assertEquals("0000-0000-0000-0003", id.getPath());
+    }
+    
+    @Resource
+    SchemaOrgMBWriterV3 writerV3;
+    
+    @Test
+    public void testSchemaOrgMBWriterV3() throws WebApplicationException, IOException{
+        Response response = serviceDelegator.viewRecord(ORCID);
+        Record record = (Record) response.getEntity();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writerV3.writeTo(record, record.getClass(), null, null, null, null, out);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        SchemaOrgDocument doc = objectMapper.readerFor(SchemaOrgDocument.class).readValue(out.toString());
+        assertTrue(doc.id.endsWith(ORCID));
+        assertEquals("Person",doc.type);
+        assertEquals("http://schema.org",doc.context);
+        assertEquals("Credit Name",doc.name);
+        assertEquals("Given Names",doc.givenName);
+        assertEquals("Family Name",doc.familyName);
+        assertEquals("Other Name PUBLIC",doc.alternateName.get(0));
+        assertEquals("WDB",doc.alumniOf.iterator().next().identifier.iterator().next().propertyID);
+        //they've been squashed into one because they're all the same Org.
+        assertEquals("WDB",doc.affiliation.iterator().next().identifier.iterator().next().propertyID);
+        Set<String> fundingIds = Sets.newHashSet();
+        for (SchemaOrgExternalID i: doc.worksAndFunding.funder.iterator().next().identifier)
+            fundingIds.add(i.propertyID);
+        assertEquals(Sets.newHashSet("WDB","grant_number"),fundingIds);
+        assertEquals("PUBLIC",doc.worksAndFunding.creator.iterator().next().name);
+        assertEquals("doi",doc.worksAndFunding.creator.iterator().next().identifier.iterator().next().propertyID);
+        assertEquals("http://www.researcherurl.com?id=13",doc.url.get(0));
+        assertEquals("public_type",doc.identifier.get(0).propertyID);
+        assertEquals( "public_ref",doc.identifier.get(0).value);
     }
 }


### PR DESCRIPTION
Modified registry to server schema.org metadata for v2.0, v2.1 and v3.0dev requests to record root.

Records contain basic person metadata e.g.

`curl -vH'Accept: application/ld+json' https://localhost:8443/orcid-pub-web/0000-0002-2601-8132 --insecure`

Metadata:

```
  "@type" : "Person",
  "@id" : "https://testserver.orcid.org/0000-0000-0000-0003",
  "mainEntityOfPage" : "https://testserver.orcid.org/0000-0000-0000-0003",
  "name" : "Credit Name",
  "givenName" : "Given Names",
  "familyName" : "Family Name",
  "alternateName" : ["Other","Names"],
  "address" : {
    "addressCountry" : "US",
    "@type" : "PostalAddress"
  },
"identifier" : [ {
    "@type" : "PropertyValue",
    "propertyID" : "ScopusID",
    "value" : "abc"
  },
"url" : ["",""]
```

Metadata about activities:

```
// education and qualifications go in "alumniOf"
"alumniOf" : [ {
    "@type" : "Organization",
    "@id" : "https://www.gleif.org/lei/254900ASE7KSYZL1P471", // the main fundref/lei/grid
    "leiCode" : "254900ASE7KSYZL1P471", //only for lei
    "name" : "工银国际证券有限公司",
    "alternateName" : "department name",
    "identifier" : {  //non-url ids (ringgold)
      "@type" : "PropertyValue",
      "propertyID" : "RINGGOLD",
      "value" : "397701"
    },
    "sameAs": ["https://doi.org/1",""]; //other url ids (fundref/lei/grid)

  },{} ] 
// employment, service etc go in 'affiliations'.
"affiliations" : [ {},{} ] 
```

Metadata about works and funding is inside a reverse property:
```
"@reverse" : {
    "funder" : [ {
      "@type" : "Organization",
      "@id" : "http://grid.ac/1", 
      "name" : "Org name",
      "alternateName" : "funding title",
      "identifier" : { //grant_numbers and other identifiers
        "@type" : "PropertyValue",
        "propertyID" : "grant_number",
        "value" : "2"
      },
      "sameAs":["",""]
    },{}],
    "creator" : [ {
      "@type" : "CreativeWork",
      "@id" : "https://doi.org/10.6084/m9.figshare.5479792.v1x", //doi if available
      "name" : "x",
      "identifier" : { //non-url identifiers
        "@type" : "PropertyValue",
        "propertyID" : "doi",
        "value" : "10.6084/m9.figshare.5479792.v1x"
      },{}],
      "sameAs":["",""];//url identitifiers
}
```

