### PR TITLE
add missing warning message in client edit

### DIFF
--- a/orcid-web/src/main/resources/freemarker/includes/ng2_templates/client-edit-ng2-template.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/ng2_templates/client-edit-ng2-template.ftl
@@ -117,6 +117,9 @@
                             <div class="inner-row margin-left-fix">                         
                                 <input type="text" placeholder="<@orcid.msg 'manage.developer_tools.group.redirect_uri_placeholder'/>" class="input-xlarge ruri" [(ngModel)]="rUri.value.value" />                                                         
                                 <a (click)="deleteUriOnNewClient(index)" class="glyphicon glyphicon-trash grey"></a>
+                                <span class="orcid-error https-error" *ngIf="rUri.value.value && !rUri.value.value.startsWith('https')">
+                                	<@orcid.msg 'manage.developer_tools.website_not_https'/>
+                                </span>
                                 <span class="orcid-error" *ngIf="rUri?.errors?.length > 0">
                                     <div *ngFor='let error of rUri.errors' [innerHTML]="error"></div>
                                 </span>                                 

--- a/orcid-web/src/main/resources/freemarker/includes/ng2_templates/client-edit-ng2-template.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/ng2_templates/client-edit-ng2-template.ftl
@@ -404,6 +404,9 @@
                             <div class="inner-row margin-left-fix">                         
                                 <input type="text" class="input-xlarge ruri" [(ngModel)]="rUri.value.value" placeholder="<@orcid.msg 'manage.developer_tools.group.redirect_uri_placeholder'/>"/>
                                 <a (click)="deleteUriOnExistingClient(index)" class="glyphicon glyphicon-trash grey pull-right"></a>
+                                <span class="orcid-error https-error" *ngIf="rUri.value.value && !rUri.value.value.startsWith('https')">
+                                	<@orcid.msg 'manage.developer_tools.website_not_https'/>
+                                </span>
                                 <span class="orcid-error" *ngIf="rUri?.errors?.length > 0">
                                     <div *ngFor='let error of rUri.errors' [innerHTML]="error"></div>
                                 </span>                                                                                             


### PR DESCRIPTION
https://trello.com/c/lLQX6aIW/6962-show-warning-message-to-prevent-http-redirect-uris-being-added-to-clients