### PR TITLE
Corrected biography visibility to use defaultVis.name() rather than (…

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/Jaxb2JpaAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/Jaxb2JpaAdapterImpl.java
@@ -982,7 +982,7 @@ public class Jaxb2JpaAdapterImpl implements Jaxb2JpaAdapter {
             
             //Fill the visibility in case it is still null
             if(profileEntity.getBiographyEntity().getVisibility() == null) {
-                profileEntity.getBiographyEntity().setVisibility(defaultVisibility.value());
+                profileEntity.getBiographyEntity().setVisibility(defaultVisibility.name());
             }
         }
     }


### PR DESCRIPTION
…lower case) value()