### PR TITLE
qs changed to be in the range of 0 to 1 as in specs

### DIFF
--- a/orcid-api-common/src/main/java/org/orcid/api/common/writer/rdf/RDFMessageBodyWriterV2.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/writer/rdf/RDFMessageBodyWriterV2.java
@@ -45,9 +45,11 @@ import org.orcid.jaxb.model.record_v2.Person;
 import org.orcid.jaxb.model.record_v2.Record;
 import org.orcid.jaxb.model.record_v2.ResearcherUrl;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 //Record
 @Provider
+@Component
 @Produces({ APPLICATION_RDFXML, TEXT_TURTLE, TEXT_N3, N_TRIPLES })
 public class RDFMessageBodyWriterV2 implements MessageBodyWriter<Record>{
     
@@ -441,32 +443,32 @@ public class RDFMessageBodyWriterV2 implements MessageBodyWriter<Record>{
     }
 
     private void describePersonalDetails(Name name, Individual person, OntModel m) {
-        
-        if (name.getCreditName() != null) {
-            // User has provided full name
-            String creditName = name.getCreditName().getContent();
-            person.addProperty(FOAF.name, creditName);
-            person.addLabel(creditName, null);
-        } else if (name.getGivenNames() != null && name.getFamilyName() != null) {
-            //@formatter:off
-            // Naive fallback assuming givenNames ~= first name and familyName ~= lastName
-            // See http://www.w3.org/International/questions/qa-personal-names for further
-            // considerations -- we don't report this as foaf:name as we can't be sure of the ordering.
-            //@formatter:on
-
-            // NOTE: ORCID gui is westernized asking for "First name" and
-            // "Last name" and assuming the above mapping
-            String label = name.getGivenNames().getContent() + " " + name.getFamilyName().getContent();
-            person.addLabel(label, null);
+        if(name != null) {
+            if (name.getCreditName() != null) {
+                // User has provided full name
+                String creditName = name.getCreditName().getContent();
+                person.addProperty(FOAF.name, creditName);
+                person.addLabel(creditName, null);
+            } else if (name.getGivenNames() != null && name.getFamilyName() != null) {
+                //@formatter:off
+                // Naive fallback assuming givenNames ~= first name and familyName ~= lastName
+                // See http://www.w3.org/International/questions/qa-personal-names for further
+                // considerations -- we don't report this as foaf:name as we can't be sure of the ordering.
+                //@formatter:on
+    
+                // NOTE: ORCID gui is westernized asking for "First name" and
+                // "Last name" and assuming the above mapping
+                String label = name.getGivenNames().getContent() + " " + name.getFamilyName().getContent();
+                person.addLabel(label, null);
+            }
+    
+            if (name.getGivenNames() != null) {
+                person.addProperty(FOAF.givenName, name.getGivenNames().getContent());
+            }
+            if (name.getFamilyName() != null) {
+                person.addProperty(FOAF.familyName, name.getFamilyName().getContent());
+            }
         }
-
-        if (name.getGivenNames() != null) {
-            person.addProperty(FOAF.givenName, name.getGivenNames().getContent());
-        }
-        if (name.getFamilyName() != null) {
-            person.addProperty(FOAF.familyName, name.getFamilyName().getContent());
-        }
-
     }
 
     protected OntModel getOntModel() {

--- a/orcid-api-web/src/main/webapp/WEB-INF/web.xml
+++ b/orcid-api-web/src/main/webapp/WEB-INF/web.xml
@@ -135,7 +135,7 @@
 	    <filter-class>org.glassfish.jersey.servlet.ServletContainer</filter-class>
 	    <init-param>
 	        <param-name>jersey.config.server.provider.packages</param-name>
-	        <param-value>org.orcid.api.memberV3.server;org.orcid.api.memberV2.server;io.swagger.v3.jaxrs2.integration.resources</param-value>
+	        <param-value>org.orcid.api.memberV3.server;org.orcid.api.memberV2.server</param-value>
 	    </init-param>
 	    <init-param>
             <param-name>jersey.config.servlet.filter.staticContentRegex</param-name>

--- a/orcid-core/src/main/java/org/orcid/core/api/OrcidApiConstants.java
+++ b/orcid-core/src/main/java/org/orcid/core/api/OrcidApiConstants.java
@@ -72,16 +72,16 @@ public class OrcidApiConstants {
     public static final String STATS = "/{type}";
     public static final String STATS_ALL = "/all";
     public static final String ERROR = "/error";
-    public static final String ORCID_XML = "application/orcid+xml; qs=3";
-    public static final String ORCID_JSON = "application/orcid+json; qs=2";
-    public static final String TEXT_TURTLE = "text/turtle; qs=3";
-    public static final String TEXT_N3 = "text/n3; qs=2";
-    public static final String N_TRIPLES = "application/n-triples; qs=3";
-    public static final String JSON_LD = "application/ld+json; qs=2";
-    public static final String APPLICATION_RDFXML = "application/rdf+xml; qs=2";
-    public static final String VND_ORCID_XML = "application/vnd.orcid+xml; qs=5";
-    public static final String VND_ORCID_JSON = "application/vnd.orcid+json; qs=4";
-    public static final String HTML = "text/html; qs=1";
+    public static final String ORCID_XML = "application/orcid+xml; qs=0.3";
+    public static final String ORCID_JSON = "application/orcid+json; qs=0.2";
+    public static final String TEXT_TURTLE = "text/turtle; qs=0.3";
+    public static final String TEXT_N3 = "text/n3; qs=0.2";
+    public static final String N_TRIPLES = "application/n-triples; qs=0.3";
+    public static final String JSON_LD = "application/ld+json; qs=0.2";
+    public static final String APPLICATION_RDFXML = "application/rdf+xml; qs=0.2";
+    public static final String VND_ORCID_XML = "application/vnd.orcid+xml; qs=0.5";
+    public static final String VND_ORCID_JSON = "application/vnd.orcid+json; qs=0.4";
+    public static final String HTML = "text/html; qs=0.1";
     public static final String HTML_UTF = "text/html; charset=UTF-8";
 
     public static final String TEXT_CSV = "text/csv";

--- a/orcid-pub-web/src/main/java/org/orcid/api/lod/ExperimentalRDFResource.java
+++ b/orcid-pub-web/src/main/java/org/orcid/api/lod/ExperimentalRDFResource.java
@@ -39,8 +39,10 @@ import org.orcid.jaxb.model.record_v2.PersonExternalIdentifier;
 import org.orcid.jaxb.model.record_v2.ResearcherUrl;
 import org.orcid.jaxb.model.record_v2.Work;
 import org.orcid.jaxb.model.v3.release.groupid.GroupIdRecord;
+import org.springframework.stereotype.Component;
 
-@Path(OrcidApiConstants.EXPERIMENTAL_RDF_V1 )
+@Component
+@Path(OrcidApiConstants.EXPERIMENTAL_RDF_V1)
 public class ExperimentalRDFResource {
 
     protected PublicV2ApiServiceDelegator<Education, Employment, PersonExternalIdentifier, Funding, GroupIdRecord, OtherName, PeerReview, ResearcherUrl, Work> serviceDelegator;

--- a/orcid-pub-web/src/main/webapp/WEB-INF/web.xml
+++ b/orcid-pub-web/src/main/webapp/WEB-INF/web.xml
@@ -156,7 +156,7 @@
 	    <filter-class>org.glassfish.jersey.servlet.ServletContainer</filter-class>
 	    <init-param>
 	        <param-name>jersey.config.server.provider.packages</param-name>
-	        <param-value>org.orcid.api.publicV3.server;org.orcid.api.publicV2.server;io.swagger.v3.jaxrs2.integration.resources</param-value>
+	        <param-value>org.orcid.api.publicV3.server;org.orcid.api.publicV2.server;org.orcid.api.lod;org.orcid.api.common.writer.rdf</param-value>
 	    </init-param>
 	    <init-param>
             <param-name>jersey.config.servlet.filter.staticContentRegex</param-name>


### PR DESCRIPTION
qs values can vary in the range 0.000 to 1.000. Note that any variant with a qs value of 0.000 will never be chosen. Variants with no 'qs' parameter value are given a qs factor of 1.0. The qs parameter indicates the relative 'quality' of this variant compared to the other available variants, independent of the client's capabilities. For example, a JPEG file is usually of higher source quality than an ASCII file if it is attempting to represent a photograph. However, if the resource being represented is an original ASCII art, then an ASCII representation would have a higher source quality than a JPEG representation. A qs value is therefore specific to a given variant depending on the nature of the resource it represents.