### PR TITLE
Fixes as required by product for typeahead

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/manager/OrgDisambiguatedManager.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/OrgDisambiguatedManager.java
@@ -35,6 +35,6 @@ public interface OrgDisambiguatedManager {
 
     void createOrgDisambiguatedExternalIdentifier(OrgDisambiguatedExternalIdentifierEntity identifier);
     
-    public List<OrgDisambiguated> findOrgDisambiguatedIdsForSameExternalIdentifier(String type, String identifier);
+    public List<OrgDisambiguated> findOrgDisambiguatedIdsForSameExternalIdentifier(String identifier, String type);
 
 }

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/OrgDisambiguatedManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/OrgDisambiguatedManagerImpl.java
@@ -97,6 +97,7 @@ public class OrgDisambiguatedManagerImpl implements OrgDisambiguatedManager {
             entities = orgDisambiguatedDaoReadOnly.findOrgsToGroup(startIndex, INDEXING_CHUNK_SIZE);
             LOGGER.info("GROUP: Found chunk of {} disambiguated orgs for indexing as group", entities.size());
             for (OrgDisambiguatedEntity entity : entities) {
+                
                 new OrgGrouping(entity, this).markGroupForIndexing(orgDisambiguatedDao);
             }
             startIndex = startIndex + entities.size();
@@ -263,9 +264,9 @@ public class OrgDisambiguatedManagerImpl implements OrgDisambiguatedManager {
         orgDisambiguatedExternalIdentifierDao.merge(identifier);
     }
 
-    public List<OrgDisambiguated> findOrgDisambiguatedIdsForSameExternalIdentifier(String type, String identifier) {
+    public List<OrgDisambiguated> findOrgDisambiguatedIdsForSameExternalIdentifier( String identifier, String type ) {
         List<OrgDisambiguated> orgDisambiguatedIds = new ArrayList<OrgDisambiguated>();
-        List<OrgDisambiguatedExternalIdentifierEntity> extIds = orgDisambiguatedExternalIdentifierDao.findByIdentifierIdAndType(type, identifier);
+        List<OrgDisambiguatedExternalIdentifierEntity> extIds = orgDisambiguatedExternalIdentifierDao.findByIdentifierIdAndType(identifier, type);
         extIds.stream().forEach((e) -> orgDisambiguatedIds.add(convertEntity(e.getOrgDisambiguated())));
         return orgDisambiguatedIds;
     }

--- a/orcid-core/src/main/java/org/orcid/core/orgs/grouping/OrgGrouping.java
+++ b/orcid-core/src/main/java/org/orcid/core/orgs/grouping/OrgGrouping.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
 
+import org.apache.commons.lang3.StringUtils;
+import org.datacite.schema.kernel_4.FunderIdentifierType;
 import org.orcid.core.manager.OrgDisambiguatedManager;
 import org.orcid.core.orgs.OrgDisambiguatedSourceType;
 import org.orcid.persistence.constants.OrganizationStatus;
@@ -97,11 +99,14 @@ public class OrgGrouping implements Serializable {
                             if (!orgGroup.getOrgs().containsKey(orgKey)) {
                                 orgGroup.getOrgs().put(orgKey, org);
                             }
-                        } else {
-                            // check other possible orgs that have the same
-                            // identifier
+                        } 
+
+                    }
+                    else {
+                        // check other possible orgs that have the same ISNI identifier
+                        if(StringUtils.equals(externalIdentifiers.getIdentifierType(), FunderIdentifierType.ISNI.value())){
                             List<OrgDisambiguated> orgsFromExternalIdentifier = orgDisambiguatedManager
-                                    .findOrgDisambiguatedIdsForSameExternalIdentifier(externalIdentifiers.getIdentifierType(), externalIdentifier);
+                                    .findOrgDisambiguatedIdsForSameExternalIdentifier(externalIdentifier, externalIdentifiers.getIdentifierType());
                             if (orgsFromExternalIdentifier != null) {
                                 orgsFromExternalIdentifier.stream().forEach((o -> {
                                     String key = buildOrgDisambiguatedKey(o);
@@ -114,7 +119,6 @@ public class OrgGrouping implements Serializable {
                                 }));
                             }
                         }
-
                     }
                 }
             }

--- a/orcid-core/src/main/java/org/orcid/core/solr/OrcidSolrOrgsClient.java
+++ b/orcid-core/src/main/java/org/orcid/core/solr/OrcidSolrOrgsClient.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrcidSolrOrgsClient {
 
-    private static final String SOLR_ORGS_QUERY = "(org-disambiguated-name:%s)^100.0 (org-disambiguated-name-string:%s)^50.0";
+    private static final String SOLR_ORGS_QUERY = "(org-disambiguated-name-string:%s)^100.0 (org-disambiguated-name:%s)^50.0";
     private static final String SOLR_SELF_SERVICE_ORGS_QUERY = "(org-disambiguated-id-from-source:%s)^50.0 (org-disambiguated-name%s)^50.0 (org-disambiguated-name-string:%s)^25.0";
 
     @Resource(name = "solrReadOnlyOrgsClient")
@@ -61,8 +61,7 @@ public class OrcidSolrOrgsClient {
             query.addOrUpdateSort("org-disambiguated-popularity", ORDER.desc);
         }
 
-        query.addFilterQuery(String.format("(%s:(%s OR %s OR %s)) OR (%s:%s)", SolrConstants.ORG_DISAMBIGUATED_ID_SOURCE_TYPE, "ROR", "RINGGOLD", "FUNDREF",
-                SolrConstants.ORG_DISAMBIGUATED_ID_SOURCE_TYPE, "LEI"));
+        query.addFilterQuery(String.format("(%s:(%s OR %s OR %s))", SolrConstants.ORG_DISAMBIGUATED_ID_SOURCE_TYPE, "ROR", "RINGGOLD", "FUNDREF"));
 
         try {
             QueryResponse queryResponse = solrReadOnlyOrgsClient.query(query);

--- a/orcid-core/src/main/java/org/orcid/core/solr/OrcidSolrOrgsClient.java
+++ b/orcid-core/src/main/java/org/orcid/core/solr/OrcidSolrOrgsClient.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrcidSolrOrgsClient {
 
-    private static final String SOLR_ORGS_QUERY = "(org-disambiguated-name-string:%s)^100.0 (org-disambiguated-name:%s)^50.0";
+    private static final String SOLR_ORGS_QUERY = "(org-disambiguated-name:%s)^50.0 (org-disambiguated-name-string:%s)^50.0";
     private static final String SOLR_SELF_SERVICE_ORGS_QUERY = "(org-disambiguated-id-from-source:%s)^50.0 (org-disambiguated-name%s)^50.0 (org-disambiguated-name-string:%s)^25.0";
 
     @Resource(name = "solrReadOnlyOrgsClient")

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedDaoImpl.java
@@ -87,12 +87,9 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     @Override
     public List<OrgDisambiguatedEntity> findOrgsToGroup(int firstResult, int maxResult) {
         TypedQuery<OrgDisambiguatedEntity> query = entityManager.createQuery(
-                "from OrgDisambiguatedEntity where (source_type=:ROR or source_type=:FUNDREF or source_type=:RINGGOLD) and status !=:status",
+                "from OrgDisambiguatedEntity where source_type=:ROR",
                 OrgDisambiguatedEntity.class);
         query.setParameter("ROR", "ROR");
-        query.setParameter("RINGGOLD", "RINGGOLD");
-        query.setParameter("FUNDREF", "FUNDREF");
-        query.setParameter("status", "PART_OF_GROUP");
         query.setFirstResult(firstResult);
         query.setMaxResults(maxResult);
         return query.getResultList();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedExternalIdentifierDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedExternalIdentifierDaoImpl.java
@@ -8,10 +8,14 @@ import javax.persistence.TypedQuery;
 
 import org.orcid.persistence.dao.OrgDisambiguatedExternalIdentifierDao;
 import org.orcid.persistence.jpa.entities.OrgDisambiguatedExternalIdentifierEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 public class OrgDisambiguatedExternalIdentifierDaoImpl extends GenericDaoImpl<OrgDisambiguatedExternalIdentifierEntity, Long>
         implements OrgDisambiguatedExternalIdentifierDao {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrgDisambiguatedExternalIdentifierDaoImpl.class);
 
     public OrgDisambiguatedExternalIdentifierDaoImpl() {
         super(OrgDisambiguatedExternalIdentifierEntity.class);
@@ -70,7 +74,8 @@ public class OrgDisambiguatedExternalIdentifierDaoImpl extends GenericDaoImpl<Or
         TypedQuery<OrgDisambiguatedExternalIdentifierEntity> query = entityManager.createQuery("FROM OrgDisambiguatedExternalIdentifierEntity WHERE identifier = :identifier AND identifierType = :identifierType",
                 OrgDisambiguatedExternalIdentifierEntity.class);
         query.setParameter("identifier", identifier);
-        query.setParameter("identifierType", identifierType);
+        query.setParameter("identifierType", identifierType);;
+        LOGGER.info("OrgDisambiguatedExternalIdentifier by id and type: [" + query.toString() + "]");
         return query.getResultList();
     }
 

--- a/solr-config/cores/fundingSubType/conf/stopwords.txt
+++ b/solr-config/cores/fundingSubType/conf/stopwords.txt
@@ -13,4 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-university

--- a/solr-config/cores/org/conf/stopwords.txt
+++ b/solr-config/cores/org/conf/stopwords.txt
@@ -13,4 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-university

--- a/solr-config/cores/profile/conf/stopwords.txt
+++ b/solr-config/cores/profile/conf/stopwords.txt
@@ -12,5 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-university


### PR DESCRIPTION
Implemented the following:

Stopword is not working, but that's OK. We actually want to remove it from the acceptance criteria anyway
LEI is still being indexed, let's remove from index AND filter on query
Not all RINGGOLDS linked to RORs, so lets make that happen ( thru ISNI)
Switch org-disambiguated-name-string and org-disambiguated-name. The string version should have the bigger boost for exact matches.