### PR TITLE
Add "Authorization" to allowed CORS headers

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/web/filters/CorsFilterWeb.java
+++ b/orcid-core/src/main/java/org/orcid/core/web/filters/CorsFilterWeb.java
@@ -51,7 +51,7 @@ public class CorsFilterWeb extends OncePerRequestFilter {
                 if (request.getHeader("Access-Control-Request-Method") != null && "OPTIONS".equals(request.getMethod())) {
                     // CORS "pre-flight" request
                     response.addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
-                    response.addHeader("Access-Control-Allow-Headers", "X-Requested-With,Origin,Content-Type,Accept,x-csrf-token");
+                    response.addHeader("Access-Control-Allow-Headers", "X-Requested-With,Origin,Content-Type,Accept,Authorization,x-csrf-token");
                 }
             }
 


### PR DESCRIPTION
Requests to `/oauth/userinfo` are authenticated using a Bearer token in the `Authorization` header, so this needs to be added to the list of allowed headers in `Access-Control-Allow-Headers`.

fixes #5675