### PR TITLE
PD-6180 Resolve PubMed identifiers via EuropePMC instead of the NCBI landing page

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/utils/v3/identifiers/resolvers/PubMedResolver.java
+++ b/orcid-core/src/main/java/org/orcid/core/utils/v3/identifiers/resolvers/PubMedResolver.java
@@ -13,6 +13,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.annotation.Resource;
 import jakarta.ws.rs.core.MediaType;
@@ -46,11 +48,19 @@ import org.orcid.pojo.IdentifierType;
 import org.orcid.pojo.PIDResolutionResult;
 import org.orcid.pojo.WorkExtended;
 import org.orcid.pojo.ajaxForm.PojoUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
 @Component
 public class PubMedResolver implements LinkResolver, MetadataResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PubMedResolver.class);
 
     @Resource
     PIDNormalizationService normalizationService;
@@ -73,15 +83,31 @@ public class PubMedResolver implements LinkResolver, MetadataResolver {
 
     private String metadataEndpoint = "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query={type}:{id}&resultType=core&format=json";
 
+    /**
+     * Existence of an identifier is decided by EuropePMC, never by fetching the
+     * pubmed.ncbi.nlm.nih.gov landing page: NCBI serves that page behind a
+     * cookie/bot challenge that answers HTTP 203 to non-browser clients, which
+     * made every PubMed import fail (PD-6180). Cached so that repeated form
+     * validations of the same identifier only call EuropePMC once. A loader that
+     * throws is not cached by Guava, so transient EuropePMC failures do not stick
+     * for the life of the entry.
+     */
+    private final LoadingCache<String, Boolean> existsInEuropePmc = CacheBuilder.newBuilder().expireAfterWrite(20, TimeUnit.MINUTES).maximumSize(10000)
+            .build(new CacheLoader<String, Boolean>() {
+                public Boolean load(String endpoint) throws IOException, JSONException {
+                    return hasResults(fetchMetadata(endpoint));
+                }
+            });
+
     @Override
     public List<String> canHandle() {
         return types;
     }
 
     /**
-     * Checks for a http 200 normalizing the value and creating a URL using the
-     * resolution prefix
-     * 
+     * Checks that EuropePMC knows the identifier, normalizing the value and
+     * creating a URL using the resolution prefix
+     *
      */
     @Override
     public PIDResolutionResult resolve(String apiTypeName, String value) {
@@ -90,7 +116,7 @@ public class PubMedResolver implements LinkResolver, MetadataResolver {
 
         String normUrl = normalizationService.generateNormalisedURL(apiTypeName, value);
         if (!StringUtils.isEmpty(normUrl)) {
-            if (cache.isHttp200(normUrl)) {
+            if (exists(apiTypeName, value)) {
                 return new PIDResolutionResult(true, true, true, normUrl);
             } else {
                 return new PIDResolutionResult(false, true, true, null);
@@ -102,35 +128,54 @@ public class PubMedResolver implements LinkResolver, MetadataResolver {
 
     @Override
     public WorkExtended resolveMetadata(String apiTypeName, String value) {
-        PIDResolutionResult rr = this.resolve(apiTypeName, value);
-        if (!rr.isResolved())
+        if (StringUtils.isEmpty(value) || StringUtils.isEmpty(normalizationService.normalise(apiTypeName, value)))
             return null;
 
         try {
-            String endpoint = getPubMedEndpoint(apiTypeName, value);
-            InputStream inputStream = cache.get(endpoint, MediaType.APPLICATION_JSON);
-            BufferedReader in = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8.name()));
-
-            StringBuffer response = new StringBuffer();
-            in.lines().forEach(i -> response.append(i));
-            in.close();
-
-            // Read JSON response and print
-            JSONObject json = new JSONObject(response.toString());
-
-            if (json != null) {
+            JSONObject json = fetchMetadata(getPubMedEndpoint(apiTypeName, value));
+            if (hasResults(json)) {
                 return getWork(json);
             }
         } catch (UnexpectedResponseCodeException e) {
             // TODO: For future projects, we might want to retry when
             // e.getReceivedCode() tell us that we can retry later, like 503 or
             // 504
+            LOG.warn(String.format("UnexpectedResponseCode retrieving %s %s from EuropePMC. Expected %s, got %s", apiTypeName, value, e.getExpectedCode(),
+                    e.getReceivedCode()), e);
         } catch (IOException | JSONException | ParseException e) {
-            throw new RuntimeException(e);
+            // Returning null asks the caller to report "unable to import", which
+            // is a better outcome than a 500 the work modal cannot handle.
+            LOG.warn(String.format("Error retrieving %s %s from EuropePMC", apiTypeName, value), e);
         }
         return null;
     }
-    
+
+    private boolean exists(String apiTypeName, String value) {
+        try {
+            return existsInEuropePmc.get(getPubMedEndpoint(apiTypeName, value));
+        } catch (ExecutionException e) {
+            LOG.warn(String.format("Error resolving %s %s against EuropePMC", apiTypeName, value), e.getCause());
+            return false;
+        }
+    }
+
+    private JSONObject fetchMetadata(String endpoint) throws IOException, JSONException {
+        InputStream inputStream = cache.get(endpoint, MediaType.APPLICATION_JSON);
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8.name()))) {
+            StringBuffer response = new StringBuffer();
+            in.lines().forEach(i -> response.append(i));
+            return new JSONObject(response.toString());
+        }
+    }
+
+    private boolean hasResults(JSONObject json) throws JSONException {
+        if (json == null || !json.has("resultList")) {
+            return false;
+        }
+        JSONObject resultList = json.getJSONObject("resultList");
+        return resultList != null && resultList.has("result") && resultList.getJSONArray("result").length() > 0;
+    }
+
     // returns PID without prefix or URL etc
     private String getPubMedEndpoint(String apiTypeName, String userInput) {
         String normalised = normalizationService.normalise(apiTypeName, userInput);

--- a/orcid-core/src/test/java/org/orcid/core/utils/PubMedResolverTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/utils/PubMedResolverTest.java
@@ -1,7 +1,10 @@
 package org.orcid.core.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -32,6 +35,7 @@ import org.orcid.jaxb.model.common.WorkType;
 import org.orcid.jaxb.model.v3.release.record.Work;
 import org.orcid.pojo.ContributorsRolesAndSequences;
 import org.orcid.pojo.IdentifierType;
+import org.orcid.pojo.PIDResolutionResult;
 import org.orcid.pojo.WorkExtended;
 import org.orcid.test.TargetProxyHelper;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -139,8 +143,6 @@ public class PubMedResolverTest {
             }
         });
 
-        when(cache.isHttp200(anyString())).thenReturn(true);
-
         when(cache.get("https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=PMCID:PMC1&resultType=core&format=json", MediaType.APPLICATION_JSON))
                 .thenAnswer(new Answer<InputStream>() {
 
@@ -157,6 +159,16 @@ public class PubMedResolverTest {
                     @Override
                     public InputStream answer(InvocationOnMock invocation) throws Throwable {
                         return PubMedResolverTest.class.getResourceAsStream("/examples/works/form_autofill/pmid.json");
+                    }
+
+                });
+
+        when(cache.get("https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID:pmid404&resultType=core&format=json", MediaType.APPLICATION_JSON))
+                .thenAnswer(new Answer<InputStream>() {
+
+                    @Override
+                    public InputStream answer(InvocationOnMock invocation) throws Throwable {
+                        return PubMedResolverTest.class.getResourceAsStream("/examples/works/form_autofill/pmid-no-results.json");
                     }
 
                 });
@@ -236,6 +248,57 @@ public class PubMedResolverTest {
         assertEquals(getRole(contributors, 1), "author");
         assertEquals("Author Two", getName(contributors, 1));
         assertEquals("ORCID Consortium", getName(contributors, 2));
+    }
+
+    /**
+     * PD-6180: NCBI answers HTTP 203 for pubmed.ncbi.nlm.nih.gov landing pages, so
+     * resolution must not depend on that page returning 200.
+     */
+    @Test
+    public void resolvePMIDMetadataWhenLandingPageIsNotHttp200Test() {
+        when(cache.isHttp200(anyString())).thenReturn(false);
+
+        WorkExtended work = resolver.resolveMetadata("pmid", "pmid1");
+        assertNotNull(work);
+        assertEquals("PMID title", work.getWorkTitle().getTitle().getContent());
+    }
+
+    @Test
+    public void resolvePMIDWhenLandingPageIsNotHttp200Test() {
+        when(cache.isHttp200(anyString())).thenReturn(false);
+
+        PIDResolutionResult result = resolver.resolve("pmid", "pmid1");
+        assertTrue(result.isResolved());
+        assertTrue(result.getAttemptedResolution());
+        assertTrue(result.isValidFormat());
+        assertEquals("https://www.ncbi.nlm.nih.gov/pubmed/pmid1", result.getGeneratedUrl());
+    }
+
+    @Test
+    public void resolvePMIDUnknownToEuropePMCTest() {
+        PIDResolutionResult result = resolver.resolve("pmid", "pmid404");
+        assertFalse(result.isResolved());
+        assertTrue(result.getAttemptedResolution());
+        assertTrue(result.isValidFormat());
+        assertNull(result.getGeneratedUrl());
+    }
+
+    @Test
+    public void resolveMetadataPMIDUnknownToEuropePMCTest() {
+        assertNull(resolver.resolveMetadata("pmid", "pmid404"));
+    }
+
+    @Test
+    public void resolvePMIDNotAttemptedForEmptyValueTest() {
+        PIDResolutionResult result = resolver.resolve("pmid", "");
+        assertFalse(result.isResolved());
+        assertFalse(result.getAttemptedResolution());
+    }
+
+    @Test
+    public void resolveMetadataCallsEuropePMCOnlyOnceTest() throws IOException {
+        assertNotNull(resolver.resolveMetadata("pmid", "pmid1"));
+        Mockito.verify(cache, Mockito.times(1)).get(anyString(), anyString());
     }
 
     private String getRole(List<ContributorsRolesAndSequences> contributors, Integer contributorsIndex) {

--- a/orcid-test/src/main/resources/examples/works/form_autofill/pmid-no-results.json
+++ b/orcid-test/src/main/resources/examples/works/form_autofill/pmid-no-results.json
@@ -1,0 +1,16 @@
+{
+	"version": "6.9",
+	"hitCount": 0,
+	"nextCursorMark": "xxx",
+	"request": {
+		"query": "EXT_ID:pmid404",
+		"resultType": "core",
+		"synonym": false,
+		"cursorMark": "*",
+		"pageSize": 25,
+		"sort": ""
+	},
+	"resultList": {
+		"result": []
+	}
+}


### PR DESCRIPTION
## Summary

PubMed identifiers (PMID/PMC) are rejected as invalid when adding works, in both QA and Sandbox — surfaced by the Cypress regression run (Qase 44, 45, 78, 86).

Root cause: `PubMedResolver` gated every resolution on a `HEAD` request to `https://pubmed.ncbi.nlm.nih.gov/<id>` returning exactly HTTP 200. NCBI now fronts that page with a cookie/bot challenge that answers **HTTP 203** to non-browser clients regardless of User-Agent, so the check always failed — before EuropePMC, the actual metadata source (which still resolves these identifiers correctly), was ever called. This is an external change, not a regression in this repo: no ORCID commit to the resolver path is implicated.

## Changes

- `PubMedResolver` now uses EuropePMC as the sole authority for whether an identifier exists (`resolve()` and `resolveMetadata()`), and never fetches the NCBI landing page.
- Existence is cached 20 minutes, matching prior behavior, but a failing lookup is no longer cached (a throwing loader isn't cached by Guava), so a transient EuropePMC hiccup doesn't stick for the full window.
- `resolveMetadata()` now returns `null` when EuropePMC has no results, instead of a `WorkExtended` populated with only a work type.
- The previously-silent `UnexpectedResponseCodeException` catch, and other failure paths, are now logged.

## Test plan

- [x] `PubMedResolverTest` extended with regression coverage; new tests were confirmed to fail against the pre-fix resolver before the fix was applied.
- [x] `mvn test -pl orcid-core -Dtest=PubMedResolverTest,DOIResolverTest,ArXivResolverTest,PIDResolverServiceTest` — 17/17 pass.
- [x] Live-verified against real EuropePMC using the three PMIDs from the ticket (10848626, 37098064, 10848627) — all resolve with correct title/contributors; an unknown PMID still correctly reports not-found.
- [ ] Once deployed to QA, run the four affected Cypress specs in `orcid-cypress_tests-private/cypress/e2e/contributors/` (they exercise the real resolver, no stubbing).