### PR TITLE
Update Member doc page

### DIFF
--- a/orcid-api-web/README.md
+++ b/orcid-api-web/README.md
@@ -153,7 +153,7 @@ Request a second - Number of request that can be made a second.
 
 * [Documentation on the latest XSD version](https://github.com/ORCID/orcid-model/blob/master/src/main/resources/record_2.1/README.md)
 
-* [Members.orcid.org](https://members.orcid.org/api/) for detailed tutorials and workflows
+* [Member Integration Guide](https://info.orcid.org/documentation/integration-guide/) for detailed workflows and information for integrators using the ORCID Member API
 
 ## Tutorials and API Version Specific Docs
 


### PR DESCRIPTION
Update Member doc page as members.orcid.org was sunset as part of the website migration.