### PR TITLE
PD-6102 Fix for JDK 17+ forbids objectFieldOffset on hidden classes →throws UnsupportedOperationException

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/impl/MapperFacadeFactory.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/impl/MapperFacadeFactory.java
@@ -165,7 +165,8 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     private MapperFactory getNewMapperFactory() {
-        return new DefaultMapperFactory.Builder().build();
+        // dumpStateOnException(false): prevents RamUsageEstimator from crashing on JDK17+ hidden classes (lambdas)
+        return new DefaultMapperFactory.Builder().dumpStateOnException(false).build();
     }
 
     @Override

--- a/orcid-core/src/main/java/org/orcid/core/adapter/v3/impl/MapperFacadeFactory.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/v3/impl/MapperFacadeFactory.java
@@ -196,9 +196,14 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     @Resource
     private ContributorsRolesAndSequencesConverter contributorsRolesAndSequencesConverter;
 
+    private MapperFactory getNewMapperFactory() {
+        // dumpStateOnException(false): prevents RamUsageEstimator from crashing on JDK17+ hidden classes (lambdas)
+        return new DefaultMapperFactory.Builder().dumpStateOnException(false).build();
+    }
+
     @Override
     public MapperFacade getObject() throws Exception {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         // Register converters
         ConverterFactory converterFactory = mapperFactory.getConverterFactory();
@@ -405,7 +410,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getExternalIdentifierMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         mapperFactory.getConverterFactory().registerConverter("visibilityConverter", new VisibilityConverter());
 
         ClassMapBuilder<PersonExternalIdentifier, ExternalIdentifierEntity> externalIdentifierClassMap = mapperFactory.classMap(PersonExternalIdentifier.class,
@@ -435,7 +440,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getResearcherUrlMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         mapperFactory.getConverterFactory().registerConverter("visibilityConverter", new VisibilityConverter());
         mapperFactory.getConverterFactory().registerConverter("emptyStringToNullConverter", new EmptyStringToNullConverter());
 
@@ -453,7 +458,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getOtherNameMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         mapperFactory.getConverterFactory().registerConverter("visibilityConverter", new VisibilityConverter());
 
         ClassMapBuilder<OtherName, OtherNameEntity> otherNameClassMap = mapperFactory.classMap(OtherName.class, OtherNameEntity.class);
@@ -469,7 +474,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getKeywordMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         mapperFactory.getConverterFactory().registerConverter("visibilityConverter", new VisibilityConverter());
 
         ClassMapBuilder<Keyword, ProfileKeywordEntity> keywordClassMap = mapperFactory.classMap(Keyword.class, ProfileKeywordEntity.class);
@@ -485,7 +490,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getAddressMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         mapperFactory.getConverterFactory().registerConverter("visibilityConverter", new VisibilityConverter());
 
         ClassMapBuilder<Address, AddressEntity> addressClassMap = mapperFactory.classMap(Address.class, AddressEntity.class);
@@ -502,7 +507,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getEmailMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         mapperFactory.getConverterFactory().registerConverter("visibilityConverter", new VisibilityConverter());
         ClassMapBuilder<Email, EmailEntity> emailClassMap = mapperFactory.classMap(Email.class, EmailEntity.class);
         emailClassMap.byDefault();
@@ -543,7 +548,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
     
     public MapperFacade getWorkMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         WorkContributorsConverter wcc = new WorkContributorsConverter(workContributorsRoleConverter);
         ConverterFactory converterFactory = mapperFactory.getConverterFactory();
@@ -811,7 +816,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getFundingMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         
         ConverterFactory converterFactory = mapperFactory.getConverterFactory();
         converterFactory.registerConverter("fundingExternalIdentifiersConverterId", new JSONFundingExternalIdentifiersConverterV3());
@@ -877,7 +882,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getEducationMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ClassMapBuilder<Education, OrgAffiliationRelationEntity> classMap = mapperFactory.classMap(Education.class, OrgAffiliationRelationEntity.class);
 
@@ -888,7 +893,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getEmploymentMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ClassMapBuilder<Employment, OrgAffiliationRelationEntity> classMap = mapperFactory.classMap(Employment.class, OrgAffiliationRelationEntity.class);
 
@@ -899,7 +904,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getDistinctionMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ClassMapBuilder<Distinction, OrgAffiliationRelationEntity> classMap = mapperFactory.classMap(Distinction.class, OrgAffiliationRelationEntity.class);
 
@@ -910,7 +915,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getInvitedPositionMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ClassMapBuilder<InvitedPosition, OrgAffiliationRelationEntity> classMap = mapperFactory.classMap(InvitedPosition.class, OrgAffiliationRelationEntity.class);
 
@@ -921,7 +926,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getMembershipMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ClassMapBuilder<Membership, OrgAffiliationRelationEntity> classMap = mapperFactory.classMap(Membership.class, OrgAffiliationRelationEntity.class);
 
@@ -932,7 +937,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getQualificationMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ClassMapBuilder<Qualification, OrgAffiliationRelationEntity> classMap = mapperFactory.classMap(Qualification.class, OrgAffiliationRelationEntity.class);
 
@@ -943,7 +948,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getServiceMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ClassMapBuilder<Service, OrgAffiliationRelationEntity> classMap = mapperFactory.classMap(Service.class, OrgAffiliationRelationEntity.class);
 
@@ -1009,7 +1014,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getPeerReviewMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ConverterFactory converterFactory = mapperFactory.getConverterFactory();
         converterFactory.registerConverter("workExternalIdentifiersConverterId", new JSONWorkExternalIdentifiersConverterV3(norm, resolverService, localeManager));
@@ -1072,7 +1077,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getResearchResourceMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         registerOrgClassMappings(mapperFactory);
         
         ConverterFactory converterFactory = mapperFactory.getConverterFactory();
@@ -1140,7 +1145,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getGroupIdRecordMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
 
         ClassMapBuilder<GroupIdRecord, GroupIdRecordEntity> classMap = mapperFactory.classMap(GroupIdRecord.class, GroupIdRecordEntity.class);
         addV3CommonFields(classMap);
@@ -1156,7 +1161,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getClientMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         ClassMapBuilder<ClientSummary, ClientDetailsEntity> clientSummaryClassMap = mapperFactory.classMap(ClientSummary.class, ClientDetailsEntity.class);
         clientSummaryClassMap.field("name", "clientName");
         clientSummaryClassMap.field("description", "clientDescription");
@@ -1262,7 +1267,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getNameMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         mapperFactory.getConverterFactory().registerConverter("visibilityConverter", new VisibilityConverter());
         mapperFactory.getConverterFactory().registerConverter("familyNameConverter", new FamilyNameConverter());
         mapperFactory.getConverterFactory().registerConverter("givenNamesConverter", new GivenNamesConverter());
@@ -1285,7 +1290,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
     }
 
     public MapperFacade getInvalidRecordDataChangeMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         ClassMapBuilder<RecordCorrection, InvalidRecordDataChangeEntity> classMap = mapperFactory.classMap(RecordCorrection.class, InvalidRecordDataChangeEntity.class);
         classMap.fieldBToA("id", "sequence");
         classMap.fieldBToA("sqlUsedToUpdate", "sqlUsedToUpdate");
@@ -1299,7 +1304,7 @@ public class MapperFacadeFactory implements FactoryBean<MapperFacade> {
 
 
     public MapperFacade getSpamMapperFacade() {
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = getNewMapperFactory();
         ClassMapBuilder<Spam, SpamEntity> classMap = mapperFactory.classMap(Spam.class, SpamEntity.class);                       
         classMap.fieldBToA("sourceType", "sourceType");
         classMap.fieldBToA("spamCounter", "spamCounter");


### PR DESCRIPTION
Both MapperFacadeFactory files now create the Orika factory with .dumpStateOnException(false) Now, when a mapping fails, the real MappingException (with the actual mapping error as its cause) will propagate instead.