### PR TITLE
Treat `interruptedException` from `ViewMQStatistics`

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/cli/ViewMQStatistics.java
+++ b/orcid-core/src/main/java/org/orcid/core/cli/ViewMQStatistics.java
@@ -57,8 +57,8 @@ public class ViewMQStatistics {
             try {
                 Thread.sleep(5000l);
             } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                LOG.warn("Thread sleep interrupted", e);
+                Thread.currentThread().interrupt();
             }
         }
     }


### PR DESCRIPTION
**What was made**
- Add log warn;
- Maintaining Outage Status

**Add log warn**
- Instead of just printing the stack trace to the console, a logging system was used. This allows you to monitor, debug, and understand system behavior.

**Maintaining Outage Status**
  
When calling Thread.interrupt(), the interrupt status of the thread is set to true. When a thread throws an InterruptedException exception, the interrupt status is automatically reset to false. This is so that the code that caught the exception has the responsibility for deciding how to handle the interruption.

 Preserving the interrupt status means that even after catching the exception and any further handling, the interrupt status must be maintained if the thread is still interrupted.

 The reason for preserving the interrupt status is to allow later parts of the code or external libraries to detect that the thread was interrupted, even if the exception was handled locally. This facilitates coordination and communication between threads, especially in situations where the interrupt is used to signal to a thread that it should terminate its operations.