### PR TITLE
Use system property org.orcid.ehcache.dir for ehcache files

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/utils/OrcidEhCacheManagerFactoryBean.java
+++ b/orcid-core/src/main/java/org/orcid/core/utils/OrcidEhCacheManagerFactoryBean.java
@@ -4,6 +4,8 @@ import java.io.File;
 
 import javax.annotation.Resource;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.ehcache.PersistentCacheManager;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.orcid.core.manager.impl.OrcidUrlManager;
@@ -14,6 +16,8 @@ import org.springframework.beans.factory.FactoryBean;
 public class OrcidEhCacheManagerFactoryBean implements FactoryBean<PersistentCacheManager> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OrcidEhCacheManagerFactoryBean.class);
+    
+    private static final String EHCACHE_DIR_PROPERTY = "org.orcid.ehcache.dir";
 
     private static PersistentCacheManager persistentCacheManager;
 
@@ -21,11 +25,17 @@ public class OrcidEhCacheManagerFactoryBean implements FactoryBean<PersistentCac
     private OrcidUrlManager orcidUrlManager;
 
     private String getStoragePath() {
-        String tmpDir = System.getProperty("java.io.tmpdir");
-        if (!tmpDir.endsWith(File.separator)) {
-            tmpDir += File.separator;
+        String ehcacheDir = System.getProperty(EHCACHE_DIR_PROPERTY);
+        if(StringUtils.isBlank(ehcacheDir)) {
+            String tmpDir = System.getProperty("java.io.tmpdir");
+            if (!tmpDir.endsWith(File.separator)) {
+                tmpDir += File.separator;
+            }
+            String randomString = RandomStringUtils.randomAlphanumeric(16);
+            ehcacheDir = tmpDir + "ehcache" + File.separator + randomString;
+            System.setProperty(EHCACHE_DIR_PROPERTY, ehcacheDir);
         }
-        return tmpDir + "ehcache" + File.separator + orcidUrlManager.getAppName() + File.separator + "programmatic";
+        return ehcacheDir + File.separator + orcidUrlManager.getAppName() + File.separator + "programmatic";
     }
 
     @Override

--- a/orcid-core/src/main/resources/ehcache_default.xml
+++ b/orcid-core/src/main/resources/ehcache_default.xml
@@ -24,7 +24,7 @@
             http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.1.xsd
             http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
         
-    <ehcache:persistence directory="${java.io.tmpdir}/ehcache/default/annotations" />
+    <ehcache:persistence directory="${org.orcid.ehcache.dir}/default/annotations" />
 
     <ehcache:cache alias="country-list" uses-template="defaultTemplate">
         <ehcache:expiry>

--- a/orcid-core/src/main/resources/ehcache_orcid-api-web.xml
+++ b/orcid-core/src/main/resources/ehcache_orcid-api-web.xml
@@ -24,7 +24,7 @@
             http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.1.xsd
             http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
         
-    <ehcache:persistence directory="${java.io.tmpdir}/ehcache/orcid-api-web/annotations" />
+    <ehcache:persistence directory="${org.orcid.ehcache.dir}/orcid-api-web/annotations" />
 
     <ehcache:cache alias="country-list" uses-template="defaultTemplate">
         <ehcache:expiry>

--- a/orcid-core/src/main/resources/ehcache_orcid-internal-api.xml
+++ b/orcid-core/src/main/resources/ehcache_orcid-internal-api.xml
@@ -24,7 +24,7 @@
             http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.1.xsd
             http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
         
-    <ehcache:persistence directory="${java.io.tmpdir}/ehcache/orcid-internal-api/annotations" />
+    <ehcache:persistence directory="${org.orcid.ehcache.dir}/orcid-internal-api/annotations" />
 
     <ehcache:cache alias="country-list" uses-template="defaultTemplate">
         <ehcache:expiry>

--- a/orcid-core/src/main/resources/ehcache_orcid-pub-web.xml
+++ b/orcid-core/src/main/resources/ehcache_orcid-pub-web.xml
@@ -24,7 +24,7 @@
             http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.1.xsd
             http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
         
-    <ehcache:persistence directory="${java.io.tmpdir}/ehcache/orcid-pub-web/annotations" />
+    <ehcache:persistence directory="${org.orcid.ehcache.dir}/orcid-pub-web/annotations" />
 
     <ehcache:cache alias="country-list" uses-template="defaultTemplate">
         <ehcache:expiry>

--- a/orcid-core/src/main/resources/ehcache_orcid-scheduler-web.xml
+++ b/orcid-core/src/main/resources/ehcache_orcid-scheduler-web.xml
@@ -24,7 +24,7 @@
             http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.1.xsd
             http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
         
-    <ehcache:persistence directory="${java.io.tmpdir}/ehcache/orcid-scheduler-web/annotations" />
+    <ehcache:persistence directory="${org.orcid.ehcache.dir}/orcid-scheduler-web/annotations" />
 
     <ehcache:cache alias="country-list" uses-template="defaultTemplate">
         <ehcache:expiry>

--- a/orcid-core/src/main/resources/ehcache_orcid-web.xml
+++ b/orcid-core/src/main/resources/ehcache_orcid-web.xml
@@ -24,7 +24,7 @@
             http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.1.xsd
             http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.1.xsd">
         
-    <ehcache:persistence directory="${java.io.tmpdir}/ehcache/orcid-web/annotations" />
+    <ehcache:persistence directory="${org.orcid.ehcache.dir}/orcid-web/annotations" />
 
     <ehcache:cache alias="country-list" uses-template="defaultTemplate">
         <ehcache:expiry>

--- a/orcid-core/src/main/resources/orcid-core-context.xml
+++ b/orcid-core/src/main/resources/orcid-core-context.xml
@@ -1018,7 +1018,7 @@
 		class="org.orcid.core.utils.OrcidEhCacheManagerFactoryBean" >
 	</bean>
 	
-	<bean id="springCoreCacheManager" class="org.springframework.cache.jcache.JCacheCacheManager">
+	<bean id="springCoreCacheManager" class="org.springframework.cache.jcache.JCacheCacheManager" depends-on="coreCacheManager">
 	    <property name="cacheManager">
 	        <bean class="org.springframework.cache.jcache.JCacheManagerFactoryBean">
 	            <property name="cacheManagerUri" value="classpath:ehcache#{orcidUrlManager.appNameSuffix}.xml" />


### PR DESCRIPTION
Use system property org.orcid.ehcache.dir for ehcache files, and default to random subdirectory of java.io.tmpdir if not set.