### PR TITLE
fix oauth session should not continue if user navigates to signin or …

### DIFF
--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/BaseController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/BaseController.java
@@ -573,8 +573,8 @@ public class BaseController {
 
     protected String calculateRedirectUrl(HttpServletRequest request, HttpServletResponse response, boolean justRegistered) {
         String targetUrl = null;
-        Boolean isOauth2ScreensRequest = (Boolean) request.getSession().getAttribute(OrcidOauth2Constants.OAUTH_2SCREENS);
-        if (isOauth2ScreensRequest != null && isOauth2ScreensRequest) {
+        Boolean isOauth2ScreensRequest = (Boolean) request.getSession().getAttribute(OrcidOauth2Constants.OAUTH_2SCREENS);       
+        if (isOauth2ScreensRequest != null && isOauth2ScreensRequest && request.getQueryString() != null && !request.getQueryString().isEmpty()) {
             // Just redirect to the authorization screen
             String queryString = (String) request.getSession().getAttribute(OrcidOauth2Constants.OAUTH_QUERY_STRING);
             targetUrl = orcidUrlManager.getBaseUrl() + "/oauth/authorize?" + queryString;


### PR DESCRIPTION
https://trello.com/c/N6WgO5E8/7093-qa-oauth-session-should-not-persist-after-the-user-abandons-the-authorization-screen