### PR TITLE
fix contact support button in spam error modal

### DIFF
--- a/orcid-web/src/main/resources/freemarker/includes/ng2_templates/spam-error-message-ng2-template.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/ng2_templates/spam-error-message-ng2-template.ftl
@@ -4,7 +4,7 @@
         <br />
         <div class="row">
             <div class="col-xs-6">
-                <button class="spam-button-left btn btn-white-no-border" ><@orcid.msg 'freemarker.btnContactSupport'/></button>
+                <a role="button" href="https://support.orcid.org/hc/en-us/requests/new" target="_blank" class="spam-button-left btn btn-white-no-border" ><@orcid.msg 'freemarker.btnContactSupport'/></a>
             </div>
             <div class="col-xs-6">
                 <button class="spam-button btn btn-white-no-border" (click)="close()"><@orcid.msg 'freemarker.btnclose'/></button>


### PR DESCRIPTION
https://trello.com/c/IXDeQZa5/6642-qa-contact-support-button-in-report-spam-modal-doesnt-work