### PR TITLE
fix: Update orcid-model to support affiliation types v3 in notificati…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -917,7 +917,7 @@ the software.
             <dependency>
                <groupId>org.orcid</groupId>
                <artifactId>orcid-model</artifactId>
-               <version>3.0.10</version>
+               <version>3.0.11</version>
             </dependency>
             <dependency>
                <groupId>org.orcid</groupId>


### PR DESCRIPTION
Do not merge until [orcid-model](https://oss.sonatype.org/#nexus-search;quick~org.orcid) 3.0.11  is published