### PR TITLE
PD-3912 Removed the check if the connection is working

### DIFF
--- a/orcid-scheduler-web/src/main/java/org/orcid/scheduler/autospam/cli/AutoLockSpamRecords.java
+++ b/orcid-scheduler-web/src/main/java/org/orcid/scheduler/autospam/cli/AutoLockSpamRecords.java
@@ -223,9 +223,6 @@ public class AutoLockSpamRecords {
                 AmazonS3 s3 = AmazonS3ClientBuilder.standard()
                         .withRegion(Regions.US_EAST_2)
                         .build();
-                // Fastest and more generic way to know if the connection is working
-                s3.getS3AccountOwner();
-                LOG.info("Connected to Amazon S3");
 
                 S3Object response = s3.getObject(new GetObjectRequest(SPAM_BUCKET, ORCID_S3_SPAM_FILE));
                 byte[] byteArray = IOUtils.toByteArray(response.getObjectContent());


### PR DESCRIPTION
https://orcid.slack.com/archives/CLHFX1XK2/p1768902847304169 

Removing the line that check for connection to s3 as we catch exceptions anyway.

```

2026-01-20 07:00:00,928 ERROR [scheduler-19] cli.AutoLockSpamRecords (AutoLockSpamRecords.java:234) - Error processing spam ids from Amazon S3
com.amazonaws.services.s3.model.AmazonS3Exception: User: arn:aws:sts::804177324965:assumed-role/reg-sched-role/i-0bbf264699c62d0a3 is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the>
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1879) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1418) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1387) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1157) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:814) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:781) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:755) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:715) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:697) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:561) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:541) ~[aws-java-sdk-core-1.12.261.jar:?]
    at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5456) ~[aws-java-sdk-s3-1.12.261.jar:?]
    at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5403) ~[aws-java-sdk-s3-1.12.261.jar:?]
    at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5397) ~[aws-java-sdk-s3-1.12.261.jar:?]
    at com.amazonaws.services.s3.AmazonS3Client.getS3AccountOwner(AmazonS3Client.java:1016) ~[aws-java-sdk-s3-1.12.261.jar:?]
    at com.amazonaws.services.s3.AmazonS3Client.getS3AccountOwner(AmazonS3Client.java:1006) ~[aws-java-sdk-s3-1.12.261.jar:?]
    at org.orcid.scheduler.autospam.cli.AutoLockSpamRecords.getAllSpamIDs(AutoLockSpamRecords.java:227) [classes/:?]
    at org.orcid.scheduler.autospam.cli.AutoLockSpamRecords.process(AutoLockSpamRecords.java:178) [classes/:?]
```