### PR TITLE
fix long resource and url tooltip in ie11

### DIFF
--- a/orcid-web/src/main/webapp/static/css/orcid.new.css
+++ b/orcid-web/src/main/webapp/static/css/orcid.new.css
@@ -2541,7 +2541,8 @@ ul.workspace-private-toolbar li.bulk-checkbox-item input {
 }
 
 .popover-pos .popover-help-container .popover {
-    min-width: 250px
+    min-width: 250px;
+    max-width: 650px;
 }
 
 .workspace-top .popover.bottom .arrow {
@@ -4200,7 +4201,7 @@ ul#body-membership-list>li {
     display: block;
     float: left;
     font-size: 13px;
-    word-break: break-word;
+    word-break: break-all;
 }
 
 .id-details a,.validations li,.versions li {
@@ -5708,7 +5709,8 @@ ul.oauth-scopes li {
 
 .url-popover .popover-help-container .popover {
     left: 0;
-    top: 15px
+    top: 15px;
+    word-break: break-all;
 }
 
 .url-popover .popover.bottom .arrow {


### PR DESCRIPTION
https://trello.com/c/8vRb5Os0/6801-peer-review-with-long-source-work-id-breaks-ui