### PR TITLE
build: Rollback spring security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ the software.
 
     <properties>
         <spring.version>5.3.20</spring.version>
-        <security.version>5.6.4</security.version>
+        <security.version>5.6.2</security.version>
         <liquibase.version>4.9.1</liquibase.version>
         <jersey.version>1.19.1</jersey.version>
         <swagger.version>1.5.16</swagger.version>


### PR DESCRIPTION
The latest version of spring security is accepting only readable ASCII codes in the URL which causes a problem when you are looking for an element with an unicode i.e `Université de Montréal`