### PR TITLE
fix: Add missing external url and relationship fields in notification…

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/v3/impl/MapperFacadeFactory.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/v3/impl/MapperFacadeFactory.java
@@ -327,8 +327,13 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
         amendNotificationClassMap.field("items.items", "notificationItems");
         mapCommonFields(amendNotificationClassMap).register();
 
-        mapperFactory.classMap(NotificationItemEntity.class, Item.class).fieldMap("externalIdType", "externalIdentifier.type").converter("externalIdentifierIdConverter")
-                .add().field("externalIdValue", "externalIdentifier.value").customize(new CustomMapper<NotificationItemEntity, Item>() {
+        ClassMapBuilder<NotificationItemEntity, Item> itemClassMap = mapperFactory.classMap(NotificationItemEntity.class, Item.class);
+        itemClassMap.fieldMap("externalIdType", "externalIdentifier.type").converter("externalIdentifierIdConverter").add();
+        itemClassMap.field("externalIdValue", "externalIdentifier.value");
+        itemClassMap.field("externalIdUrl", "externalIdentifier.url.value");
+        itemClassMap.field("externalIdRelationship", "externalIdentifier.relationship");
+
+        itemClassMap.customize(new CustomMapper<NotificationItemEntity, Item>() {
                     @Override
                     public void mapAtoB(NotificationItemEntity entity, Item item, MappingContext context) {
                         if (!PojoUtil.isEmpty(entity.getAdditionalInfo())) {

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbNotificationAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbNotificationAdapterTest.java
@@ -12,8 +12,10 @@ import javax.annotation.Resource;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.orcid.jaxb.model.common.Relationship;
 import org.orcid.jaxb.model.v3.release.common.Source;
 import org.orcid.jaxb.model.v3.release.common.SourceClientId;
+import org.orcid.jaxb.model.v3.release.common.Url;
 import org.orcid.jaxb.model.v3.release.notification.Notification;
 import org.orcid.jaxb.model.v3.release.notification.NotificationType;
 import org.orcid.jaxb.model.v3.release.notification.amended.NotificationAmended;
@@ -110,6 +112,8 @@ public class JpaJaxbNotificationAdapterTest {
         activity.setExternalIdentifier(extId);
         extId.setType("doi");
         extId.setValue("1234/abc123");
+        extId.setUrl(new Url("https://example.com/1234/abc123"));
+        extId.setRelationship(Relationship.SELF);
 
         NotificationEntity notificationEntity = jpaJaxbNotificationAdapter.toNotificationEntity(notification);
 
@@ -135,7 +139,9 @@ public class JpaJaxbNotificationAdapterTest {
         assertEquals(org.orcid.jaxb.model.notification.permission_v2.ItemType.WORK.name(), activityEntity.getItemType());
         assertEquals("Latest Research Article", activityEntity.getItemName());
         assertEquals("DOI", activityEntity.getExternalIdType());
-        assertEquals("1234/abc123", activityEntity.getExternalIdValue());        
+        assertEquals("1234/abc123", activityEntity.getExternalIdValue());
+        assertEquals("https://example.com/1234/abc123", activityEntity.getExternalIdUrl());
+        assertEquals("SELF", activityEntity.getExternalIdRelationship());
     }
 
     @Test

--- a/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/NotificationItemEntity.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/jpa/entities/NotificationItemEntity.java
@@ -24,6 +24,8 @@ public class NotificationItemEntity extends BaseEntity<Long> {
     private String itemName;
     private String externalIdType;
     private String externalIdValue;
+    private String externalIdUrl;
+    private String externalIdRelationship;
     private String actionType;
     private String additionalInfo;
     
@@ -75,6 +77,25 @@ public class NotificationItemEntity extends BaseEntity<Long> {
         this.externalIdValue = externalIdValue;
     }
 
+    @Column(name = "external_id_url")
+    public String getExternalIdUrl() {
+        return externalIdUrl;
+    }
+
+    public void setExternalIdUrl(String externalIdUrl) {
+        this.externalIdUrl = externalIdUrl;
+    }
+
+    @Column(name = "external_id_relationship")
+    public String getExternalIdRelationship() {
+        return externalIdRelationship;
+    }
+
+    public void setExternalIdRelationship(String externalIdRelationship) {
+        this.externalIdRelationship = externalIdRelationship;
+    }
+
+    
     @Column(name = "action_type")
     public String getActionType() {
         return actionType;

--- a/orcid-persistence/src/main/resources/db-master.xml
+++ b/orcid-persistence/src/main/resources/db-master.xml
@@ -363,4 +363,5 @@
   <include file="/db/updates/identifier-types/update-pmc-resolution-prefix.xml" />
   <include file="/db/updates/profile_lock_cols.xml" />
   <include file="/db/updates/add_top_contributors_json_to_work.xml" />
+  <include file="/db/updates/add_external_url_and_relationship_to_notification_item.xml" />
 </databaseChangeLog>

--- a/orcid-persistence/src/main/resources/db/updates/add_external_url_and_relationship_to_notification_item.xml
+++ b/orcid-persistence/src/main/resources/db/updates/add_external_url_and_relationship_to_notification_item.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="Daniel Palafox" id="ADD-EXTERNAL-URL-AND-RELATIONSHIP-TO-NOTIFICATION-ITEM">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <and>
+                    <columnExists tableName="notification_item" columnName="external_id_url"/>
+                    <columnExists tableName="notification_item" columnName="external_id_relationship"/>
+                </and>
+            </not>
+        </preConditions>
+        <addColumn tableName="notification_item">
+            <column name="external_id_url" type="VARCHAR(255)" />
+            <column name="external_id_relationship" type="VARCHAR(255)" />
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [[QA] External ID relationship type and url in notifications not returned by API](https://trello.com/c/0uBCetx2/8193-qa-external-id-relationship-type-and-url-in-notifications-not-returned-by-api)