### PR TITLE
feature/add-trelloflow-config

### DIFF
--- a/.trello
+++ b/.trello
@@ -9,6 +9,6 @@ trello_in_progress_list_id="50a2a79da535468428000175"
 trello_submitted_list="Ready on this sprint"
 trello_submitted_list_id="50d22ac32c146a385f0010fa"
 
-github_poke_slack_channel=tech-team
+github_poke_slack_channel=team-tech
 
 gitub_pr_default_reviewers=ORCID/orcid-core-ost-open-source-team

--- a/.trello
+++ b/.trello
@@ -1,0 +1,14 @@
+trello_board="ORCID: Registry Current Development"
+
+trello_backlog_list="Sprint Backlog"
+trello_backlog_list_id="5c0555fad616ea6c04f44d2e"
+
+trello_in_progress_list="In progress"
+trello_in_progress_list_id="50a2a79da535468428000175"
+
+trello_submitted_list="Ready on this sprint"
+trello_submitted_list_id="50d22ac32c146a385f0010fa"
+
+github_poke_slack_channel=tech-team
+
+gitub_pr_default_reviewers=ORCID/orcid-core-ost-open-source-team


### PR DESCRIPTION
ORCID > ORCID: Registry Current Development > In Progress > [feature] add trelloflow config
You are subscribed to this card.
1 member: Giles Westwood (you)

If staff install shellkit on their machine they will be able to use the trello flow command now in the registry projects with the command

```
tf --help
```


```
(feature/add-trelloflow-config %)) gwestwood@Giless-MacBook-Pro:~/work/orcid-angular/sk-trello-pick-debug
trello show-cards -b ORCID: Registry Current Development -l Sprint Backlog
dDXewR5M - QA allocated time for documentation and automation - (Sprint MM-DD-YYYY)
DayoVzeb - [R&D] Investigate feasibility of spam ML in sagemaker
BszUB9jU - [BUG] Do not update the last modified when new inbox notifications are created
MD3egOuT - Add a new admin functionality that will allow adding email addresses to iDs where no email is associated
bW0ct0qN - Create an admin function to move a client from one group ID to another
NCr5x0k2 - [Tech] Build the 2022 data dump
tdmPVOYd - [Tech] [On-call] Write slite page for InsightOps
5Oevq3ci - [Tech] [On-call] Write slite page for java thread dumps and heap dumps
NmkPG484 - [Tech] [On-call] Write slite page for Newrelic
5vaZLwtV - [Tech] [On-call] Write slite page for rackspace
zGg64vhg - Works without a publication date should show after works with a publication date
ZrDg65ec - [feature] add trelloflow config

```
