### PR TITLE
Added unique constraint for external id identifier for disambiguated org

### DIFF
--- a/orcid-persistence/src/main/resources/db-master.xml
+++ b/orcid-persistence/src/main/resources/db-master.xml
@@ -403,4 +403,5 @@
   <include file="/db/updates/create_profile_email_domain_table.xml" />
   <include file="/db/updates/create_dw_notification.xml" />
   <include file="/db/updates/create_dw_profile_email_domain.xml" />
+  <include file="/db/updates/add_unique_constraint_external_id_disambiguated_org.xml" />
 </databaseChangeLog>

--- a/orcid-persistence/src/main/resources/db/updates/add_unique_constraint_external_id_disambiguated_org.xml
+++ b/orcid-persistence/src/main/resources/db/updates/add_unique_constraint_external_id_disambiguated_org.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+
+    <changeSet id="ADD-UNIQUE-CONSTRAINT-EXTID-DISAMBIGUATED-ORG" author="Camelia Dumitru" dbms="postgresql">
+        <addUniqueConstraint 
+        columnNames="org_disambiguated_id, identifier, identifier_type" 
+        tableName="org_disambiguated_external_identifier" 
+        constraintName="uq_org_disambiguated_identifier_type"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This pool request has to be merged/deployed only after the coresponding database has been cleaned for duplicates.