### PR TITLE
Update funding.md

### DIFF
--- a/orcid-api-web/tutorial/funding.md
+++ b/orcid-api-web/tutorial/funding.md
@@ -53,7 +53,7 @@ Editing the funding section of a record requires a 3 step OAuth token with the `
 
 - **end-date** _(optional)_ The date the funding ended or will end
 
-- **external-id-type** _(required)_ The type of identifier. This field must be set to ```grant_number```
+- **external-id-type** _(required)_ The type of identifier.
 
 - **external-id-value** _(required)_ The identifier itself
 


### PR DESCRIPTION
Removing sentence that said external-id-type must be set to grant_number.