### PR TITLE
Removing ActivitiesStatusDaoTest's test-order dependency

### DIFF
--- a/orcid-message-listener/src/test/java/org/orcid/listener/persistence/managers/ActivitiesStatusManagerTest.java
+++ b/orcid-message-listener/src/test/java/org/orcid/listener/persistence/managers/ActivitiesStatusManagerTest.java
@@ -72,6 +72,7 @@ public class ActivitiesStatusManagerTest {
         assertNotNull(entity);
         assertEquals(orcid, entity.getId());
         assertEquals(Integer.valueOf(3), entity.getEducationsStatus());
+        activitiesStatusManager.markAsSent(orcid, ActivityType.EDUCATIONS);
     }
 
     @Test


### PR DESCRIPTION
ActivitiesStatusDaoTest fails when run after ActivitiesStatusManagerTest. More specifically, ActivitiesStatusDaoTest.getFailedElementsTest fails when run after ActivitiesStatusManagerTest.markAsFailedTest since markAsFailedTest adds a new failed element and getFailedElementsTest counts the extra failed element, leading to an assertion failure. The proposed patch is to set the element to be sent at the end of markAsFailedTest. Removing the test-order dependency allows these tests to be run in any order.

Ideally, it would be good to remove the added elements entirely at the end of the test, but I could not find the relevant API call to do this. I would be happy to discuss the patch more.