### PR TITLE
PD-6181 Send password reset link to all verified emails on the account

### DIFF
--- a/orcid-core/src/main/resources/org/orcid/core/template/reset_password_email.ftl
+++ b/orcid-core/src/main/resources/org/orcid/core/template/reset_password_email.ftl
@@ -1,6 +1,6 @@
 <#import "email_macros.ftl" as emailMacros />
 
-<@emailMacros.msg "email.reset_password.orcid_id" /> ${recipientEmail} <@emailMacros.msg "email.reset_password.is" /> ${baseUri}/${orcid}
+<@emailMacros.msg "email.reset_password.orcid_id" /> {recipientEmail} <@emailMacros.msg "email.reset_password.is" /> ${baseUri}/${orcid}
 
 <@emailMacros.msg "email.reset_password.to_reset" />
 

--- a/orcid-core/src/main/resources/org/orcid/core/template/reset_password_email.ftl
+++ b/orcid-core/src/main/resources/org/orcid/core/template/reset_password_email.ftl
@@ -1,6 +1,6 @@
 <#import "email_macros.ftl" as emailMacros />
 
-<@emailMacros.msg "email.reset_password.orcid_id" /> ${submittedEmail} <@emailMacros.msg "email.reset_password.is" /> ${baseUri}/${orcid}
+<@emailMacros.msg "email.reset_password.orcid_id" /> ${recipientEmail} <@emailMacros.msg "email.reset_password.is" /> ${baseUri}/${orcid}
 
 <@emailMacros.msg "email.reset_password.to_reset" />
 

--- a/orcid-core/src/main/resources/org/orcid/core/template/reset_password_email_html.ftl
+++ b/orcid-core/src/main/resources/org/orcid/core/template/reset_password_email_html.ftl
@@ -10,7 +10,7 @@
 			<img src="https://orcid.org/sites/all/themes/orcid/img/orcid-logo.png" alt="ORCID.org"/>
 		    <hr />
 		    <p style="font-family: arial, helvetica, sans-serif; font-size: 15px; color: #494A4C;">
-		    	<@emailMacros.msg "email.reset_password.orcid_id" /> ${recipientEmail} <@emailMacros.msg "email.reset_password.is" /> <a href="${baseUri}/${orcid}?lang=${locale}">${baseUri}/${orcid}</a>
+		    	<@emailMacros.msg "email.reset_password.orcid_id" /> {recipientEmail} <@emailMacros.msg "email.reset_password.is" /> <a href="${baseUri}/${orcid}?lang=${locale}">${baseUri}/${orcid}</a>
 		    </p>
 		    <p style="font-family: arial, helvetica, sans-serif; font-size: 15px; color: #494A4C;">
                 <@emailMacros.msg "email.reset_password.to_reset" />

--- a/orcid-core/src/main/resources/org/orcid/core/template/reset_password_email_html.ftl
+++ b/orcid-core/src/main/resources/org/orcid/core/template/reset_password_email_html.ftl
@@ -10,7 +10,7 @@
 			<img src="https://orcid.org/sites/all/themes/orcid/img/orcid-logo.png" alt="ORCID.org"/>
 		    <hr />
 		    <p style="font-family: arial, helvetica, sans-serif; font-size: 15px; color: #494A4C;">
-		    	<@emailMacros.msg "email.reset_password.orcid_id" /> ${submittedEmail} <@emailMacros.msg "email.reset_password.is" /> <a href="${baseUri}/${orcid}?lang=${locale}">${baseUri}/${orcid}</a>
+		    	<@emailMacros.msg "email.reset_password.orcid_id" /> ${recipientEmail} <@emailMacros.msg "email.reset_password.is" /> <a href="${baseUri}/${orcid}?lang=${locale}">${baseUri}/${orcid}</a>
 		    </p>
 		    <p style="font-family: arial, helvetica, sans-serif; font-size: 15px; color: #494A4C;">
                 <@emailMacros.msg "email.reset_password.to_reset" />

--- a/orcid-web/src/main/java/org/orcid/frontend/email/RecordEmailSender.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/email/RecordEmailSender.java
@@ -43,11 +43,19 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.context.NoSuchMessageException;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.HtmlUtils;
 
 @Component
 public class RecordEmailSender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RecordEmailSender.class);
+
+    /**
+     * Literal text in reset_password_email.ftl / _html.ftl. The reset templates are rendered once
+     * per request and this token is swapped per recipient, rather than re-rendering N times for a
+     * single differing value.
+     */
+    private static final String RECIPIENT_EMAIL_PLACEHOLDER = "{recipientEmail}";
 
     @Value("${org.orcid.core.mail.apiRecordCreationEmailEnabled:true}")
     private boolean apiRecordCreationEmailEnabled;
@@ -290,17 +298,22 @@ public class RecordEmailSender {
 
         String subject = verifyEmailUtils.getSubject("email.subject.reset", locale);
         Collection<String> recipients = buildPasswordResetRecipients(submittedEmail, userOrcid);
+        // Rendered once for the whole request: only the recipient's own address differs between
+        // copies, and it is substituted below. Rendering also stays outside the per-recipient
+        // catch, because a broken template fails for every recipient alike and swallowing that
+        // would turn "nobody got a link" into a warning nobody reads.
+        String bodyTemplate = templateManager.processTemplate("reset_password_email.ftl", templateParams);
+        String htmlBodyTemplate = templateManager.processTemplate("reset_password_email_html.ftl", templateParams);
         int accepted = 0;
         int failed = 0;
         for (String recipient : recipients) {
+            String body = bodyTemplate.replace(RECIPIENT_EMAIL_PLACEHOLDER, recipient);
+            // The HTML template renders inside <#escape x as x?html>, but this substitution runs
+            // after FreeMarker has finished, so the address has to be escaped here or it would be
+            // the one unescaped value in the document.
+            String htmlBody = htmlBodyTemplate.replace(RECIPIENT_EMAIL_PLACEHOLDER, HtmlUtils.htmlEscape(recipient));
             // One send per recipient on purpose. Putting every address in a single "to" would
             // disclose the record's whole verified email list to each of them.
-            templateParams.put("recipientEmail", recipient);
-            // Rendering stays outside the catch below. A broken template fails for every
-            // recipient alike, so swallowing it here would turn "nobody got a link" into a
-            // warning nobody reads.
-            String body = templateManager.processTemplate("reset_password_email.ftl", templateParams);
-            String htmlBody = templateManager.processTemplate("reset_password_email_html.ftl", templateParams);
             try {
                 if (mailgunManager.sendEmail(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG, recipient, subject, body, htmlBody)) {
                     accepted++;

--- a/orcid-web/src/main/java/org/orcid/frontend/email/RecordEmailSender.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/email/RecordEmailSender.java
@@ -1,6 +1,10 @@
 package org.orcid.frontend.email;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -50,6 +54,9 @@ public class RecordEmailSender {
 
     @Value("${org.orcid.utils.jwtExpirationInMinutes:240}")
     private long jwtExpirationInMinutes;
+
+    @Value("${org.orcid.core.mail.passwordReset.maxRecipients:25}")
+    private int passwordResetMaxRecipients;
     
     @Resource
     private ProfileEventDao profileEventDao;
@@ -261,12 +268,14 @@ public class RecordEmailSender {
 
         // Create map of template params
         Map<String, Object> templateParams = new HashMap<String, Object>();
-        templateParams.put("submittedEmail", submittedEmail);
         templateParams.put("orcid", userOrcid);
         templateParams.put("subject", verifyEmailUtils.getSubject("email.subject.reset", getUserLocaleFromProfileEntity(record)));
         templateParams.put("baseUri", orcidUrlManager.getBaseUrl());
         templateParams.put("baseUriHttp", orcidUrlManager.getBaseUriHttp());
-        // Generate body from template
+        // Mint the token and record it as the only redeemable one for this record before sending
+        // anything. The fan out below is one network round trip per recipient, so the link has to
+        // be redeemable by the time the first message lands; overwriting the entry is also what
+        // invalidates every previously issued link.
         String token;
         try {
             token = expiringLinkService.generateExpiringToken(userOrcid, jwtExpirationInMinutes, ExpiringLinkService.ExpiringLinkType.PASSWORD_RESET);
@@ -279,10 +288,71 @@ public class RecordEmailSender {
         templateParams.put("passwordResetUrl", resetUrl);
         verifyEmailUtils.addMessageParams(templateParams, locale);
 
-        // Generate body from template
-        String body = templateManager.processTemplate("reset_password_email.ftl", templateParams);
-        String htmlBody = templateManager.processTemplate("reset_password_email_html.ftl", templateParams);
-        mailgunManager.sendEmail(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG, submittedEmail, verifyEmailUtils.getSubject("email.subject.reset", locale), body, htmlBody);
+        String subject = verifyEmailUtils.getSubject("email.subject.reset", locale);
+        Collection<String> recipients = buildPasswordResetRecipients(submittedEmail, userOrcid);
+        int accepted = 0;
+        int failed = 0;
+        for (String recipient : recipients) {
+            // One send per recipient on purpose. Putting every address in a single "to" would
+            // disclose the record's whole verified email list to each of them.
+            templateParams.put("recipientEmail", recipient);
+            // Rendering stays outside the catch below. A broken template fails for every
+            // recipient alike, so swallowing it here would turn "nobody got a link" into a
+            // warning nobody reads.
+            String body = templateManager.processTemplate("reset_password_email.ftl", templateParams);
+            String htmlBody = templateManager.processTemplate("reset_password_email_html.ftl", templateParams);
+            try {
+                if (mailgunManager.sendEmail(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG, recipient, subject, body, htmlBody)) {
+                    accepted++;
+                }
+            } catch (Exception e) {
+                // The token is already redeemable, so one bad recipient must not deny the rest
+                // their copy of the link. Log the orcid only, never the address list.
+                failed++;
+                LOGGER.warn("Password reset: failed to send reset link for '" + userOrcid + "' to one of its recipients", e);
+            }
+        }
+        if (!recipients.isEmpty() && failed == recipients.size()) {
+            LOGGER.error("Password reset: could not send the reset link for '{}' to any of its {} recipients", userOrcid, recipients.size());
+        } else {
+            LOGGER.info("Password reset: reset link for '{}' accepted for {} of {} recipients", new Object[] { userOrcid, accepted, recipients.size() });
+        }
+    }
+
+    /**
+     * The reset link goes to the submitted address plus every verified address on the record, so a
+     * user who has lost access to the mailbox they typed can still recover through one they still
+     * hold. Addresses resolve case insensitively, so entries are de-duplicated on a normalized key
+     * while the stored form is what actually gets mailed.
+     */
+    private Collection<String> buildPasswordResetRecipients(String submittedEmail, String userOrcid) {
+        Map<String, String> recipients = new LinkedHashMap<String, String>();
+        // The submitted address goes first: it is the one named on the confirmation screen the
+        // user is watching. Keeping it also means an account with no verified address at all can
+        // still reset, exactly as it could before.
+        if (!PojoUtil.isEmpty(submittedEmail)) {
+            recipients.put(normalizePasswordResetRecipient(submittedEmail), submittedEmail);
+        }
+        Emails verifiedEmails = emailManager.getVerifiedEmails(userOrcid);
+        if (verifiedEmails != null && verifiedEmails.getEmails() != null) {
+            for (Email email : verifiedEmails.getEmails()) {
+                if (!PojoUtil.isEmpty(email.getEmail())) {
+                    // Overwrites the value but keeps the insertion order, so the submitted address
+                    // stays first and is mailed in its stored casing rather than as typed.
+                    recipients.put(normalizePasswordResetRecipient(email.getEmail()), email.getEmail());
+                }
+            }
+        }
+        if (recipients.size() <= passwordResetMaxRecipients) {
+            return recipients.values();
+        }
+        LOGGER.warn("Password reset: record '{}' has {} recipients, capping at {}", new Object[] { userOrcid, recipients.size(), passwordResetMaxRecipients });
+        List<String> capped = new ArrayList<String>(recipients.values());
+        return capped.subList(0, passwordResetMaxRecipients);
+    }
+
+    private String normalizePasswordResetRecipient(String email) {
+        return OrcidStringUtils.filterEmailAddress(email).toLowerCase(Locale.ROOT);
     }
 
     public void sendPasswordResetNotFoundEmail(String submittedEmail, Locale locale) {

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/PasswordResetController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/PasswordResetController.java
@@ -176,7 +176,9 @@ public class PasswordResetController extends BaseController {
                     LOGGER.info("Password reset: API record creation email sent to '{}'", passwordResetRequest.getEmail());
                     recordEmailSender.sendClaimReminderEmail(orcid,0,passwordResetRequest.getEmail());
                 } else {
-                    LOGGER.info("Password reset: Reset password email sent to '{}'", passwordResetRequest.getEmail());
+                    // The sender fans the link out to every verified address on the record and
+                    // logs the recipient counts itself, so this only records the request.
+                    LOGGER.info("Password reset: Reset password requested for '{}'", passwordResetRequest.getEmail());
                     recordEmailSender.sendPasswordResetEmail(passwordResetRequest.getEmail(), orcid);
                 }
             } else {

--- a/orcid-web/src/test/java/org/orcid/frontend/email/RecordEmailSenderTest.java
+++ b/orcid-web/src/test/java/org/orcid/frontend/email/RecordEmailSenderTest.java
@@ -1,8 +1,14 @@
 package org.orcid.frontend.email;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,6 +26,8 @@ import org.apache.commons.lang3.LocaleUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.orcid.core.adapter.v3.JpaJaxbNotificationAdapter;
@@ -30,8 +38,10 @@ import org.orcid.core.manager.ProfileEntityCacheManager;
 import org.orcid.core.manager.v3.EmailManager;
 import org.orcid.core.manager.v3.RecordNameManager;
 import org.orcid.core.manager.v3.SourceManager;
+import org.orcid.core.utils.cache.redis.RedisClient;
 import org.orcid.jaxb.model.common.AvailableLocales;
 import org.orcid.jaxb.model.v3.release.record.Email;
+import org.orcid.jaxb.model.v3.release.record.Emails;
 import org.orcid.persistence.dao.GenericDao;
 import org.orcid.persistence.dao.NotificationDao;
 import org.orcid.persistence.dao.ProfileDao;
@@ -66,6 +76,9 @@ public class RecordEmailSenderTest {
 
     @Mock
     public RecordNameManager mockRecordNameManager;
+
+    @Mock
+    private RedisClient mockRedisClient;
     
     @Resource
     RecordEmailSender recordEmailSender;
@@ -88,6 +101,27 @@ public class RecordEmailSenderTest {
         ReflectionTestUtils.setField(recordEmailSender, "recordNameManager", mockRecordNameManager);
         ReflectionTestUtils.setField(recordEmailSender, "profileEventDao", mockProfileEventDao);
         ReflectionTestUtils.setField(recordEmailSender, "mailgunManager", mockMailGunManager);
+        // expiringLinkService stays the real bean so the rendered bodies carry a genuine JWT.
+        ReflectionTestUtils.setField(recordEmailSender, "redisClient", mockRedisClient);
+    }
+
+    /** Builds a verified {@link Emails} list; the reset fan out reads it through getVerifiedEmails. */
+    private Emails verifiedEmails(String... addresses) {
+        Emails emails = new Emails();
+        for (String address : addresses) {
+            Email email = new Email();
+            email.setEmail(address);
+            email.setVerified(true);
+            emails.getEmails().add(email);
+        }
+        return emails;
+    }
+
+    private List<String> capturedResetRecipients() {
+        ArgumentCaptor<String> to = ArgumentCaptor.forClass(String.class);
+        verify(mockMailGunManager, atLeastOnce()).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), to.capture(), anyString(), anyString(),
+                anyString());
+        return to.getAllValues();
     }
     
     @Test
@@ -223,12 +257,193 @@ public class RecordEmailSenderTest {
     public void testResetEmail() throws Exception {
         String userOrcid = "0000-0000-0000-0003";
         String primaryEmail = "public_0000-0000-0000-0003@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(primaryEmail));
         for (AvailableLocales locale : AvailableLocales.values()) {
             EncryptionManager mockEncypter = mock(EncryptionManager.class);
             when(mockEncypter.encryptForExternalUse(any(String.class)))
                     .thenReturn("Ey+qsh7G2BFGEuqqkzlYRidL4NokGkIgDE+1KOv6aLTmIyrppdVA6WXFIaQ3KsQpKEb9FGUFRqiWorOfhbB2ww==");
             recordEmailSender.sendPasswordResetEmail(primaryEmail, userOrcid);
         }
+    }
+
+    @Test
+    public void testResetEmail_sendsToEveryVerifiedEmail() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "primary@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(submitted, "second@test.orcid.org", "third@test.orcid.org"));
+
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        verify(mockMailGunManager, times(1)).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), eq(submitted), anyString(), anyString(), anyString());
+        verify(mockMailGunManager, times(1)).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), eq("second@test.orcid.org"), anyString(), anyString(),
+                anyString());
+        verify(mockMailGunManager, times(1)).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), eq("third@test.orcid.org"), anyString(), anyString(),
+                anyString());
+        verify(mockMailGunManager, times(3)).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testResetEmail_sameLinkToEveryRecipient() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "primary@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(submitted, "second@test.orcid.org", "third@test.orcid.org"));
+
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        ArgumentCaptor<String> bodies = ArgumentCaptor.forClass(String.class);
+        verify(mockMailGunManager, times(3)).sendEmail(anyString(), anyString(), anyString(), bodies.capture(), anyString());
+
+        String firstLink = resetLinkIn(bodies.getAllValues().get(0));
+        assertTrue("no reset link found in the body", firstLink.length() > 0);
+        for (String body : bodies.getAllValues()) {
+            assertEquals(firstLink, resetLinkIn(body));
+        }
+    }
+
+    private String resetLinkIn(String body) {
+        java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("/reset-password-email/(\\S+)").matcher(body);
+        return matcher.find() ? matcher.group(1) : "";
+    }
+
+    @Test
+    public void testResetEmail_writesOneRedisEntryForAllRecipients() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails("primary@test.orcid.org", "second@test.orcid.org"));
+
+        recordEmailSender.sendPasswordResetEmail("primary@test.orcid.org", userOrcid);
+
+        verify(mockRedisClient, times(1)).set(eq("password-reset-token-" + userOrcid), anyString(), anyInt());
+        verify(mockMailGunManager, times(2)).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testResetEmail_tokenIsWrittenBeforeAnySend() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails("primary@test.orcid.org", "second@test.orcid.org"));
+
+        recordEmailSender.sendPasswordResetEmail("primary@test.orcid.org", userOrcid);
+
+        InOrder inOrder = inOrder(mockRedisClient, mockMailGunManager);
+        inOrder.verify(mockRedisClient).set(eq("password-reset-token-" + userOrcid), anyString(), anyInt());
+        inOrder.verify(mockMailGunManager, atLeastOnce()).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testResetEmail_dedupesSubmittedAddressCaseInsensitively() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String stored = "primary@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(stored));
+
+        recordEmailSender.sendPasswordResetEmail("Primary@Test.Orcid.Org", userOrcid);
+
+        // One message only, addressed in the stored casing rather than as typed.
+        verify(mockMailGunManager, times(1)).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), eq(stored), anyString(), anyString(), anyString());
+        verify(mockMailGunManager, times(1)).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testResetEmail_includesUnverifiedSubmittedAddress() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String unverifiedSubmitted = "unverified@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails("verified@test.orcid.org"));
+
+        recordEmailSender.sendPasswordResetEmail(unverifiedSubmitted, userOrcid);
+
+        verify(mockMailGunManager, times(1)).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), eq(unverifiedSubmitted), anyString(), anyString(), anyString());
+        verify(mockMailGunManager, times(1)).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), eq("verified@test.orcid.org"), anyString(), anyString(),
+                anyString());
+        verify(mockMailGunManager, times(2)).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testResetEmail_stillSendsWhenRecordHasNoVerifiedEmails() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "unverified@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(new Emails());
+
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        verify(mockMailGunManager, times(1)).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), eq(submitted), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testResetEmail_submittedAddressIsFirstRecipient() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "second@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails("first@test.orcid.org", submitted));
+
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        assertEquals(submitted, capturedResetRecipients().get(0));
+    }
+
+    @Test
+    public void testResetEmail_bodyNamesEachRecipientsOwnAddress() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "primary@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(submitted, "second@test.orcid.org"));
+
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        ArgumentCaptor<String> to = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> bodies = ArgumentCaptor.forClass(String.class);
+        verify(mockMailGunManager, times(2)).sendEmail(anyString(), to.capture(), anyString(), bodies.capture(), anyString());
+
+        for (int i = 0; i < to.getAllValues().size(); i++) {
+            String recipient = to.getAllValues().get(i);
+            String body = bodies.getAllValues().get(i);
+            assertTrue("body for " + recipient + " should name that recipient", body.contains(recipient));
+        }
+        // ...and must not leak the other address on the record.
+        assertEquals(submitted, to.getAllValues().get(0));
+        assertTrue(!bodies.getAllValues().get(0).contains("second@test.orcid.org"));
+    }
+
+    @Test
+    public void testResetEmail_continuesWhenOneRecipientFails() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "primary@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(submitted, "second@test.orcid.org", "third@test.orcid.org"));
+        doThrow(new RuntimeException("mailgun down")).when(mockMailGunManager).sendEmail(anyString(), eq("second@test.orcid.org"), anyString(), anyString(),
+                anyString());
+
+        // No exception escapes: the token is already redeemable, so the rest must still be tried.
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        verify(mockMailGunManager, times(1)).sendEmail(eq(EmailConstants.DO_NOT_REPLY_NOTIFY_ORCID_ORG), eq("third@test.orcid.org"), anyString(), anyString(),
+                anyString());
+        verify(mockMailGunManager, times(3)).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testResetEmail_toleratesMailgunReturningFalse() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "primary@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(submitted, "second@test.orcid.org"));
+        when(mockMailGunManager.sendEmail(anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(false);
+
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        verify(mockMailGunManager, times(2)).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testResetEmail_capsRecipients() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "primary@test.orcid.org";
+        int cap = 25;
+        String[] addresses = new String[40];
+        addresses[0] = submitted;
+        for (int i = 1; i < addresses.length; i++) {
+            addresses[i] = "extra" + i + "@test.orcid.org";
+        }
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(addresses));
+
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        verify(mockMailGunManager, times(cap)).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+        // The address the user typed is always inside the cap.
+        assertEquals(submitted, capturedResetRecipients().get(0));
     }
 
     @Test

--- a/orcid-web/src/test/java/org/orcid/frontend/email/RecordEmailSenderTest.java
+++ b/orcid-web/src/test/java/org/orcid/frontend/email/RecordEmailSenderTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,6 +38,7 @@ import org.orcid.core.manager.EncryptionManager;
 import org.orcid.core.manager.ProfileEntityCacheManager;
 import org.orcid.core.manager.v3.EmailManager;
 import org.orcid.core.manager.v3.RecordNameManager;
+import org.orcid.core.manager.TemplateManager;
 import org.orcid.core.manager.v3.SourceManager;
 import org.orcid.core.utils.cache.redis.RedisClient;
 import org.orcid.jaxb.model.common.AvailableLocales;
@@ -397,6 +399,47 @@ public class RecordEmailSenderTest {
         // ...and must not leak the other address on the record.
         assertEquals(submitted, to.getAllValues().get(0));
         assertTrue(!bodies.getAllValues().get(0).contains("second@test.orcid.org"));
+    }
+
+    @Test
+    public void testResetEmail_rendersEachTemplateOnceForAllRecipients() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        String submitted = "primary@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(verifiedEmails(submitted, "second@test.orcid.org", "third@test.orcid.org"));
+
+        TemplateManager real = (TemplateManager) ReflectionTestUtils.getField(recordEmailSender, "templateManager");
+        TemplateManager spyTemplateManager = spy(real);
+        ReflectionTestUtils.setField(recordEmailSender, "templateManager", spyTemplateManager);
+        try {
+            recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+            // Three recipients, but only the address differs between copies, so each template is
+            // rendered once and the placeholder is substituted per recipient.
+            verify(spyTemplateManager, times(1)).processTemplate(eq("reset_password_email.ftl"), any());
+            verify(spyTemplateManager, times(1)).processTemplate(eq("reset_password_email_html.ftl"), any());
+            verify(mockMailGunManager, times(3)).sendEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+        } finally {
+            ReflectionTestUtils.setField(recordEmailSender, "templateManager", real);
+        }
+    }
+
+    @Test
+    public void testResetEmail_escapesRecipientAddressInHtmlBody() throws Exception {
+        String userOrcid = "0000-0000-0000-0003";
+        // The substitution happens after FreeMarker's <#escape x as x?html> has run, so the
+        // address is the one value that could reach the HTML unescaped.
+        String submitted = "a&b@test.orcid.org";
+        when(mockEmailManager.getVerifiedEmails(userOrcid)).thenReturn(new Emails());
+
+        recordEmailSender.sendPasswordResetEmail(submitted, userOrcid);
+
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> htmlBody = ArgumentCaptor.forClass(String.class);
+        verify(mockMailGunManager, times(1)).sendEmail(anyString(), eq(submitted), anyString(), body.capture(), htmlBody.capture());
+
+        assertTrue("plain text body should carry the raw address", body.getValue().contains(submitted));
+        assertTrue("html body should carry the escaped address", htmlBody.getValue().contains("a&amp;b@test.orcid.org"));
+        assertTrue("html body must not carry the raw ampersand", !htmlBody.getValue().contains("a&b@test.orcid.org"));
     }
 
     @Test

--- a/orcid-web/src/test/java/org/orcid/frontend/web/controllers/PasswordResetControllerTest.java
+++ b/orcid-web/src/test/java/org/orcid/frontend/web/controllers/PasswordResetControllerTest.java
@@ -6,9 +6,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -48,6 +50,8 @@ import org.orcid.test.OrcidJUnit4ClassRunner;
 import org.orcid.test.TargetProxyHelper;
 import org.orcid.utils.ExpiringLinkService;
 import com.nimbusds.jwt.JWTClaimsSet;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ContextConfiguration;
@@ -140,20 +144,48 @@ public class PasswordResetControllerTest extends DBUnitTest {
     }
     
     @Test
+    public void testPasswordResetActiveClaimedSendsResetEmail() throws DatatypeConfigurationException {
+        String email = "email1@test.orcid.org";
+        String orcid = "0000-0000-0000-0000";
+        when(emailManager.emailExists(email)).thenReturn(true);
+        when(emailManager.findOrcidIdByEmail(email)).thenReturn(orcid);
+        when(profileEntityManager.isDeactivated(orcid)).thenReturn(false);
+        when(profileEntityManager.isProfileClaimedByEmail(email)).thenReturn(true);
+        ProfileEntity record = new ProfileEntity();
+        when(profileEntityCacheManager.retrieve(orcid)).thenReturn(record);
+        EmailRequest resetRequest = new EmailRequest();
+        resetRequest.setEmail(email);
+
+        ResponseEntity<EmailRequest> response = passwordResetController.issuePasswordResetRequest(new MockHttpServletRequest(), resetRequest);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody().getErrors());
+        assertTrue(response.getBody().getErrors().isEmpty());
+        // The controller hands the submitted address to the sender, which decides the full
+        // recipient set. Nothing about the fan out belongs here.
+        verify(mockRecordEmailSender, times(1)).sendPasswordResetEmail(eq(email), eq(orcid));
+        verify(mockRecordEmailSender, never()).sendReactivationEmail(anyString(), anyString());
+        verify(mockRecordEmailSender, never()).sendPasswordResetNotFoundEmail(anyString(), any());
+    }
+
+    @Test
     public void testPasswordResetUnclaimedSendEmail() throws DatatypeConfigurationException {
         String email = "email1@test.orcid.org";
         String orcid = "0000-0000-0000-0000";
         when(emailManager.emailExists(email)).thenReturn(true); 
         when(emailManager.findOrcidIdByEmail(email)).thenReturn(orcid);
         when(profileEntityManager.isDeactivated(orcid)).thenReturn(false);
-        when(profileEntityManager.isProfileClaimedByEmail(orcid)).thenReturn(false);
+        when(profileEntityManager.isProfileClaimedByEmail(email)).thenReturn(false);
         ProfileEntity record= new ProfileEntity();
         when(profileEntityCacheManager.retrieve(orcid)).thenReturn(record);
         EmailRequest resetRequest = new EmailRequest();
         resetRequest.setEmail("email1@test.orcid.org");
         resetRequest = passwordResetController.issuePasswordResetRequest(new MockHttpServletRequest(), resetRequest).getBody();
         assertNotNull(resetRequest.getErrors());
-        assertTrue(resetRequest.getErrors().isEmpty());   
+        assertTrue(resetRequest.getErrors().isEmpty());
+        verify(mockRecordEmailSender, times(1)).sendClaimReminderEmail(eq(orcid), eq(0), eq(email));
+        // An unclaimed record gets a claim reminder, never a fanned out reset link.
+        verify(mockRecordEmailSender, never()).sendPasswordResetEmail(anyString(), anyString());
     }    
     
     @Test
@@ -163,6 +195,9 @@ public class PasswordResetControllerTest extends DBUnitTest {
         resetRequest = passwordResetController.issuePasswordResetRequest(new MockHttpServletRequest(), resetRequest).getBody();
         assertNotNull(resetRequest.getErrors());
         assertTrue(resetRequest.getErrors().isEmpty());
+        verify(mockRecordEmailSender, times(1)).sendPasswordResetNotFoundEmail(eq("not_in_orcid@test.orcid.org"), any());
+        // There is no account here, so there is no verified email set to fan out to.
+        verify(mockRecordEmailSender, never()).sendPasswordResetEmail(anyString(), anyString());
     }
 
     @Test
@@ -178,7 +213,11 @@ public class PasswordResetControllerTest extends DBUnitTest {
         resetRequest.setEmail("email1@test.orcid.org");
         resetRequest = passwordResetController.issuePasswordResetRequest(new MockHttpServletRequest(), resetRequest).getBody();
         assertNotNull(resetRequest.getErrors());
-        assertTrue(resetRequest.getErrors().isEmpty());   
+        assertTrue(resetRequest.getErrors().isEmpty());
+        verify(mockRecordEmailSender, times(1)).sendReactivationEmail(eq(email), eq(orcid));
+        // A deactivated record gets a reactivation link, which is a different decision from
+        // fanning a password reset link out across the record's addresses.
+        verify(mockRecordEmailSender, never()).sendPasswordResetEmail(anyString(), anyString());
     }
 
     @Test


### PR DESCRIPTION
Sends the password reset link to every verified email address on the account, not only the address typed into the form ([PD-6181](https://orcid.clickup.com/t/9014437828/PD-6181)).

## What changed

`RecordEmailSender.sendPasswordResetEmail` now builds a recipient set and sends one message per recipient. Everything else in the flow is untouched — `PasswordResetController` keeps its param whitelist, email resolution, three-way branch and response shape; only its log wording changed.

- **Recipients** = the submitted address ∪ every verified address on the record, de-duplicated on a normalized key (`filterEmailAddress` + lowercase), since address lookup is case insensitive and would otherwise send two copies. The stored form of the address is what gets mailed, not the casing the user typed. The submitted address is ordered first.
- **Token handling is unchanged and deliberately stays ahead of the loop.** One JWT and one Redis entry per request, written before any send, so the link is redeemable when the first message lands.
- **Per-recipient body.** The template variable `submittedEmail` is renamed `recipientEmail` in `reset_password_email.ftl` / `_html.ftl`, so the line *"The ORCID iD registered to your address …"* is true in every copy and one address is not disclosed to another. Both templates have exactly one caller.
- **One send per recipient, never a multi-address `to`** — that would put the record's whole verified email list in the header of every copy.
- **Failure handling.** `MailGunManager.sendEmail` returns `false` rather than throwing on a non-200 or a QA/sandbox filter miss, so the send is wrapped per recipient and the loop continues; the endpoint still returns 200. Template rendering stays *outside* that catch — a broken template fails for every recipient alike, and swallowing it would turn "nobody got a link" into a warning nobody reads.
- **Logging** is keyed on the orcid and recipient counts, never the address list, to avoid dumping a record's whole email set into application logs on every request.
- **Recipient cap**, `org.orcid.core.mail.passwordReset.maxRecipients` (default 25), warns when it bites. Fan-out multiplies outbound mail per request against a Cloudflare budget of 30 requests / 600s per IP on `/reset-password.json`.

