### PR TITLE
Removing RecordStatusManagerTest's test-order dependency

### DIFF
--- a/orcid-message-listener/src/test/java/org/orcid/listener/persistence/managers/RecordStatusManagerTest.java
+++ b/orcid-message-listener/src/test/java/org/orcid/listener/persistence/managers/RecordStatusManagerTest.java
@@ -57,6 +57,7 @@ public class RecordStatusManagerTest {
 		assertNotNull(entity);
 		assertEquals(orcid, entity.getId());
 		assertEquals(Integer.valueOf(3), entity.getDumpStatus20Api());
+		recordStatusManager.markAsSent(orcid, AvailableBroker.DUMP_STATUS_2_0_API);
 	}
 	
 	@Test


### PR DESCRIPTION
Similar to #5130, RecordStatusDaoTest fails when run after RecordStatusManagerTest. The failure is due to same reason as in #5130, concerning extra failed elements added in RecordStatusManagerTest.markAsFailedTest. The proposed patch is similar to what was proposed in #5130 as well.