### PR TITLE
Remove npm vulnerability

### DIFF
--- a/orcid-web/src/main/webapp/static/javascript/ng1Orcid/package.json
+++ b/orcid-web/src/main/webapp/static/javascript/ng1Orcid/package.json
@@ -50,7 +50,6 @@
     "html-loader": "0.5.5",
     "http-server": "0.11.1",
     "lite-server": "^2.4.0",
-    "lodash": "4.17.10",
     "rimraf": "2.6.2",
     "ts-loader": "4.3.1",
     "tslint": "5.10.0",


### PR DESCRIPTION
This is going to remove the GitHub alert. The dependency is being removed since we are not using it. 