### PR TITLE
PD-6176 Index version-of and funded-by external identifiers in Solr

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/solr/SolrConstants.java
+++ b/orcid-core/src/main/java/org/orcid/core/solr/SolrConstants.java
@@ -82,6 +82,7 @@ public class SolrConstants {
     public static final String DYNAMIC_SELF = "-self";
     public static final String DYNAMIC_PART_OF = "-part-of";
     public static final String DYNAMIC_VERSION_OF = "-version-of";
+    public static final String DYNAMIC_FUNDED_BY = "-funded-by";
     public static final String DYNAMIC_ORGANISATION_ID = "-org-id";
     public static final String RINGGOLD_ORGANISATION_ID = "ringgold-org-id";
     public static final String FUNDREF_ORGANISATION_ID = "fundref-org-id";

--- a/orcid-message-listener/src/main/java/org/orcid/listener/solr/OrcidRecordToSolrDocument.java
+++ b/orcid-message-listener/src/main/java/org/orcid/listener/solr/OrcidRecordToSolrDocument.java
@@ -162,6 +162,7 @@ public class OrcidRecordToSolrDocument {
             Map<String, List<String>> partOf = new HashMap<String, List<String>>();
             Map<String, List<String>> self = new HashMap<String, List<String>>();
             Map<String, List<String>> versionOf = new HashMap<String, List<String>>();
+            Map<String, List<String>> fundedBy = new HashMap<String, List<String>>();
 
             if (record.getActivitiesSummary() != null && record.getActivitiesSummary().getWorks() != null
                     && record.getActivitiesSummary().getWorks().getWorkGroup() != null) {
@@ -193,6 +194,22 @@ public class OrcidRecordToSolrDocument {
                                         }
                                         if (!partOf.get(id.getType() + SolrConstants.DYNAMIC_PART_OF).contains(id.getValue())) {
                                             partOf.get(id.getType() + SolrConstants.DYNAMIC_PART_OF).add(id.getValue());
+                                        }
+                                    }
+                                    if (Relationship.VERSION_OF.equals(id.getRelationship())) {
+                                        if (!versionOf.containsKey(id.getType() + SolrConstants.DYNAMIC_VERSION_OF)) {
+                                            versionOf.put(id.getType() + SolrConstants.DYNAMIC_VERSION_OF, new ArrayList<String>());
+                                        }
+                                        if (!versionOf.get(id.getType() + SolrConstants.DYNAMIC_VERSION_OF).contains(id.getValue())) {
+                                            versionOf.get(id.getType() + SolrConstants.DYNAMIC_VERSION_OF).add(id.getValue());
+                                        }
+                                    }
+                                    if (Relationship.FUNDED_BY.equals(id.getRelationship())) {
+                                        if (!fundedBy.containsKey(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY)) {
+                                            fundedBy.put(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY, new ArrayList<String>());
+                                        }
+                                        if (!fundedBy.get(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY).contains(id.getValue())) {
+                                            fundedBy.get(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY).add(id.getValue());
                                         }
                                     }
                                 }
@@ -295,6 +312,13 @@ public class OrcidRecordToSolrDocument {
                                     if (!versionOf.get(id.getType() + SolrConstants.DYNAMIC_VERSION_OF).contains(id.getValue())) {
                                         versionOf.get(id.getType() + SolrConstants.DYNAMIC_VERSION_OF).add(id.getValue());
                                     }
+                                } else if (org.orcid.jaxb.model.common.Relationship.FUNDED_BY.equals(id.getRelationship())) {
+                                    if (!fundedBy.containsKey(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY)) {
+                                        fundedBy.put(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY, new ArrayList<String>());
+                                    }
+                                    if (!fundedBy.get(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY).contains(id.getValue())) {
+                                        fundedBy.get(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY).add(id.getValue());
+                                    }
                                 }
                             }
                         }
@@ -356,6 +380,13 @@ public class OrcidRecordToSolrDocument {
                                     if (!versionOf.get(id.getType() + SolrConstants.DYNAMIC_VERSION_OF).contains(id.getValue())) {
                                         versionOf.get(id.getType() + SolrConstants.DYNAMIC_VERSION_OF).add(id.getValue());
                                     }
+                                } else if (org.orcid.jaxb.model.common.Relationship.FUNDED_BY.equals(id.getRelationship())) {
+                                    if (!fundedBy.containsKey(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY)) {
+                                        fundedBy.put(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY, new ArrayList<String>());
+                                    }
+                                    if (!fundedBy.get(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY).contains(id.getValue())) {
+                                        fundedBy.get(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY).add(id.getValue());
+                                    }
                                 }
                             }
                         }
@@ -405,6 +436,13 @@ public class OrcidRecordToSolrDocument {
                                         }
                                         if (!versionOf.get(id.getType() + SolrConstants.DYNAMIC_VERSION_OF).contains(id.getValue())) {
                                             versionOf.get(id.getType() + SolrConstants.DYNAMIC_VERSION_OF).add(id.getValue());
+                                        }
+                                    } else if (org.orcid.jaxb.model.common.Relationship.FUNDED_BY.equals(id.getRelationship())) {
+                                        if (!fundedBy.containsKey(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY)) {
+                                            fundedBy.put(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY, new ArrayList<String>());
+                                        }
+                                        if (!fundedBy.get(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY).contains(id.getValue())) {
+                                            fundedBy.get(id.getType() + SolrConstants.DYNAMIC_FUNDED_BY).add(id.getValue());
                                         }
                                     }
                                 }
@@ -658,10 +696,11 @@ public class OrcidRecordToSolrDocument {
                 }
             }
 
-            // Now add all self, part of and version of identifiers
+            // Now add all self, part of, version of and funded by identifiers
             profileIndexDocument.setSelfIds(self);
             profileIndexDocument.setPartOfIds(partOf);
             profileIndexDocument.setVersionOfIds(versionOf);
+            profileIndexDocument.setFundedByIds(fundedBy);
             // Now add all activities ext ids to the doc, the old way
             addExternalIdentifiersToIndexDocument(profileIndexDocument, allExternalIdentifiers);
 

--- a/orcid-message-listener/src/test/java/org/orcid/listener/converter/OrcidRecordToSolrDocumentTest.java
+++ b/orcid-message-listener/src/test/java/org/orcid/listener/converter/OrcidRecordToSolrDocumentTest.java
@@ -1,6 +1,7 @@
 package org.orcid.listener.converter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -13,13 +14,25 @@ import jakarta.xml.bind.Unmarshaller;
 
 import org.junit.Test;
 import org.orcid.jaxb.model.common.PeerReviewType;
+import org.orcid.jaxb.model.common.Relationship;
 import org.orcid.jaxb.model.common.Role;
 import org.orcid.jaxb.model.v3.release.common.DisambiguatedOrganization;
+import org.orcid.jaxb.model.v3.release.common.OrcidIdentifier;
 import org.orcid.jaxb.model.v3.release.common.Organization;
+import org.orcid.jaxb.model.v3.release.record.ExternalID;
+import org.orcid.jaxb.model.v3.release.record.ExternalIDs;
+import org.orcid.jaxb.model.v3.release.record.Person;
 import org.orcid.jaxb.model.v3.release.record.Record;
 import org.orcid.jaxb.model.v3.release.record.ResearchResource;
 import org.orcid.jaxb.model.v3.release.record.ResearchResourceHosts;
 import org.orcid.jaxb.model.v3.release.record.ResearchResourceItem;
+import org.orcid.jaxb.model.v3.release.record.summary.ActivitiesSummary;
+import org.orcid.jaxb.model.v3.release.record.summary.FundingGroup;
+import org.orcid.jaxb.model.v3.release.record.summary.FundingSummary;
+import org.orcid.jaxb.model.v3.release.record.summary.Fundings;
+import org.orcid.jaxb.model.v3.release.record.summary.WorkGroup;
+import org.orcid.jaxb.model.v3.release.record.summary.WorkSummary;
+import org.orcid.jaxb.model.v3.release.record.summary.Works;
 import org.orcid.listener.solr.OrcidRecordToSolrDocument;
 import org.orcid.utils.solr.entities.OrcidSolrDocument;
 import org.orcid.utils.solr.entities.SolrConstants;
@@ -112,10 +125,95 @@ public class OrcidRecordToSolrDocumentTest {
         assertTrue(v3Doc.getResearchResourceProposalTitles().contains("Giant Laser Award"));
         assertTrue(v3Doc.getResearchResourceProposalTitles().contains("Giant Laser Award2"));
         assertEquals(2, v3Doc.getResearchResourceItemNames().size());
-        assertTrue(v3Doc.getResearchResourceItemNames().contains("Giant Laser 1")); 
-        assertTrue(v3Doc.getResearchResourceItemNames().contains("Moon Targets"));        
+        assertTrue(v3Doc.getResearchResourceItemNames().contains("Giant Laser 1"));
+        assertTrue(v3Doc.getResearchResourceItemNames().contains("Moon Targets"));
+
+        // Relationship based identifiers. These were previously untested, so they are asserted here
+        // to protect the existing self/part-of behaviour.
+        assertNotNull(v3Doc.getSelfIds());
+        assertNotNull(v3Doc.getPartOfIds());
+        assertNotNull(v3Doc.getVersionOfIds());
+        assertNotNull(v3Doc.getFundedByIds());
+
+        // The funding in this record carries a grant_number external id with a 'self' relationship,
+        // but fundings do not contribute relationship based identifiers. Funding grant numbers stay
+        // searchable through the separate 'grant-numbers' field asserted above.
+        assertTrue(!v3Doc.getSelfIds().containsKey("grant_number" + SolrConstants.DYNAMIC_SELF));
+
+        // This record has no version-of or funded-by identifiers
+        assertTrue(v3Doc.getVersionOfIds().isEmpty());
+        assertTrue(v3Doc.getFundedByIds().isEmpty());
     }
-    
+
+    @Test
+    public void convertIndexesVersionOfAndFundedByTest() {
+        Record record = new Record();
+        record.setOrcidIdentifier(new OrcidIdentifier("0000-0001-2345-6789"));
+        // The activities are only indexed when a person is present on the record
+        record.setPerson(new Person());
+
+        WorkSummary work = new WorkSummary();
+        work.setExternalIdentifiers(externalIds(
+                externalId("doi", "10.1000/self", Relationship.SELF),
+                externalId("doi", "10.1000/part-of", Relationship.PART_OF),
+                externalId("doi", "10.1000/version-of", Relationship.VERSION_OF),
+                externalId("grant_number", "work-funded-by", Relationship.FUNDED_BY)));
+        WorkGroup workGroup = new WorkGroup();
+        workGroup.getWorkSummary().add(work);
+        Works works = new Works();
+        works.getWorkGroup().add(workGroup);
+
+        FundingSummary funding = new FundingSummary();
+        funding.setExternalIdentifiers(externalIds(
+                externalId("proposal-id", "funding-self", Relationship.SELF),
+                externalId("grant_number", "funding-funded-by", Relationship.FUNDED_BY)));
+        FundingGroup fundingGroup = new FundingGroup();
+        fundingGroup.getFundingSummary().add(funding);
+        Fundings fundings = new Fundings();
+        fundings.getFundingGroup().add(fundingGroup);
+
+        ActivitiesSummary activities = new ActivitiesSummary();
+        activities.setWorks(works);
+        activities.setFundings(fundings);
+        record.setActivitiesSummary(activities);
+
+        OrcidSolrDocument doc = new OrcidRecordToSolrDocument(false).convert(record, null);
+
+        // version-of on works is the gap this change closes
+        assertEquals(Arrays.asList("10.1000/version-of"), doc.getVersionOfIds().get("doi" + SolrConstants.DYNAMIC_VERSION_OF));
+
+        // funded-by was not indexed for any activity type before this change
+        assertEquals(Arrays.asList("work-funded-by"), doc.getFundedByIds().get("grant_number" + SolrConstants.DYNAMIC_FUNDED_BY));
+
+        // self and part-of keep working
+        assertEquals(Arrays.asList("10.1000/self"), doc.getSelfIds().get("doi" + SolrConstants.DYNAMIC_SELF));
+        assertEquals(Arrays.asList("10.1000/part-of"), doc.getPartOfIds().get("doi" + SolrConstants.DYNAMIC_PART_OF));
+
+        // Fundings deliberately contribute no relationship based identifiers. Indexing them would
+        // change the results of self and part-of queries that already work today, which is out of
+        // scope for PD-6176. The funding above carries both a 'self' and a 'funded-by' identifier
+        // and neither should appear.
+        assertNull(doc.getSelfIds().get("proposal-id" + SolrConstants.DYNAMIC_SELF));
+        assertNull(doc.getFundedByIds().get("proposal-id" + SolrConstants.DYNAMIC_FUNDED_BY));
+        assertTrue(!doc.getFundedByIds().get("grant_number" + SolrConstants.DYNAMIC_FUNDED_BY).contains("funding-funded-by"));
+    }
+
+    private ExternalIDs externalIds(ExternalID... ids) {
+        ExternalIDs externalIds = new ExternalIDs();
+        for (ExternalID id : ids) {
+            externalIds.getExternalIdentifier().add(id);
+        }
+        return externalIds;
+    }
+
+    private ExternalID externalId(String type, String value, Relationship relationship) {
+        ExternalID id = new ExternalID();
+        id.setType(type);
+        id.setValue(value);
+        id.setRelationship(relationship);
+        return id;
+    }
+
     private Record getRecord(String name) throws JAXBException {
         JAXBContext context = JAXBContext.newInstance(Record.class);
         Unmarshaller unmarshaller = context.createUnmarshaller();

--- a/orcid-utils/src/main/java/org/orcid/utils/solr/entities/OrcidSolrDocument.java
+++ b/orcid-utils/src/main/java/org/orcid/utils/solr/entities/OrcidSolrDocument.java
@@ -200,7 +200,11 @@ public class OrcidSolrDocument {
     // e.g. doi-version-of
     @Field("*" + SolrConstants.DYNAMIC_VERSION_OF)
     private Map<String, List<String>> versionOfIds;
-    
+
+    // e.g. grant_number-funded-by
+    @Field("*" + SolrConstants.DYNAMIC_FUNDED_BY)
+    private Map<String, List<String>> fundedByIds;
+
     // e.g. ringgold-org-id
     @Field("*" + SolrConstants.DYNAMIC_ORGANISATION_ID)
     private Map<String, Set<String>> organisationIds;
@@ -662,6 +666,14 @@ public class OrcidSolrDocument {
         this.versionOfIds = versionOfIds;
     }
 
+    public Map<String, List<String>> getFundedByIds() {
+        return fundedByIds;
+    }
+
+    public void setFundedByIds(Map<String, List<String>> fundedByIds) {
+        this.fundedByIds = fundedByIds;
+    }
+
     public Map<String, Set<String>> getOrganisationIds() {
         return organisationIds;
     }
@@ -784,6 +796,7 @@ public class OrcidSolrDocument {
         result = prime * result + ((externalIdSources == null) ? 0 : externalIdSources.hashCode());
         result = prime * result + ((externalIdTypeAndValue == null) ? 0 : externalIdTypeAndValue.hashCode());
         result = prime * result + ((familyName == null) ? 0 : familyName.hashCode());
+        result = prime * result + ((fundedByIds == null) ? 0 : fundedByIds.hashCode());
         result = prime * result + ((fundingTitles == null) ? 0 : fundingTitles.hashCode());
         result = prime * result + ((givenAndFamilyNames == null) ? 0 : givenAndFamilyNames.hashCode());
         result = prime * result + ((givenNames == null) ? 0 : givenNames.hashCode());
@@ -940,6 +953,11 @@ public class OrcidSolrDocument {
             if (other.familyName != null)
                 return false;
         } else if (!familyName.equals(other.familyName))
+            return false;
+        if (fundedByIds == null) {
+            if (other.fundedByIds != null)
+                return false;
+        } else if (!fundedByIds.equals(other.fundedByIds))
             return false;
         if (fundingTitles == null) {
             if (other.fundingTitles != null)

--- a/orcid-utils/src/main/java/org/orcid/utils/solr/entities/SolrConstants.java
+++ b/orcid-utils/src/main/java/org/orcid/utils/solr/entities/SolrConstants.java
@@ -80,6 +80,7 @@ public class SolrConstants {
     public static final String DYNAMIC_SELF = "-self";
     public static final String DYNAMIC_PART_OF = "-part-of";
     public static final String DYNAMIC_VERSION_OF = "-version-of";
+    public static final String DYNAMIC_FUNDED_BY = "-funded-by";
     public static final String DYNAMIC_ORGANISATION_ID = "-org-id";
     public static final String RINGGOLD_ORGANISATION_ID = "ringgold-org-id";
     public static final String FUNDREF_ORGANISATION_ID = "fundref-org-id";

--- a/orcid-utils/src/test/java/org/orcid/utils/solr/entities/OrcidSolrDocumentTest.java
+++ b/orcid-utils/src/test/java/org/orcid/utils/solr/entities/OrcidSolrDocumentTest.java
@@ -1,0 +1,61 @@
+package org.orcid.utils.solr.entities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.solr.client.solrj.beans.DocumentObjectBinder;
+import org.apache.solr.common.SolrInputDocument;
+import org.junit.Test;
+
+/**
+ * Verifies that the relationship based identifier maps are bound to the dynamic Solr fields the
+ * search queries rely on, e.g. a "grant_number-funded-by" map key must end up as a
+ * "grant_number-funded-by" field on the document. This is the same binder SolrJ uses internally
+ * when SolrIndexUpdater calls solrClient.addBean(...).
+ */
+public class OrcidSolrDocumentTest {
+
+    @Test
+    public void relationshipIdentifiersAreBoundToDynamicFields() {
+        OrcidSolrDocument doc = new OrcidSolrDocument();
+        doc.setOrcid("0000-0001-2345-6789");
+        doc.setSelfIds(map("doi" + SolrConstants.DYNAMIC_SELF, "10.1000/self"));
+        doc.setPartOfIds(map("doi" + SolrConstants.DYNAMIC_PART_OF, "10.1000/part-of"));
+        doc.setVersionOfIds(map("doi" + SolrConstants.DYNAMIC_VERSION_OF, "10.1000/version-of"));
+        doc.setFundedByIds(map("grant_number" + SolrConstants.DYNAMIC_FUNDED_BY, "funded-by-value"));
+
+        SolrInputDocument solrDoc = new DocumentObjectBinder().toSolrInputDocument(doc);
+
+        assertTrue(solrDoc.containsKey("doi-self"));
+        assertTrue(solrDoc.containsKey("doi-part-of"));
+        assertTrue(solrDoc.containsKey("doi-version-of"));
+        assertTrue(solrDoc.containsKey("grant_number-funded-by"));
+
+        assertTrue(solrDoc.getFieldValues("doi-version-of").contains("10.1000/version-of"));
+        assertTrue(solrDoc.getFieldValues("grant_number-funded-by").contains("funded-by-value"));
+    }
+
+    @Test
+    public void fundedByIdsAreIncludedInEqualsAndHashCode() {
+        OrcidSolrDocument one = new OrcidSolrDocument();
+        OrcidSolrDocument two = new OrcidSolrDocument();
+        assertEquals(one, two);
+
+        one.setFundedByIds(map("grant_number" + SolrConstants.DYNAMIC_FUNDED_BY, "funded-by-value"));
+        assertTrue(!one.equals(two));
+
+        two.setFundedByIds(map("grant_number" + SolrConstants.DYNAMIC_FUNDED_BY, "funded-by-value"));
+        assertEquals(one, two);
+        assertEquals(one.hashCode(), two.hashCode());
+    }
+
+    private Map<String, java.util.List<String>> map(String key, String value) {
+        Map<String, java.util.List<String>> result = new HashMap<String, java.util.List<String>>();
+        result.put(key, Arrays.asList(value));
+        return result;
+    }
+}

--- a/solr-config/cores/profile/conf/schema.xml
+++ b/solr-config/cores/profile/conf/schema.xml
@@ -1156,6 +1156,7 @@
 	<dynamicField name="*-self" type="string" indexed="true" stored="false" multiValued="true"/>
 	<dynamicField name="*-part-of" type="string" indexed="true" stored="false" multiValued="true"/>
 	<dynamicField name="*-version-of" type="string" indexed="true" stored="false" multiValued="true"/>
+	<dynamicField name="*-funded-by" type="string" indexed="true" stored="false" multiValued="true"/>
 	
 	<!-- org names and org ids -->
 	<dynamicField name="*-org-id" type="string" indexed="true" stored="false" multiValued="true"/>


### PR DESCRIPTION
Closes PD-6176 — https://orcid.clickup.com/t/9014437828/PD-6176

## Problem

Activity external identifiers are indexed into the `profile` Solr core as dynamic fields named `<id-type>-<relationship>`, so people can search:

```
https://pub.orcid.org/v3.0/csv-search/?q=<ID-TYPE>-self:<ID>&fl=orcid
```

Only `self` and `part-of` actually work. The two halves of this ticket turned out to be different problems:

- **`funded-by`** was never implemented at any layer — no constant, no document field, no Solr field.
- **`version-of`** already had a Solr field and indexer support for research resources and peer reviews, but the works loop only ever checked `SELF` and `PART_OF`. Since works are the dominant activity type, **every `*-version-of` field is empty in production**.

Measured with a field-existence query (`q=<field>:[* TO *]`) against `/v3.0/search/`. Note `/csv-search/` silently swallows Solr errors and returns empty for any garbage field name, so it can't be used to test this.

| Field | Sandbox | Production |
|---|---|---|
| `doi-self` | 9,200 | 7,667,297 |
| `doi-part-of` | 163 | 273,478 |
| `doi-version-of` | 0 | **0** |
| `*-funded-by` (all types) | HTTP 500 undefined field | HTTP 500 undefined field |

## Changes

- `DYNAMIC_FUNDED_BY` in both `SolrConstants` copies
- `fundedByIds` map on `OrcidSolrDocument`, including `equals`/`hashCode`
- `VERSION_OF` + `FUNDED_BY` indexed for works
- `FUNDED_BY` indexed for research resources, resource items and peer reviews
- `*-funded-by` dynamic field declared in the profile schema
- test coverage for the relationship maps, which had none

No `orcid-model` change is needed — `Relationship` already ships all four values.

## Fundings are deliberately out of scope

Fundings contribute no relationship based identifiers at all, so funding external identifiers are invisible to `self` and `part-of` queries too. That is a real gap, but fixing it would **change the results of queries that already work today** across millions of records, which is a different risk profile from adding brand new fields and is not what this ticket asked for. Funding grant numbers remain searchable through the existing `grant-numbers` field.

Raised separately on the ticket for product to consider. A test asserts the exclusion so it is not reintroduced by accident.

## ⚠️ Deployment ordering

**The Solr dynamic field must be applied to the running cores BEFORE this is deployed.**

The profile core uses a *managed* schema (`ClassicIndexSchemaFactory` is commented out in `solrconfig.xml`), so the `schema.xml` change in this PR **does not update an already provisioned core**. Verified locally: on startup Solr converts `schema.xml` into `managed-schema` and renames the original to `schema.xml.bak`.

There is no `AddSchemaFieldsUpdateProcessorFactory`, so unknown fields are not auto-created. Verified locally against two Solr 8.0.0 instances with the same document:

- with the field → HTTP 200
- without it → **HTTP 400 undefined field**

Because the listener sends the whole document via `addBean`, that 400 fails the **entire record**, not just the unknown field. Deploying this before the schema would break indexing for every record carrying a `funded-by` identifier.

Applying the field is hot, auto-reloads the core, and needs no reindex:

```bash
curl -X POST -H 'Content-type:application/json' --data-binary '{"add-dynamic-field":{"name":"*-funded-by","type":"string","indexed":true,"stored":false,"multiValued":true}}' http://<solr-write-host>:6983/solr/profile/schema
```

## Backfill

Solr documents are fully replaced on update, so existing documents only gain the new fields once re-indexed. Backfill script is in a companion ORCID-Internal PR: https://github.com/ORCID/ORCID-Internal/pull/736

## Testing

- 155 tests pass across `orcid-utils` and `orcid-message-listener`
- new tests confirmed to fail without the fix (`expected:<[10.1000/version-of]> but was:<null>`)
- end to end against a real Solr 8.0.0 loaded with this schema: ran the actual converter through SolrJ `addBean`, then queried — `doi-version-of`, `doi-funded-by`, `grant_number-funded-by` and `doi-self` all returned the record

## Notes

`*-funded-by` values will also flow into the catch-all `text` field via the existing `<copyField source="*" dest="text"/>`, consistent with how the other three relationships already behave.