### PR TITLE
Get the last ROR dump available , after  ROR metadata and versioning  change.

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/cli/LoadDataForOrganizationSource.java
+++ b/orcid-core/src/main/java/org/orcid/core/cli/LoadDataForOrganizationSource.java
@@ -1,0 +1,87 @@
+package org.orcid.core.cli;
+
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.orcid.core.orgs.load.manager.OrgLoadManager;
+import org.orcid.core.orgs.load.source.OrgLoadSource;
+import org.orcid.pojo.ajaxForm.PojoUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class LoadDataForOrganizationSource {
+    private static final Logger LOG = LoggerFactory.getLogger(LoadDataForOrganizationSource.class);
+    private OrgLoadManager orgLoadManager;
+    
+
+    private OrgLoadSource rorOrgSource;
+    private OrgLoadSource fundrefOrgSource;
+    private OrgLoadSource ringgoldOrgSource;
+
+    private static final String ROR_TYPE="ROR";
+    private static final String FUNDREF_TYPE="FUNDREF";
+    private static final String RINGGOLD_TYPE="RINGGOLD";
+    
+    
+    
+    @Option(name = "-o", usage = "The organization type. Can be one of the following ROR, FUNDREF, RINGGOLD")
+    private String orgType;
+    
+    /**
+     * Setup our spring resources
+     * 
+     */
+    @SuppressWarnings({ "resource" })
+    private void init() {
+        ApplicationContext context = new ClassPathXmlApplicationContext("orcid-core-context.xml");
+        orgLoadManager = (OrgLoadManager) context.getBean("orgLoadManager");
+        rorOrgSource = (OrgLoadSource) context.getBean("rorOrgDataSource");
+        fundrefOrgSource = (OrgLoadSource) context.getBean("fundrefOrgDataSource");
+        ringgoldOrgSource = (OrgLoadSource) context.getBean("ringgoldOrgDataSource");
+    }
+
+    public static void main(String[] args) {
+        LoadDataForOrganizationSource loadData  = new LoadDataForOrganizationSource();
+        CmdLineParser parser = new CmdLineParser(loadData);
+        // TODO Auto-generated method stub
+        try {
+            parser.parseArgument(args);
+            loadData.validateParameters(parser);
+            loadData.init();
+            if(StringUtils.equalsIgnoreCase(loadData.orgType, FUNDREF_TYPE)) {
+                LOG.info("Loading orgs from Fundref");
+                loadData.orgLoadManager.loadOrg(loadData.fundrefOrgSource);
+            }
+            else if(StringUtils.equalsIgnoreCase(loadData.orgType, RINGGOLD_TYPE)) {
+                LOG.info("Loading orgs from Ringgold");
+                loadData.orgLoadManager.loadOrg(loadData.ringgoldOrgSource);
+            }
+            else { //default to ROR
+                LOG.info("Loading orgs from ROR");
+                loadData.orgLoadManager.loadOrg(loadData.rorOrgSource);
+            }
+  
+        } catch (Exception e) {
+            LOG.error("Exception when importing data for org type: " + loadData.orgType , e);
+            System.err.println(e.getMessage());
+        } finally {
+            System.exit(0);
+        }
+
+    }
+    
+    public void validateParameters(CmdLineParser parser) throws CmdLineException {
+
+        if (PojoUtil.isEmpty(orgType)) {
+            throw new CmdLineException(parser, "-o parameter must not be null.");
+            
+        } else if(!orgType.toUpperCase().equals(ROR_TYPE) && !orgType.toUpperCase().equals(FUNDREF_TYPE)&& !orgType.toUpperCase().equals(RINGGOLD_TYPE)){
+            throw new CmdLineException(parser, "-o parameter must be one of the following.");
+        }
+    }
+
+}

--- a/orcid-core/src/main/java/org/orcid/core/orgs/load/source/ror/RorOrgLoadSource.java
+++ b/orcid-core/src/main/java/org/orcid/core/orgs/load/source/ror/RorOrgLoadSource.java
@@ -106,17 +106,19 @@ public class RorOrgLoadSource implements OrgLoadSource {
             fileRotator.removeFileIfExists(localDataPath);
             orgDataClient.init();
             
-            ZenodoRecords zenodoRecords = orgDataClient.get(rorZenodoRecordsUrl+"&sort=-publication_date&size=1", userAgent,
+            ZenodoRecords zenodoRecords = orgDataClient.get(rorZenodoRecordsUrl+"&sort=mostrecent&size=1", userAgent,
                     new GenericType<ZenodoRecords>() {
                     });
+            
+            
             
             ZenodoRecordsHit zenodoHit = zenodoRecords.getHits().getHits().get(0);
      
             boolean success = false;
             
-            //we are returning the collection ordered by last publication date and size 1, just need to get first element in the list
-            String zenodoUrl = zenodoHit.getFiles().get(0).getLinks().getSelf();
-            
+            //we are returning the collection ordered by mostrecent and size 1, we need to get the last element in the list that has the last version
+            String zenodoUrl = zenodoHit.getFiles().get(zenodoHit.getFiles().size()>0?zenodoHit.getFiles().size()-1:0).getLinks().getSelf();
+            LOGGER.info("Retrieving ROR data from: " + zenodoUrl);
             success = orgDataClient.downloadFile(zenodoUrl, userAgent, zipFilePath);
             orgDataClient.cleanUp();
          

--- a/orcid-core/src/main/resources/orcid-core-context.xml
+++ b/orcid-core/src/main/resources/orcid-core-context.xml
@@ -1550,6 +1550,10 @@
     <bean id="gridOrgDataClient" class="org.orcid.core.orgs.load.io.OrgDataClient" />
     
     <bean id="rorOrgDataClient" class="org.orcid.core.orgs.load.io.OrgDataClient" />
+    
+    <bean id="rorOrgDataSource" class="org.orcid.core.orgs.load.source.ror.RorOrgLoadSource" />
+    <bean id="fundrefOrgDataSource" class="org.orcid.core.orgs.load.source.fundref.FundrefOrgLoadSource" />
+    <bean id="ringgoldOrgDataSource" class="org.orcid.core.orgs.load.source.ringgold.RinggoldOrgLoadSource" />
 
     <bean id="workContributorsConverter" class="org.orcid.core.adapter.v3.converter.WorkContributorsConverter">
         <constructor-arg ref="workContributorRoleConverter" />


### PR DESCRIPTION
As per ROR recommendation now we need to do the following to retrieve the latest file (https://ror.readme.io/docs/data-dump#download-ror-data-dumps-programmatically-with-the-zenodo-api) https://zenodo.org/api/records/?communities=ror-data&sort=mostrecent&size=1
In the response, the most recent record will be hits.hits[0]. Find the latest file attached to this record by checking the last item in hits.hits[0].files. The file URL is in links.self within the file object

I added a cli to be able to load orgs for a type at any time manually  without the need to wait for the weekly schedule. To trigger a load  organization for a specific org type  ( -o can have the supported values FUNDREF, ROR or RINGGOLD)

mvn exec:java -Dexec.args="-o ROR" -Djava.io.tmpdir="/Users/camelia/OrcidDev/github/jdk11/ORCID-Source/orcid-core/tmp" -Dexec.mainClass="org.orcid.core.cli.LoadDataForOrganizationSource" -Dorg.orcid.config.file="file:///Users/camelia/OrcidDev/github/jdk11/ORCID-Source/orcid-core/tmp/orcid.properties" -Dorg.orcid.persistence.messaging.brokerURL=tcp://127.0.0.1:61616?jms.useAsyncSend=true -Dorg.orcid.persistence.messaging.enabled=true