### PR TITLE
display warning error only in production

### DIFF
--- a/orcid-web/src/main/resources/freemarker/includes/ng2_templates/client-edit-ng2-template.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/ng2_templates/client-edit-ng2-template.ftl
@@ -117,7 +117,7 @@
                             <div class="inner-row margin-left-fix">                         
                                 <input type="text" placeholder="<@orcid.msg 'manage.developer_tools.group.redirect_uri_placeholder'/>" class="input-xlarge ruri" [(ngModel)]="rUri.value.value" />                                                         
                                 <a (click)="deleteUriOnNewClient(index)" class="glyphicon glyphicon-trash grey"></a>
-                                <span class="orcid-error https-error" *ngIf="rUri.value.value && !rUri.value.value.startsWith('https')">
+                                <span class="orcid-error https-error" *ngIf="getBaseUri().startsWith('https://orcid.org') && rUri.value.value && !rUri.value.value.startsWith('https')">
                                 	<@orcid.msg 'manage.developer_tools.website_not_https'/>
                                 </span>
                                 <span class="orcid-error" *ngIf="rUri?.errors?.length > 0">
@@ -404,7 +404,7 @@
                             <div class="inner-row margin-left-fix">                         
                                 <input type="text" class="input-xlarge ruri" [(ngModel)]="rUri.value.value" placeholder="<@orcid.msg 'manage.developer_tools.group.redirect_uri_placeholder'/>"/>
                                 <a (click)="deleteUriOnExistingClient(index)" class="glyphicon glyphicon-trash grey pull-right"></a>
-                                <span class="orcid-error https-error" *ngIf="rUri.value.value && !rUri.value.value.startsWith('https')">
+                                <span class="orcid-error https-error" *ngIf="getBaseUri().startsWith('https://orcid.org') && rUri.value.value && !rUri.value.value.startsWith('https')">
                                 	<@orcid.msg 'manage.developer_tools.website_not_https'/>
                                 </span>
                                 <span class="orcid-error" *ngIf="rUri?.errors?.length > 0">

--- a/orcid-web/src/main/resources/freemarker/includes/ng2_templates/developer-tools-ng2-template.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/ng2_templates/developer-tools-ng2-template.ftl
@@ -117,7 +117,7 @@
                                 <h4><@orcid.msg 'manage.developer_tools.redirect_uri'/></h4>                        
                                 <div *ngFor="let rUri of client.redirectUris; index as idx;">                            
                                     <input type="text" placeholder="<@orcid.msg 'manage.developer_tools.redirect_uri.placeholder'/>" [(ngModel)]="rUri.value.value">
-                                    <span class="orcid-error https-error" *ngIf="rUri.value.value && !rUri.value.value.startsWith('https')">
+                                    <span class="orcid-error https-error" *ngIf="getBaseUri().startsWith('https://orcid.org') && rUri.value.value && !rUri.value.value.startsWith('https')">
                                         <@orcid.msg 'manage.developer_tools.website_not_https'/>
                                     </span>
                                     <a (click)="deleteRedirectUri(idx);" class="glyphicon glyphicon-trash blue"></a>

--- a/orcid-web/src/main/resources/freemarker/includes/ng2_templates/manage-member-find-client-ng2-template.ftl
+++ b/orcid-web/src/main/resources/freemarker/includes/ng2_templates/manage-member-find-client-ng2-template.ftl
@@ -120,7 +120,7 @@
 									<!-- URI -->
 									<div class="col-md-12 col-sm-12 col-xs-12">
 										<input type="text" [(ngModel)]="rUri.value.value" class="input-xlarge">
-										<span class="orcid-error https-error" *ngIf="rUri.value.value && !rUri.value.value.startsWith('https')">
+										<span class="orcid-error https-error" *ngIf="getBaseUri().startsWith('https://orcid.org') && rUri.value.value && !rUri.value.value.startsWith('https')">
                                 			<@orcid.msg 'manage.developer_tools.website_not_https'/>
                                     	</span>
 										<a *ngIf="_client.type.value == 'public-client'" href="" id="delete-redirect-uri" (click)="deleteRedirectUri(i)" class="glyphicon glyphicon-trash grey"></a>


### PR DESCRIPTION
https://trello.com/c/pPanvRsM/7069-show-warning-message-only-in-production-to-prevent-http-redirect-uris-being-added-to-clients