### PR TITLE
Hide tooltip if an anchor tag is displayed

### DIFF
--- a/orcid-web/src/main/resources/freemarker/includes/ng2_templates/websites-form-ng2-template.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/ng2_templates/websites-form-ng2-template.ftl
@@ -114,7 +114,7 @@
                                                             <input type="text" class="input-url-websites" [(ngModel)]="website.urlName" *ngIf="website.source == orcidId" [focusMe]="newInput" [ngClass]="{'focusInput' : !website.urlName}"placeholder="${springMacroRequestContext.getMessage('manual_work_form_contents.labeldescription')}" />
                                                             <div class="form-inline">
                                                                 <input class="website-value input-url-websites" type="text" [(ngModel)]="website.url.value" *ngIf="website.source == orcidId" placeholder="${springMacroRequestContext.getMessage('common.url')}" />
-                                                                <div class="popover-help-container tooltip-url-websites">
+                                                                <div *ngIf="website.source == orcidId" class="popover-help-container tooltip-url-websites">
                                                                     <i class="glyphicon glyphicon-question-sign"></i>
                                                                     <div id="widget-help" class="popover bottom">
                                                                         <div class="arrow"></div>


### PR DESCRIPTION
https://trello.com/c/f48kzGUU/6687-qa-url-tooltip-not-entirely-visible-for-urls-added-via-api