### PR TITLE
PD-6028 Fixed Hibernate 6 HQL compatibility issues across  DAO files

### DIFF
--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/BackupCodeDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/BackupCodeDaoImpl.java
@@ -43,7 +43,7 @@ public class BackupCodeDaoImpl extends GenericDaoImpl<BackupCodeEntity, Long> im
 
     @Override
     public Date getBackupCodesCreationDate(String orcid) {
-        Query query = entityManager.createQuery("SELECT MAX(dateCreated) FROM BackupCodeEntity WHERE orcid = :orcid");
+        Query query = entityManager.createQuery("SELECT MAX(b.dateCreated) FROM BackupCodeEntity b WHERE b.orcid = :orcid");
         query.setParameter("orcid", orcid);
         return (Date) query.getSingleResult();
     }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientDetailsDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientDetailsDaoImpl.java
@@ -213,7 +213,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
      */
     public String getMemberName(String clientId) {
         TypedQuery<String> query = entityManager
-                .createQuery("select creditName from RecordNameEntity where orcid = (select groupProfileId from ClientDetailsEntity where id=:clientId)", String.class);
+                .createQuery("select r.creditName from RecordNameEntity r where r.orcid = (select c.groupProfileId from ClientDetailsEntity c where c.id=:clientId)", String.class);
         query.setParameter("clientId", clientId);
         return query.getSingleResult();
     }
@@ -221,7 +221,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     @Override
     public boolean existsAndIsNotPublicClient(String clientId) {
         TypedQuery<Long> query = entityManager
-                .createQuery("select count(*) from ClientDetailsEntity where id=:clientId and clientType != 'PUBLIC_CLIENT'", Long.class);
+                .createQuery("select count(c) from ClientDetailsEntity c where c.id=:clientId and c.clientType != 'PUBLIC_CLIENT'", Long.class);
         query.setParameter("clientId", clientId);
         Long result = query.getSingleResult();
         return (result != null && result > 0);
@@ -229,7 +229,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
 
     @Override
     public Date getLastModifiedIfNotPublicClient(String clientId) {
-        Query query = entityManager.createQuery("SELECT lastModified FROM ClientDetailsEntity WHERE id = :id AND clientType != :type");
+        Query query = entityManager.createQuery("SELECT c.lastModified FROM ClientDetailsEntity c WHERE c.id = :id AND c.clientType != :type");
         query.setParameter("id", clientId);
         query.setParameter("type", PUBLIC_CLIENT);
         Date result = (Date) query.getSingleResult();
@@ -245,7 +245,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
 
     @Override
     public List<String> findLegacyClientIds() {
-        TypedQuery<String> query = entityManager.createQuery("select id from ClientDetailsEntity where id not like 'APP-%'", String.class);
+        TypedQuery<String> query = entityManager.createQuery("select c.id from ClientDetailsEntity c where c.id not like 'APP-%'", String.class);
         return query.getResultList();
     }
 

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/CustomEmailDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/CustomEmailDaoImpl.java
@@ -121,7 +121,7 @@ public class CustomEmailDaoImpl extends GenericDaoImpl<CustomEmailEntity, Custom
      * */
     @Override
     public boolean exists(String clientDetailsId, EmailType emailType) {
-        TypedQuery<Long> query = entityManager.createQuery("SELECT count(*) FROM CustomEmailEntity WHERE clientDetailsEntity.id=:clientDetailsId and emailType=:emailType", Long.class);
+        TypedQuery<Long> query = entityManager.createQuery("SELECT count(c) FROM CustomEmailEntity c WHERE c.clientDetailsEntity.id=:clientDetailsId and c.emailType=:emailType", Long.class);
         query.setParameter("clientDetailsId", clientDetailsId);
         query.setParameter("emailType", emailType);
         Long result = query.getSingleResult();
@@ -136,7 +136,7 @@ public class CustomEmailDaoImpl extends GenericDaoImpl<CustomEmailEntity, Custom
      * */
     @Override
     public Date getLastModified(String clientDetailsId, EmailType emailType) {
-        TypedQuery<Date> query = entityManager.createQuery("SELECT lastModified FROM CustomEmailEntity WHERE clientDetailsEntity.id=:clientDetailsId and emailType=:emailType", Date.class);
+        TypedQuery<Date> query = entityManager.createQuery("SELECT c.lastModified FROM CustomEmailEntity c WHERE c.clientDetailsEntity.id=:clientDetailsId and c.emailType=:emailType", Date.class);
         query.setParameter("clientDetailsId", clientDetailsId);
         query.setParameter("emailType", emailType);
         Date result = null;

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/GroupIdRecordDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/GroupIdRecordDaoImpl.java
@@ -29,7 +29,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
 
     @Override
     public boolean exists(String groupId) {
-        TypedQuery<Long> query = entityManager.createQuery("select count(*) from GroupIdRecordEntity where trim(lower(groupId)) = trim(lower(:groupId))", Long.class);
+        TypedQuery<Long> query = entityManager.createQuery("select count(g) from GroupIdRecordEntity g where trim(lower(g.groupId)) = trim(lower(:groupId))", Long.class);
         query.setParameter("groupId", groupId);
         Long result = query.getSingleResult();
         return (result != null && result > 0);
@@ -55,7 +55,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
 
     @Override
     public boolean haveAnyPeerReview(String groupId) {
-        TypedQuery<Long> query = entityManager.createQuery("select count(*) from PeerReviewEntity where trim(lower(groupId)) = trim(lower(:groupId))", Long.class);
+        TypedQuery<Long> query = entityManager.createQuery("select count(p) from PeerReviewEntity p where trim(lower(p.groupId)) = trim(lower(:groupId))", Long.class);
         query.setParameter("groupId", groupId);
         Long result = query.getSingleResult();
         return (result != null && result > 0);
@@ -63,9 +63,9 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
 
     @Override
     public boolean duplicateExists(Long putCode, String groupId) {
-        StringBuilder queryString = new StringBuilder("select count(*) from GroupIdRecordEntity where trim(lower(groupId)) = trim(lower(:groupId))");
+        StringBuilder queryString = new StringBuilder("select count(g) from GroupIdRecordEntity g where trim(lower(g.groupId)) = trim(lower(:groupId))");
         if (putCode != null) {
-            queryString.append(" and id != :putCode");
+            queryString.append(" and g.id != :putCode");
         }
         TypedQuery<Long> query = entityManager.createQuery(queryString.toString(), Long.class);
         query.setParameter("groupId", groupId);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/NotificationDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/NotificationDaoImpl.java
@@ -79,7 +79,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
 
     @Override
     public int getUnreadCount(String orcid) {
-        TypedQuery<Long> query = entityManager.createQuery("select count(*) from NotificationEntity where readDate is null and archivedDate is null and orcid = :orcid",
+        TypedQuery<Long> query = entityManager.createQuery("select count(n) from NotificationEntity n where n.readDate is null and n.archivedDate is null and n.orcid = :orcid",
                 Long.class);
         query.setParameter("orcid", orcid);
         return query.getSingleResult().intValue();
@@ -89,9 +89,9 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     @Override
     public int getTotalCount(String orcid, boolean archived) {
         StringBuffer sb = new StringBuffer();
-        sb.append("select count(*) from NotificationEntity where orcid = :orcid");
+        sb.append("select count(n) from NotificationEntity n where n.orcid = :orcid");
         if (!archived) {
-            sb.append(" and archivedDate is null");
+            sb.append(" and n.archivedDate is null");
         } 
         TypedQuery<Long> query = entityManager.createQuery(sb.toString(),
                 Long.class);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrcidPropsDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrcidPropsDaoImpl.java
@@ -84,7 +84,7 @@ public class OrcidPropsDaoImpl extends GenericDaoImpl<OrcidPropsEntity, String> 
     @Override
     public String getValue(String key) {
         Assert.hasText(key, "Cannot look for empty keys");
-        Query query = entityManager.createQuery("SELECT value FROM OrcidPropsEntity WHERE key=:key");
+        Query query = entityManager.createQuery("SELECT o.value FROM OrcidPropsEntity o WHERE o.key=:key");
         query.setParameter("key", key);
         try {
             return (String) query.getSingleResult();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedExternalIdentifierDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedExternalIdentifierDaoImpl.java
@@ -56,7 +56,7 @@ public class OrgDisambiguatedExternalIdentifierDaoImpl extends GenericDaoImpl<Or
     @Override
     public boolean exists(Long orgDisambiguatedId, String identifier, String identifierType) {
         try {
-            TypedQuery<Long> query = entityManager.createQuery("SELECT count(identifier) FROM OrgDisambiguatedExternalIdentifierEntity WHERE orgDisambiguated.id = :orgDisambiguatedId AND identifier = :identifier AND identifierType = :identifierType",
+            TypedQuery<Long> query = entityManager.createQuery("SELECT count(e) FROM OrgDisambiguatedExternalIdentifierEntity e WHERE e.orgDisambiguated.id = :orgDisambiguatedId AND e.identifier = :identifier AND e.identifierType = :identifierType",
                     Long.class);
             query.setParameter("orgDisambiguatedId", orgDisambiguatedId);
             query.setParameter("identifier", identifier);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileDaoImpl.java
@@ -819,7 +819,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     @Override
     public boolean isOrcidValidAsDelegate(String orcid) {
         TypedQuery<Long> query = entityManager.createQuery(
-                "SELECT count(orcid) FROM ProfileEntity WHERE orcid=:orcid AND profile_deactivation_date is NULL AND deprecated_date is NULL AND primary_record is NULL AND (record_locked is NULL OR record_locked is FALSE)",
+                "SELECT count(p) FROM ProfileEntity p WHERE p.id=:orcid AND p.deactivationDate is NULL AND p.deprecatedDate is NULL AND p.primaryRecord is NULL AND (p.recordLocked is NULL OR p.recordLocked is FALSE)",
                 Long.class);
         query.setParameter("orcid", orcid);
         Long result = query.getSingleResult();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/RecordNameDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/RecordNameDaoImpl.java
@@ -70,7 +70,7 @@ public class RecordNameDaoImpl extends GenericDaoImpl<RecordNameEntity, Long> im
     
     @Override
     public Date getLastModified(String orcid) {
-        TypedQuery<Date> query = entityManager.createQuery("SELECT lastModified FROM RecordNameEntity WHERE orcid = :orcid", Date.class);
+        TypedQuery<Date> query = entityManager.createQuery("SELECT r.lastModified FROM RecordNameEntity r WHERE r.orcid = :orcid", Date.class);
         query.setParameter("orcid", orcid);
         return query.getSingleResult();
     }


### PR DESCRIPTION
Added explicit entity aliases (e.g., p, r, n, etc.) to all FROM clauses Prefixed all property references with alias (e.g., p.deactivationDate instead of profile_deactivation_date) Changed count(*) → count(alias) where needed
Used entity property names instead of database column names throughout These are Hibernate 6's stricter HQL validation requirements that weren't enforced in Hibernate 5.