### PR TITLE
PD-6015 Changed it to return the token

### DIFF
--- a/orcid-web/src/main/java/org/orcid/frontend/spring/OrcidAccessDeniedHandler.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/spring/OrcidAccessDeniedHandler.java
@@ -50,7 +50,7 @@ public class OrcidAccessDeniedHandler extends AccessDeniedHandlerImpl {
                             maskToken(cookieToken),
                             maskToken(authCookieToken)
                     );
-                            response.setHeader("X-ORCID-CSRF-DEBUG", "access-denied-handler");
+                    response.setHeader("X-ORCID-CSRF-DEBUG", "access-denied-handler");
                     response.setHeader("X-ORCID-CSRF-HDR-PRESENT", String.valueOf(headerToken != null && !headerToken.isBlank()));
                     response.setHeader("X-ORCID-CSRF-COOKIE-PRESENT", String.valueOf(cookieToken != null && !cookieToken.isBlank()));
                     response.setHeader("X-ORCID-CSRF-HDR-COOKIE-MATCH", String.valueOf(headerToken != null && headerToken.equals(cookieToken)));

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/CsrfController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/CsrfController.java
@@ -48,7 +48,7 @@ public class CsrfController {
             csrfTokenRepository.saveToken(csrfToken, request, response);
         }
         if (csrfToken != null) {
-            csrfToken.getToken();
+            return Collections.singletonMap(csrfToken.getParameterName(), csrfToken.getToken());
         }
         return Collections.emptyMap();
     }

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/CsrfController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/CsrfController.java
@@ -47,9 +47,7 @@ public class CsrfController {
             csrfToken = csrfTokenRepository.generateToken(request);
             csrfTokenRepository.saveToken(csrfToken, request, response);
         }
-        if (csrfToken != null) {
-            return Collections.singletonMap(csrfToken.getParameterName(), csrfToken.getToken());
-        }
+        // Return empty map - token is in the XSRF-TOKEN cookie, not in the response body for security
         return Collections.emptyMap();
     }
 }


### PR DESCRIPTION
The /csrf.json endpoint was returning an empty map, so Cypress tests had no way to extract the CSRF token value to include in POST request headers.