### PR TITLE
PD-7614 account recovery endpoints

### DIFF
--- a/orcid-api-common/src/main/java/org/orcid/api/common/filter/ApiVersionCheckFilter.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/filter/ApiVersionCheckFilter.java
@@ -1,5 +1,6 @@
 package org.orcid.api.common.filter;
 
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,7 +31,12 @@ public class ApiVersionCheckFilter implements ContainerRequestFilter{
 
     private static final String WEBHOOKS_PATH_PATTERN = OrcidStringUtils.ORCID_STRING + "/webhook/.+";
     
-    private static final String MEMBER_INFO_PATH = "member-info";
+    /**
+     * Paths served without a version prefix. They are allowed to use verbs other than GET without
+     * carrying a version in the URL.
+     */
+    private static final Set<String> UNVERSIONED_PATHS = Set.of("oauth/token", "member-info", "account-recovery/match",
+            "account-recovery/reset-link");
     
     public ApiVersionCheckFilter() {
     }
@@ -53,7 +59,7 @@ public class ApiVersionCheckFilter implements ContainerRequestFilter{
         if (matcher.lookingAt()) {
             version = matcher.group(1);
         }
-        if(PojoUtil.isEmpty(version) && !PojoUtil.isEmpty(method) && !"oauth/token".equals(path) && !MEMBER_INFO_PATH.equals(path) && !path.matches(WEBHOOKS_PATH_PATTERN)) {
+        if(PojoUtil.isEmpty(version) && !PojoUtil.isEmpty(method) && !UNVERSIONED_PATHS.contains(path) && !path.matches(WEBHOOKS_PATH_PATTERN)) {
             if(!RequestMethod.GET.name().equals(method)) {
                 Object params[] = {method};
                 throw new OrcidBadRequestException(localeManager.resolveMessage("apiError.badrequest_missing_version.exception", params));    

--- a/orcid-core/src/main/java/org/orcid/core/api/OrcidApiConstants.java
+++ b/orcid-core/src/main/java/org/orcid/core/api/OrcidApiConstants.java
@@ -109,6 +109,8 @@ public class OrcidApiConstants {
     public static final String INTERNAL_API_PERSON_READ = "/{orcid}/person";
     public static final String INTERNAL_API_TOGGLZ_READ = "/togglz";
     public static final String INTERNAL_API_FIND_ORCID_BY_EMAIL = "/orcid/{email}/email";
+    public static final String INTERNAL_API_ACCOUNT_RECOVERY_MATCH = "/account-recovery/match";
+    public static final String INTERNAL_API_ACCOUNT_RECOVERY_RESET_LINK = "/account-recovery/reset-link";
     public static final String OTHER_NAMES = "/{orcid}/other-names";
     public static final String PERSONAL_DETAILS = "/{orcid}/personal-details";
     public static final String MEMBER_INFO = "/member-info";

--- a/orcid-core/src/main/java/org/orcid/core/utils/cache/redis/PasswordResetTokenEntry.java
+++ b/orcid-core/src/main/java/org/orcid/core/utils/cache/redis/PasswordResetTokenEntry.java
@@ -1,4 +1,4 @@
-package org.orcid.frontend.web.util;
+package org.orcid.core.utils.cache.redis;
 
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jettison.json.JSONException;

--- a/orcid-internal-api/README.md
+++ b/orcid-internal-api/README.md
@@ -2,25 +2,72 @@
 
 The ORCID-INTERNAL-API is intended to be used for internal ORCID apps, so, only specific clients can use it.
 
+Every request needs a client credentials token (`ROLE_CLIENT`); a human admin session cannot reach
+this module at all. On top of that, each endpoint checks its own scope, so granting a client one
+internal scope does not give it the others.
+
 ### Set up
 
-1. Add the scope '/orcid-internal/person/last_modified' to the client you want to use
+1. Add the scope the client needs. Scopes are derived from the client type when a client is created,
+so an internal scope has to be inserted by hand:
 
 ``insert into client_scope values('<Client ID>','/orcid-internal/person/last_modified',now() , now() );``
 
-``update client_details set last_modified=now() where client_details_id='<CLIENT_ID>'`` 
+``update client_details set last_modified=now() where client_details_id='<CLIENT_ID>'``
+
+The `last_modified` bump is not optional: client details are cached, and without it the new scope is
+not picked up.
+
+Note this grant is not durable. Updating the member type or converting the client reconciles
+`client_scope` back to the scopes of the client type and silently drops anything else, which makes a
+service depending on an internal scope fail closed and silent. Pair it with a check that alerts on
+the resulting 403.
+
+### Scopes
+
+| Scope | Grants |
+|---|---|
+| `/orcid-internal/person/last_modified` | `GET /{orcid}/person` |
+| `/orcid-internal` | `GET /orcid/{base64(email)}/email` |
+| `/orcid-internal/account-recovery` | `POST /account-recovery/match`, `POST /account-recovery/reset-link` |
+
+These are independent of one another. Despite the nested looking paths, holding `/orcid-internal`
+grants neither of the others: inheritance is declared in `ScopePathType`, not derived from the path.
 
 ### How to use it?
 
-1. Get the token: 
+1. Get the token:
 
-``curl -i -L -k -H 'Accept: application/json' -d 'client_id=<CLIENT_ID>' -d 'client_secret=<CLIENT_SECRET>' -d 'scope=/orcid-internal/person/read' -d 'grant_type=client_credentials' 'http://localhost:8080/orcid-internal-api/oauth/token'``
+``curl -i -L -k -H 'Accept: application/json' -d 'client_id=<CLIENT_ID>' -d 'client_secret=<CLIENT_SECRET>' -d 'scope=/orcid-internal/person/last_modified' -d 'grant_type=client_credentials' 'http://localhost:8080/orcid-internal-api/oauth/token'``
 
 2. Use the token to get user info
 
 ``curl -H 'Accept: application/json' -H 'Authorization: Bearer <TOKEN>' http://localhost:8080/orcid-internal-api/<ORCID>/person``
 
+### Account recovery
+
+Used by the lost email account recovery workflow (PD-5872), which needs to act on records the
+verified only lookups will not resolve. Both endpoints need the
+`/orcid-internal/account-recovery` scope.
+
+**Confirm an iD and an email belong to the same record.** Answers for locked, deactivated,
+unclaimed and deprecated records too. It only ever confirms whether the pair matches: an unknown
+email, an unknown iD, and an email belonging to a different record all produce the same
+`{"match": false}`, so it cannot be used to discover whether an address is registered.
+
+``curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer <TOKEN>' -d '{"orcid":"<ORCID>","email":"<EMAIL>"}' http://localhost:8080/orcid-internal-api/account-recovery/match``
+
+Returns `{"match": true, "recordStatus": "ACTIVE"}`, where the status is one of `ACTIVE`, `LOCKED`,
+`DEACTIVATED`, `UNCLAIMED` or `DEPRECATED`.
+
+**Mint a single use password reset link**, the same one an admin generates by hand today. Issuing a
+link invalidates any link issued earlier for that record, and it can only be redeemed once. The
+lifetime is shared with admin generated links (`org.orcid.utils.adminJwtExpirationInMinutes`,
+24 hours by default).
+
+``curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer <TOKEN>' -d '{"orcid":"<ORCID>"}' http://localhost:8080/orcid-internal-api/account-recovery/reset-link``
+
+Returns `{"resetLink": "...", "issueDate": "...", "expiryDate": "..."}`.
 
 #License
 See [LICENSE.md](https://github.com/ORCID/ORCID-Work-in-Progress/blob/master/LICENSE.md)
-

--- a/orcid-internal-api/src/main/java/org/orcid/internal/server/InternalApiServiceImplBase.java
+++ b/orcid-internal-api/src/main/java/org/orcid/internal/server/InternalApiServiceImplBase.java
@@ -1,11 +1,14 @@
 package org.orcid.internal.server;
 
+import static org.orcid.core.api.OrcidApiConstants.INTERNAL_API_ACCOUNT_RECOVERY_MATCH;
+import static org.orcid.core.api.OrcidApiConstants.INTERNAL_API_ACCOUNT_RECOVERY_RESET_LINK;
 import static org.orcid.core.api.OrcidApiConstants.INTERNAL_API_FIND_ORCID_BY_EMAIL;
 import static org.orcid.core.api.OrcidApiConstants.INTERNAL_API_PERSON_READ;
 import static org.orcid.core.api.OrcidApiConstants.INTERNAL_API_TOGGLZ_READ;
 import static org.orcid.core.api.OrcidApiConstants.MEMBER_INFO;
 import static org.orcid.core.api.OrcidApiConstants.STATUS_PATH;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -16,6 +19,8 @@ import jakarta.ws.rs.core.Response;
 
 import org.apache.commons.net.util.Base64;
 import org.orcid.internal.server.delegator.InternalApiServiceDelegator;
+import org.orcid.internal.util.AccountRecoveryMatchRequest;
+import org.orcid.internal.util.AccountRecoveryResetLinkRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -81,5 +86,36 @@ public class InternalApiServiceImplBase {
     @Path(INTERNAL_API_FIND_ORCID_BY_EMAIL)
     public Response findOrcidByEmail(@PathParam("email") String email) {
         return serviceDelegator.findOrcidByEmail(new String(Base64.decodeBase64(email.getBytes())));
+    }
+
+    /**
+     * Confirms that an ORCID iD and an email address belong to the same record, for the lost email
+     * account recovery workflow. Answers for records the public lookups will not resolve, such as
+     * locked, deactivated or unclaimed ones.
+     *
+     * @param request the iD and email to check as a pair
+     * @return whether the pair matches, plus the record status when it does
+     */
+    @POST
+    @Consumes(value = { MediaType.APPLICATION_JSON })
+    @Produces(value = { MediaType.APPLICATION_JSON })
+    @Path(INTERNAL_API_ACCOUNT_RECOVERY_MATCH)
+    public Response accountRecoveryMatch(AccountRecoveryMatchRequest request) {
+        return serviceDelegator.accountRecoveryMatch(request);
+    }
+
+    /**
+     * Mints a single use password reset link for a record whose owner has already been identified
+     * by support. Equivalent to the reset link an admin generates by hand today.
+     *
+     * @param request the iD to mint the link for
+     * @return the reset link and when it expires
+     */
+    @POST
+    @Consumes(value = { MediaType.APPLICATION_JSON })
+    @Produces(value = { MediaType.APPLICATION_JSON })
+    @Path(INTERNAL_API_ACCOUNT_RECOVERY_RESET_LINK)
+    public Response accountRecoveryResetLink(AccountRecoveryResetLinkRequest request) {
+        return serviceDelegator.accountRecoveryResetLink(request);
     }
 }

--- a/orcid-internal-api/src/main/java/org/orcid/internal/server/delegator/InternalApiServiceDelegator.java
+++ b/orcid-internal-api/src/main/java/org/orcid/internal/server/delegator/InternalApiServiceDelegator.java
@@ -2,6 +2,9 @@ package org.orcid.internal.server.delegator;
 
 import jakarta.ws.rs.core.Response;
 
+import org.orcid.internal.util.AccountRecoveryMatchRequest;
+import org.orcid.internal.util.AccountRecoveryResetLinkRequest;
+
 /**
  * 
  * @author Angel Montenegro
@@ -13,4 +16,6 @@ public interface InternalApiServiceDelegator {
     Response viewMemberInfo(String memberIdOrName);
     Response viewTogglz();
     Response findOrcidByEmail(String email);
+    Response accountRecoveryMatch(AccountRecoveryMatchRequest request);
+    Response accountRecoveryResetLink(AccountRecoveryResetLinkRequest request);
 }

--- a/orcid-internal-api/src/main/java/org/orcid/internal/server/delegator/impl/InternalApiServiceDelegatorImpl.java
+++ b/orcid-internal-api/src/main/java/org/orcid/internal/server/delegator/impl/InternalApiServiceDelegatorImpl.java
@@ -2,6 +2,7 @@ package org.orcid.internal.server.delegator.impl;
 
 import static org.orcid.core.api.OrcidApiConstants.STATUS_OK_MESSAGE;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,21 +15,36 @@ import org.orcid.core.exception.DeactivatedException;
 import org.orcid.core.exception.LockedException;
 import org.orcid.core.exception.OrcidDeprecatedException;
 import org.orcid.core.exception.OrcidNotClaimedException;
+import org.orcid.core.manager.impl.OrcidUrlManager;
 import org.orcid.core.manager.v3.MembersManager;
 import org.orcid.core.manager.v3.OrcidSecurityManager;
+import org.orcid.core.manager.v3.ProfileEntityManager;
 import org.orcid.core.manager.v3.read_only.EmailManagerReadOnly;
 import org.orcid.core.manager.v3.read_only.ProfileEntityManagerReadOnly;
 import org.orcid.core.security.visibility.aop.AccessControl;
 import org.orcid.core.togglz.Features;
+import org.orcid.core.utils.cache.redis.PasswordResetTokenEntry;
+import org.orcid.core.utils.cache.redis.RedisClient;
 import org.orcid.internal.server.delegator.InternalApiServiceDelegator;
+import org.orcid.internal.util.AccountRecoveryMatchRequest;
+import org.orcid.internal.util.AccountRecoveryMatchResponse;
+import org.orcid.internal.util.AccountRecoveryMatchResponse.RecordStatus;
+import org.orcid.internal.util.AccountRecoveryResetLinkRequest;
+import org.orcid.internal.util.AccountRecoveryResetLinkResponse;
 import org.orcid.internal.util.EmailResponse;
 import org.orcid.internal.util.LastModifiedResponse;
 import org.orcid.internal.util.MemberInfo;
 import org.orcid.jaxb.model.error_v2.OrcidError;
 import org.orcid.jaxb.model.message.ScopePathType;
 import org.orcid.pojo.ajaxForm.Member;
+import org.orcid.pojo.ajaxForm.PojoUtil;
+import org.orcid.utils.ExpiringLinkService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+
+import com.nimbusds.jose.JOSEException;
 
 /**
  * 
@@ -37,6 +53,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class InternalApiServiceDelegatorImpl implements InternalApiServiceDelegator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InternalApiServiceDelegatorImpl.class);
 
     @Resource(name = "membersManagerV3")
     private MembersManager memberManager;
@@ -49,6 +67,25 @@ public class InternalApiServiceDelegatorImpl implements InternalApiServiceDelega
 
     @Resource(name = "orcidSecurityManagerV3")
     protected OrcidSecurityManager orcidSecurityManager;
+
+    @Resource(name = "profileEntityManagerV3")
+    private ProfileEntityManager profileEntityManager;
+
+    @Resource
+    private ExpiringLinkService expiringLinkService;
+
+    @Resource
+    private RedisClient redisClient;
+
+    @Resource
+    private OrcidUrlManager orcidUrlManager;
+
+    /** Set from the Spring context; shares the expiry configured for admin generated reset links. */
+    private long resetLinkExpirationInMinutes;
+
+    public void setResetLinkExpirationInMinutes(long resetLinkExpirationInMinutes) {
+        this.resetLinkExpirationInMinutes = resetLinkExpirationInMinutes;
+    }
 
     @Override
     public Response viewStatusText() {
@@ -117,5 +154,89 @@ public class InternalApiServiceDelegatorImpl implements InternalApiServiceDelega
             return Response.noContent().build();
         }
     }
-    
+
+    @Override
+    public Response accountRecoveryMatch(AccountRecoveryMatchRequest request) {
+        orcidSecurityManager.checkScopes(ScopePathType.INTERNAL_ACCOUNT_RECOVERY);
+
+        if (request == null || PojoUtil.isEmpty(request.getOrcid()) || PojoUtil.isEmpty(request.getEmail())) {
+            return Response.noContent().build();
+        }
+
+        // Deliberately unfiltered: recovery requests routinely come from records the verified only
+        // lookups refuse to resolve. The pair check below is what protects the record.
+        String orcidForEmail;
+        try {
+            orcidForEmail = emailManagerReadOnly.findOrcidIdByEmail(request.getEmail());
+        } catch (NoResultException e) {
+            return Response.ok(AccountRecoveryMatchResponse.noMatch()).build();
+        }
+
+        if (orcidForEmail == null || !orcidForEmail.equals(request.getOrcid())) {
+            // One answer for every kind of non match, so the caller learns nothing about which part
+            // was wrong, or whether the email is registered at all.
+            return Response.ok(AccountRecoveryMatchResponse.noMatch()).build();
+        }
+
+        return Response.ok(AccountRecoveryMatchResponse.match(recordStatusOf(orcidForEmail))).build();
+    }
+
+    private RecordStatus recordStatusOf(String orcid) {
+        try {
+            orcidSecurityManager.checkProfile(orcid);
+        } catch (OrcidDeprecatedException e) {
+            return RecordStatus.DEPRECATED;
+        } catch (OrcidNotClaimedException e) {
+            return RecordStatus.UNCLAIMED;
+        } catch (LockedException e) {
+            return RecordStatus.LOCKED;
+        } catch (DeactivatedException e) {
+            return RecordStatus.DEACTIVATED;
+        }
+        return RecordStatus.ACTIVE;
+    }
+
+    @Override
+    public Response accountRecoveryResetLink(AccountRecoveryResetLinkRequest request) {
+        orcidSecurityManager.checkScopes(ScopePathType.INTERNAL_ACCOUNT_RECOVERY);
+
+        if (request == null || PojoUtil.isEmpty(request.getOrcid())) {
+            return Response.noContent().build();
+        }
+
+        String orcid = request.getOrcid();
+        if (!profileEntityManager.orcidExists(orcid)) {
+            OrcidError orcidError = new OrcidError();
+            orcidError.setResponseCode(404);
+            orcidError.setErrorCode(0);
+            orcidError.setMoreInfo("Unable to find a record for: " + orcid);
+            orcidError.setDeveloperMessage("No record found for: " + orcid);
+            orcidError.setUserMessage("Unable to find a record for: " + orcid);
+            return Response.status(Response.Status.NOT_FOUND).entity(orcidError).build();
+        }
+
+        String token;
+        try {
+            token = expiringLinkService.generateExpiringToken(orcid, resetLinkExpirationInMinutes, ExpiringLinkService.ExpiringLinkType.PASSWORD_RESET);
+        } catch (JOSEException e) {
+            LOGGER.error("Failed to generate an account recovery password reset token", e);
+            return Response.serverError().build();
+        }
+
+        // Overwrites any link issued earlier for this record, so only the newest one can be redeemed.
+        redisClient.set(PasswordResetTokenEntry.redisKey(orcid), new PasswordResetTokenEntry(token, false).serialize(),
+                (int) (resetLinkExpirationInMinutes * 60));
+
+        Date issueDate = new Date();
+        Calendar expiry = Calendar.getInstance();
+        expiry.setTime(issueDate);
+        expiry.add(Calendar.MINUTE, (int) resetLinkExpirationInMinutes);
+
+        // Recorded so a recovery can be traced back to the client that requested it. The link itself
+        // is never logged.
+        LOGGER.info("Account recovery reset link issued for {} by client {}", orcid, orcidSecurityManager.getClientIdFromAPIRequest());
+
+        String resetLink = orcidUrlManager.getBaseUrl() + "/reset-password-email/" + token;
+        return Response.ok(new AccountRecoveryResetLinkResponse(resetLink, issueDate, expiry.getTime())).build();
+    }
 }

--- a/orcid-internal-api/src/main/java/org/orcid/internal/util/AccountRecoveryMatchRequest.java
+++ b/orcid-internal-api/src/main/java/org/orcid/internal/util/AccountRecoveryMatchRequest.java
@@ -1,0 +1,27 @@
+package org.orcid.internal.util;
+
+/**
+ * Request to confirm that an ORCID iD and an email address belong to the same record.
+ */
+public class AccountRecoveryMatchRequest {
+
+    private String orcid;
+
+    private String email;
+
+    public String getOrcid() {
+        return orcid;
+    }
+
+    public void setOrcid(String orcid) {
+        this.orcid = orcid;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/orcid-internal-api/src/main/java/org/orcid/internal/util/AccountRecoveryMatchResponse.java
+++ b/orcid-internal-api/src/main/java/org/orcid/internal/util/AccountRecoveryMatchResponse.java
@@ -1,0 +1,56 @@
+package org.orcid.internal.util;
+
+import jakarta.xml.bind.annotation.XmlElement;
+
+/**
+ * The answer to an account recovery match check.
+ *
+ * Only ever states whether the submitted iD and email belong together. A caller cannot use it to
+ * discover whether an email address is registered, or to whom: every kind of non-match - unknown
+ * email, unknown iD, or an email that belongs to a different record - produces the same response.
+ * The record status is disclosed only once the pair is confirmed to match.
+ */
+public class AccountRecoveryMatchResponse {
+
+    @XmlElement(name = "match")
+    private boolean match;
+
+    @XmlElement(name = "recordStatus")
+    private RecordStatus recordStatus;
+
+    public enum RecordStatus {
+        ACTIVE, LOCKED, DEACTIVATED, UNCLAIMED, DEPRECATED;
+    }
+
+    public static AccountRecoveryMatchResponse noMatch() {
+        return new AccountRecoveryMatchResponse(false, null);
+    }
+
+    public static AccountRecoveryMatchResponse match(RecordStatus recordStatus) {
+        return new AccountRecoveryMatchResponse(true, recordStatus);
+    }
+
+    public AccountRecoveryMatchResponse() {
+    }
+
+    public AccountRecoveryMatchResponse(boolean match, RecordStatus recordStatus) {
+        this.match = match;
+        this.recordStatus = recordStatus;
+    }
+
+    public boolean isMatch() {
+        return match;
+    }
+
+    public void setMatch(boolean match) {
+        this.match = match;
+    }
+
+    public RecordStatus getRecordStatus() {
+        return recordStatus;
+    }
+
+    public void setRecordStatus(RecordStatus recordStatus) {
+        this.recordStatus = recordStatus;
+    }
+}

--- a/orcid-internal-api/src/main/java/org/orcid/internal/util/AccountRecoveryResetLinkRequest.java
+++ b/orcid-internal-api/src/main/java/org/orcid/internal/util/AccountRecoveryResetLinkRequest.java
@@ -1,0 +1,17 @@
+package org.orcid.internal.util;
+
+/**
+ * Request to mint a single use password reset link for a record.
+ */
+public class AccountRecoveryResetLinkRequest {
+
+    private String orcid;
+
+    public String getOrcid() {
+        return orcid;
+    }
+
+    public void setOrcid(String orcid) {
+        this.orcid = orcid;
+    }
+}

--- a/orcid-internal-api/src/main/java/org/orcid/internal/util/AccountRecoveryResetLinkResponse.java
+++ b/orcid-internal-api/src/main/java/org/orcid/internal/util/AccountRecoveryResetLinkResponse.java
@@ -1,0 +1,56 @@
+package org.orcid.internal.util;
+
+import java.util.Date;
+
+import jakarta.xml.bind.annotation.XmlElement;
+
+/**
+ * A freshly minted password reset link, together with the moment it stops working.
+ *
+ * Minting a link invalidates any link issued earlier for the same record, and the link may only be
+ * redeemed once.
+ */
+public class AccountRecoveryResetLinkResponse {
+
+    @XmlElement(name = "resetLink")
+    private String resetLink;
+
+    @XmlElement(name = "issueDate")
+    private Date issueDate;
+
+    @XmlElement(name = "expiryDate")
+    private Date expiryDate;
+
+    public AccountRecoveryResetLinkResponse() {
+    }
+
+    public AccountRecoveryResetLinkResponse(String resetLink, Date issueDate, Date expiryDate) {
+        this.resetLink = resetLink;
+        this.issueDate = issueDate;
+        this.expiryDate = expiryDate;
+    }
+
+    public String getResetLink() {
+        return resetLink;
+    }
+
+    public void setResetLink(String resetLink) {
+        this.resetLink = resetLink;
+    }
+
+    public Date getIssueDate() {
+        return issueDate;
+    }
+
+    public void setIssueDate(Date issueDate) {
+        this.issueDate = issueDate;
+    }
+
+    public Date getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(Date expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+}

--- a/orcid-internal-api/src/main/resources/orcid-internal-api-context.xml
+++ b/orcid-internal-api/src/main/resources/orcid-internal-api-context.xml
@@ -50,6 +50,9 @@
     <bean id="internalApiServiceImplBase" class="org.orcid.internal.server.InternalApiServiceImplBase">
     	<property name="serviceDelegator" ref="internalApiServiceDelegator"/>
     </bean> 
-    <bean id="internalApiServiceDelegator" class="org.orcid.internal.server.delegator.impl.InternalApiServiceDelegatorImpl" />
+    <bean id="internalApiServiceDelegator" class="org.orcid.internal.server.delegator.impl.InternalApiServiceDelegatorImpl">
+        <!-- Set here rather than with @Value: this bean is declared in XML, not component scanned. -->
+        <property name="resetLinkExpirationInMinutes" value="${org.orcid.utils.adminJwtExpirationInMinutes:1440}"/>
+    </bean>
     
 </beans>

--- a/orcid-internal-api/src/test/java/org/orcid/internal/server/InternalApiServiceDelegatorTest.java
+++ b/orcid-internal-api/src/test/java/org/orcid/internal/server/InternalApiServiceDelegatorTest.java
@@ -18,6 +18,10 @@ import org.orcid.core.exception.OrcidAccessControlException;
 import org.orcid.core.manager.v3.read_only.ProfileEntityManagerReadOnly;
 import org.orcid.core.utils.SecurityContextTestUtils;
 import org.orcid.internal.server.delegator.InternalApiServiceDelegator;
+import org.orcid.internal.util.AccountRecoveryMatchRequest;
+import org.orcid.internal.util.AccountRecoveryMatchResponse;
+import org.orcid.internal.util.AccountRecoveryResetLinkRequest;
+import org.orcid.internal.util.AccountRecoveryResetLinkResponse;
 import org.orcid.internal.util.EmailResponse;
 import org.orcid.internal.util.LastModifiedResponse;
 import org.orcid.internal.util.MemberInfo;
@@ -119,5 +123,88 @@ public class InternalApiServiceDelegatorTest extends DBUnitTest {
     public void findOrcidByEmailWrongScopeTest() {
         SecurityContextTestUtils.setUpSecurityContextForClientOnly("APP-5555555555555555", ScopePathType.INTERNAL_PERSON_LAST_MODIFIED);
         internalApiServiceDelegator.findOrcidByEmail("5555-5555-5555-5558@user.com");        
+    }
+
+    private static final String USER_EMAIL = "5555-5555-5555-5558@user.com";
+
+    private AccountRecoveryMatchRequest matchRequest(String orcid, String email) {
+        AccountRecoveryMatchRequest request = new AccountRecoveryMatchRequest();
+        request.setOrcid(orcid);
+        request.setEmail(email);
+        return request;
+    }
+
+    private AccountRecoveryResetLinkRequest resetLinkRequest(String orcid) {
+        AccountRecoveryResetLinkRequest request = new AccountRecoveryResetLinkRequest();
+        request.setOrcid(orcid);
+        return request;
+    }
+
+    @Test
+    public void accountRecoveryMatchTest() {
+        SecurityContextTestUtils.setUpSecurityContextForClientOnly("APP-5555555555555555", ScopePathType.INTERNAL_ACCOUNT_RECOVERY);
+        Response response = internalApiServiceDelegator.accountRecoveryMatch(matchRequest(USER_ORCID, USER_EMAIL));
+        assertNotNull(response);
+        AccountRecoveryMatchResponse info = (AccountRecoveryMatchResponse) response.getEntity();
+        assertTrue(info.isMatch());
+        assertEquals(AccountRecoveryMatchResponse.RecordStatus.ACTIVE, info.getRecordStatus());
+    }
+
+    /**
+     * Every kind of non match has to look the same from the outside, otherwise the endpoint tells a
+     * caller whether an address is registered.
+     */
+    @Test
+    public void accountRecoveryMatchIsNotAnEmailOracleTest() {
+        SecurityContextTestUtils.setUpSecurityContextForClientOnly("APP-5555555555555555", ScopePathType.INTERNAL_ACCOUNT_RECOVERY);
+
+        // A registered email, paired with the wrong iD
+        Response wrongPair = internalApiServiceDelegator.accountRecoveryMatch(matchRequest("0000-0000-0000-0000", USER_EMAIL));
+        AccountRecoveryMatchResponse wrongPairInfo = (AccountRecoveryMatchResponse) wrongPair.getEntity();
+
+        // An address nobody has registered
+        Response unknownEmail = internalApiServiceDelegator.accountRecoveryMatch(matchRequest(USER_ORCID, "nobody@user.com"));
+        AccountRecoveryMatchResponse unknownEmailInfo = (AccountRecoveryMatchResponse) unknownEmail.getEntity();
+
+        assertEquals(wrongPair.getStatus(), unknownEmail.getStatus());
+        assertFalse(wrongPairInfo.isMatch());
+        assertFalse(unknownEmailInfo.isMatch());
+        assertNull(wrongPairInfo.getRecordStatus());
+        assertNull(unknownEmailInfo.getRecordStatus());
+    }
+
+    @Test(expected = OrcidAccessControlException.class)
+    public void accountRecoveryMatchWrongScopeTest() {
+        SecurityContextTestUtils.setUpSecurityContextForClientOnly("APP-5555555555555555", ScopePathType.INTERNAL);
+        internalApiServiceDelegator.accountRecoveryMatch(matchRequest(USER_ORCID, USER_EMAIL));
+    }
+
+    @Test
+    public void accountRecoveryResetLinkTest() {
+        SecurityContextTestUtils.setUpSecurityContextForClientOnly("APP-5555555555555555", ScopePathType.INTERNAL_ACCOUNT_RECOVERY);
+        Response response = internalApiServiceDelegator.accountRecoveryResetLink(resetLinkRequest(USER_ORCID));
+        assertNotNull(response);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        AccountRecoveryResetLinkResponse info = (AccountRecoveryResetLinkResponse) response.getEntity();
+        assertNotNull(info.getResetLink());
+        assertTrue(info.getResetLink().contains("/reset-password-email/"));
+        assertNotNull(info.getIssueDate());
+        assertNotNull(info.getExpiryDate());
+        // Proves the expiry is wired from the Spring context rather than left at zero.
+        assertTrue(info.getExpiryDate().after(info.getIssueDate()));
+    }
+
+    @Test
+    public void accountRecoveryResetLinkUnknownRecordTest() {
+        SecurityContextTestUtils.setUpSecurityContextForClientOnly("APP-5555555555555555", ScopePathType.INTERNAL_ACCOUNT_RECOVERY);
+        Response response = internalApiServiceDelegator.accountRecoveryResetLink(resetLinkRequest("0000-0000-0000-0000"));
+        assertNotNull(response);
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test(expected = OrcidAccessControlException.class)
+    public void accountRecoveryResetLinkWrongScopeTest() {
+        SecurityContextTestUtils.setUpSecurityContextForClientOnly("APP-5555555555555555", ScopePathType.INTERNAL);
+        internalApiServiceDelegator.accountRecoveryResetLink(resetLinkRequest(USER_ORCID));
     }
 }

--- a/orcid-internal-api/src/test/java/org/orcid/internal/util/AccountRecoveryJsonContractTest.java
+++ b/orcid-internal-api/src/test/java/org/orcid/internal/util/AccountRecoveryJsonContractTest.java
@@ -1,0 +1,62 @@
+package org.orcid.internal.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Date;
+
+import org.junit.Test;
+import org.orcid.api.common.jaxb.OrcidJacksonJaxbJsonProvider;
+import org.orcid.internal.util.AccountRecoveryMatchResponse.RecordStatus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Pins the JSON these endpoints put on the wire.
+ *
+ * The provider serving them extends JacksonXmlBindJsonProvider, so JAXB annotations take part in
+ * naming. These assertions are what the account recovery poller reads, and what the module README
+ * documents, so a rename here is a breaking change and should fail here first.
+ */
+public class AccountRecoveryJsonContractTest {
+
+    private final ObjectMapper mapper = new OrcidJacksonJaxbJsonProvider().locateMapper(Object.class, null);
+
+    @Test
+    public void matchResponseFieldNamesTest() throws Exception {
+        String json = mapper.writeValueAsString(AccountRecoveryMatchResponse.match(RecordStatus.LOCKED));
+        assertTrue(json, json.contains("\"match\":true"));
+        assertTrue(json, json.contains("\"recordStatus\":\"LOCKED\""));
+    }
+
+    @Test
+    public void noMatchResponseHidesRecordStatusTest() throws Exception {
+        String json = mapper.writeValueAsString(AccountRecoveryMatchResponse.noMatch());
+        assertTrue(json, json.contains("\"match\":false"));
+        // A non match must not leak anything about a record, since there may not be one.
+        assertTrue(json, json.contains("\"recordStatus\":null") || !json.contains("recordStatus"));
+    }
+
+    @Test
+    public void resetLinkResponseFieldNamesTest() throws Exception {
+        Date now = new Date();
+        String json = mapper.writeValueAsString(new AccountRecoveryResetLinkResponse("https://orcid.org/reset-password-email/token", now, now));
+        assertTrue(json, json.contains("\"resetLink\":"));
+        assertTrue(json, json.contains("\"issueDate\":"));
+        assertTrue(json, json.contains("\"expiryDate\":"));
+    }
+
+    @Test
+    public void matchRequestIsReadableTest() throws Exception {
+        AccountRecoveryMatchRequest request = mapper.readValue("{\"orcid\":\"0000-0001-0000-0000\",\"email\":\"user@example.com\"}",
+                AccountRecoveryMatchRequest.class);
+        assertEquals("0000-0001-0000-0000", request.getOrcid());
+        assertEquals("user@example.com", request.getEmail());
+    }
+
+    @Test
+    public void resetLinkRequestIsReadableTest() throws Exception {
+        AccountRecoveryResetLinkRequest request = mapper.readValue("{\"orcid\":\"0000-0001-0000-0000\"}", AccountRecoveryResetLinkRequest.class);
+        assertEquals("0000-0001-0000-0000", request.getOrcid());
+    }
+}

--- a/orcid-web/src/main/java/org/orcid/frontend/email/RecordEmailSender.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/email/RecordEmailSender.java
@@ -23,7 +23,7 @@ import org.orcid.core.manager.v3.read_only.EmailManagerReadOnly;
 import org.orcid.core.utils.SourceEntityUtils;
 import org.orcid.core.utils.VerifyEmailUtils;
 import org.orcid.core.utils.cache.redis.RedisClient;
-import org.orcid.frontend.web.util.PasswordResetTokenEntry;
+import org.orcid.core.utils.cache.redis.PasswordResetTokenEntry;
 import org.orcid.jaxb.model.common.AvailableLocales;
 import org.orcid.jaxb.model.v3.release.record.Email;
 import org.orcid.jaxb.model.v3.release.record.Emails;

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/AdminController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/AdminController.java
@@ -22,7 +22,7 @@ import org.orcid.core.utils.VerifyEmailUtils;
 import org.orcid.core.utils.cache.redis.RedisClient;
 import org.orcid.frontend.email.RecordEmailSender;
 import org.orcid.frontend.web.util.PasswordConstants;
-import org.orcid.frontend.web.util.PasswordResetTokenEntry;
+import org.orcid.core.utils.cache.redis.PasswordResetTokenEntry;
 import org.orcid.jaxb.model.clientgroup.ClientType;
 import org.orcid.jaxb.model.clientgroup.MemberType;
 import org.orcid.jaxb.model.common.OrcidType;

--- a/orcid-web/src/main/java/org/orcid/frontend/web/controllers/PasswordResetController.java
+++ b/orcid-web/src/main/java/org/orcid/frontend/web/controllers/PasswordResetController.java
@@ -31,7 +31,7 @@ import org.orcid.frontend.spring.SocialAjaxAuthenticationSuccessHandler;
 import org.orcid.frontend.spring.web.social.config.SocialSignInUtils;
 import org.orcid.frontend.web.forms.OneTimeResetPasswordForm;
 import org.orcid.frontend.web.util.CommonPasswords;
-import org.orcid.frontend.web.util.PasswordResetTokenEntry;
+import org.orcid.core.utils.cache.redis.PasswordResetTokenEntry;
 import org.orcid.jaxb.model.v3.release.record.Emails;
 import org.orcid.persistence.jpa.entities.ProfileEntity;
 import org.orcid.pojo.EmailRequest;

--- a/orcid-web/src/test/java/org/orcid/frontend/web/controllers/AdminControllerTest.java
+++ b/orcid-web/src/test/java/org/orcid/frontend/web/controllers/AdminControllerTest.java
@@ -18,7 +18,7 @@ import org.orcid.core.togglz.Features;
 import org.orcid.core.utils.VerifyEmailUtils;
 import org.orcid.core.utils.cache.redis.RedisClient;
 import org.orcid.frontend.email.RecordEmailSender;
-import org.orcid.frontend.web.util.PasswordResetTokenEntry;
+import org.orcid.core.utils.cache.redis.PasswordResetTokenEntry;
 import org.orcid.jaxb.model.clientgroup.ClientType;
 import org.orcid.jaxb.model.clientgroup.MemberType;
 import org.orcid.jaxb.model.common.OrcidType;

--- a/orcid-web/src/test/java/org/orcid/frontend/web/controllers/PasswordResetControllerTest.java
+++ b/orcid-web/src/test/java/org/orcid/frontend/web/controllers/PasswordResetControllerTest.java
@@ -41,7 +41,7 @@ import org.orcid.core.utils.cache.redis.RedisClient;
 import org.orcid.core.togglz.Features;
 import org.orcid.frontend.email.RecordEmailSender;
 import org.orcid.frontend.web.forms.OneTimeResetPasswordForm;
-import org.orcid.frontend.web.util.PasswordResetTokenEntry;
+import org.orcid.core.utils.cache.redis.PasswordResetTokenEntry;
 import org.orcid.persistence.jpa.entities.ProfileEntity;
 import org.orcid.pojo.EmailRequest;
 import org.orcid.pojo.ajaxForm.Text;

--- a/pom.xml
+++ b/pom.xml
@@ -1006,7 +1006,7 @@ the software.
             <dependency>
                <groupId>org.orcid</groupId>
                <artifactId>orcid-model</artifactId>
-               <version>4.0.0</version>
+               <version>4.0.1</version>
             </dependency>
             <dependency>
                <groupId>org.orcid</groupId>


### PR DESCRIPTION
Two machine-callable endpoints on the internal API for the lost-email account recovery workflow (PD-5872), so support tooling can generate a reset link without a human admin session.

- `POST /account-recovery/match` confirms an iD and email belong to the same record. It resolves without the verified-only filter the existing lookup applies, because recovery requests routinely come from locked, deactivated or unclaimed records. An unknown email, an unknown iD and an email registered to another record all return the same `{match: false}`, so it cannot be used to discover whether an address is registered.
- `POST /account-recovery/reset-link` reuses the machinery behind the admin reset button, including the shared expiry and the single-use Redis entry.

Guarded by `ROLE_CLIENT` plus the new `/orcid-internal/account-recovery` scope (orcid-model 4.0.1, already on Central). It is declared as a leaf scope, so the `/orcid-internal` tokens the assertion services hold cannot reach either endpoint.

Two things worth a look in review:

`PasswordResetTokenEntry` moves from orcid-web to orcid-core. orcid-internal-api cannot depend on orcid-web, and this is the only part of the reset-link path that lived there. The class body is unchanged; the other five files are import swaps.

`ApiVersionCheckFilter`'s un-versioned allowlist becomes a Set rather than a fourth `&&` clause. Same semantics, but without the two new paths in it both endpoints return 400 on every request, which is the fix `member-info` needed before them.

Tested against the published 4.0.1 with the local copy purged first: 16 tests in orcid-internal-api, plus AdminControllerTest and PasswordResetControllerTest for the moved class.
