### PR TITLE
Feature/Update-name-of-K10plus-identifier

### DIFF
--- a/orcid-core/src/main/resources/i18n/identifiers_en.properties
+++ b/orcid-core/src/main/resources/i18n/identifiers_en.properties
@@ -48,6 +48,6 @@ org.orcid.jaxb.model.record.WorkExternalIdentifierType.hal= hal\: Hyper Articles
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.grant-number=Grant Number
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.proposal-id=Proposal ID
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.cstr=cstr\: Science and technology resource identification
-org.orcid.jaxb.model.record.WorkExternalIdentifierType.k10plus=k10plus\: K10Plus
+org.orcid.jaxb.model.record.WorkExternalIdentifierType.k10plus=k10plus\: K10plus
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.cgn=cgn\: Culturegraph Number
 

--- a/orcid-core/src/main/resources/i18n/identifiers_es.properties
+++ b/orcid-core/src/main/resources/i18n/identifiers_es.properties
@@ -48,6 +48,6 @@ org.orcid.jaxb.model.record.WorkExternalIdentifierType.hal= hal\: Hiperartículo
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.grant-number=Número de Subvención
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.proposal-id=Identificación de la propuesta
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.cstr=cstr\: Identificación de recursos de ciencia y tecnología
-org.orcid.jaxb.model.record.WorkExternalIdentifierType.k10plus=k10plus\: K10Plus
+org.orcid.jaxb.model.record.WorkExternalIdentifierType.k10plus=k10plus\: K10plus
 org.orcid.jaxb.model.record.WorkExternalIdentifierType.cgn=cgn\: CGN
 


### PR DESCRIPTION
ORCID > ORCID: Registry Current Development > In Progress > [Feature] Update name of K10plus identifier
You are subscribed to this card.
Labels: Require Translations
1 member: Camelia Dumitru (you)

DNB contacted us to request that we update the name of the K10plus identifier from K10Plus to K10plus

**Acceptance Criteria**

- Identifier name shows as K10plus and not K10Plus

‌
