### PR TITLE
Fix notification with null source-name

### DIFF
--- a/orcid-web/src/main/resources/freemarker/includes/ng2_templates/notifications-ng2-template.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/ng2_templates/notifications-ng2-template.ftl
@@ -37,7 +37,7 @@
                             <td (click)="toggleDisplayBody(notification.putCode)">
                                 <i class="glyphicon-chevron-down glyphicon x0" [ngClass]="{'glyphicon-chevron-right':!displayBody[notification.putCode]}"></i>
                                 <span *ngIf="notification.overwrittenSourceName">{{notification.overwrittenSourceName}}</span>
-                                <span *ngIf="!notification.overwrittenSourceName && notification.source" >{{notification.source.sourceName.content}}</span><span *ngIf="!notification.overwrittenSourceName && !notification.source">ORCID</span>
+                                <span *ngIf="!notification.overwrittenSourceName && notification.source && notification.source.sourceName" >{{notification.source.sourceName.content}}</span><span *ngIf="!notification.overwrittenSourceName && !notification.source || !notification.source.sourceName">ORCID</span>
                             </td>
                             <td (click)="toggleDisplayBody(notification.putCode)"><span >{{notification.subject}}</span></td>
                             <td (click)="toggleDisplayBody(notification.putCode)"><span >{{notification.createdDate | date:'yyyy-MM-dd'}}</span></td>


### PR DESCRIPTION
For this solution if the `notification.source.sourceName` is null the displayed name is going to be "Orcid". As apparently was initially intended when the verification for null `notification.source` displayed "Orcid". 

The main difference is that  is that if `sourceName` is null, this is going to display "Orcid" no matter if `notification.overwrittenSourceName`  is true or false. 