### PR TITLE
1. Fixed the correct query string for showing first 10 resutls.

### DIFF
--- a/orcid-api-web/tutorial/search.md
+++ b/orcid-api-web/tutorial/search.md
@@ -402,7 +402,7 @@ Description: Search for records modified between January 1, 2018 and today
 
 Paging: First 10 results
 
-URL: ```https://pub.sandbox.orcid.org/v3.0/search/?q=profile-last-modified-date:%5B2018-01-01T00:00:00Z%20TO%20NOW%5D&start=1&rows=10```
+URL: ```https://pub.sandbox.orcid.org/v3.0/search/?q=profile-last-modified-date:%5B2018-01-01T00:00:00Z%20TO%20NOW%5D&start=0&rows=10```
 
 ### Example 14
 


### PR DESCRIPTION
 Fixed the correct query string for showing first 10 results.
 The original `start=1` skips the first record, so the result shows the first 2 - 11 records. `start=0` is the correct parameter.