### PR TITLE
PD-6145 reusable url mappers accross all adapters for v2 and v3

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/UrlMapperV2.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/UrlMapperV2.java
@@ -1,0 +1,22 @@
+package org.orcid.core.adapter.mapstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mapstruct.Mapper;
+import org.orcid.jaxb.model.common_v2.Url;
+
+@Mapper(componentModel = "spring")
+public interface UrlMapperV2 {
+
+    default String map(Url url) {
+        return url == null || StringUtils.isBlank(url.getValue()) ? null : url.getValue().trim();
+    }
+
+    default Url map(String url) {
+        if (StringUtils.isBlank(url)) {
+            return null;
+        }
+        Url result = new Url();
+        result.setValue(url.trim());
+        return result;
+    }
+}

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/UrlMapperV3.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/UrlMapperV3.java
@@ -1,0 +1,22 @@
+package org.orcid.core.adapter.mapstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mapstruct.Mapper;
+import org.orcid.jaxb.model.v3.release.common.Url;
+
+@Mapper(componentModel = "spring")
+public interface UrlMapperV3 {
+
+    default String map(Url url) {
+        return url == null || StringUtils.isBlank(url.getValue()) ? null : url.getValue().trim();
+    }
+
+    default Url map(String url) {
+        if (StringUtils.isBlank(url)) {
+            return null;
+        }
+        Url result = new Url();
+        result.setValue(url.trim());
+        return result;
+    }
+}

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbExternalIdentifierAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbExternalIdentifierAdapterImpl.java
@@ -10,6 +10,7 @@ import org.mapstruct.MappingTarget;
 
 import org.orcid.core.adapter.JpaJaxbExternalIdentifierAdapter;
 import org.orcid.core.adapter.mapstruct.SourceMapperV2;
+import org.orcid.core.adapter.mapstruct.UrlMapperV2;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV2;
 import org.orcid.jaxb.model.record_v2.PersonExternalIdentifier;
 import org.orcid.jaxb.model.record_v2.PersonExternalIdentifiers;
@@ -18,7 +19,7 @@ import org.orcid.persistence.jpa.entities.ExternalIdentifierEntity;
 
 @Mapper(
     componentModel = "spring", 
-    uses = {SourceMapperV2.class, VisibilityMapperV2.class}
+    uses = {SourceMapperV2.class, VisibilityMapperV2.class, UrlMapperV2.class}
 )
 public abstract class JpaJaxbExternalIdentifierAdapterImpl implements JpaJaxbExternalIdentifierAdapter {
 
@@ -42,7 +43,7 @@ public abstract class JpaJaxbExternalIdentifierAdapterImpl implements JpaJaxbExt
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "type", target = "externalIdCommonName")
     @Mapping(source = "value", target = "externalIdReference")
-    @Mapping(source = "url.value", target = "externalIdUrl")
+    @Mapping(source = "url", target = "externalIdUrl")
     // Orika used fieldBToA for these, meaning we ignore them on the way in
     @Mapping(target = "displayIndex", ignore = true)
     @Mapping(target = "dateCreated", ignore = true)
@@ -54,7 +55,7 @@ public abstract class JpaJaxbExternalIdentifierAdapterImpl implements JpaJaxbExt
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "externalIdCommonName", target = "type")
     @Mapping(source = "externalIdReference", target = "value")
-    @Mapping(source = "externalIdUrl", target = "url.value")
+    @Mapping(source = "externalIdUrl", target = "url")
     @Mapping(source = "dateCreated", target = "createdDate.value")
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
     @Mapping(source = ".", target = "source")
@@ -94,7 +95,7 @@ public abstract class JpaJaxbExternalIdentifierAdapterImpl implements JpaJaxbExt
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "type", target = "externalIdCommonName")
     @Mapping(source = "value", target = "externalIdReference")
-    @Mapping(source = "url.value", target = "externalIdUrl")
+    @Mapping(source = "url", target = "externalIdUrl")
     @Mapping(target = "displayIndex", ignore = true)
     @Mapping(target = "dateCreated", ignore = true)
     @Mapping(target = "lastModified", ignore = true)

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbFundingAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbFundingAdapterImpl.java
@@ -13,6 +13,7 @@ import org.mapstruct.Named;
 import org.orcid.core.adapter.JpaJaxbFundingAdapter;
 import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV2;
 import org.orcid.core.adapter.mapstruct.SourceMapperV2;
+import org.orcid.core.adapter.mapstruct.UrlMapperV2;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV2;
 import org.orcid.core.adapter.mapstruct.JSONFundingExternalIdentifiersMapperV2;
 import org.orcid.core.adapter.mapstruct.FundingContributorsMapperV2;
@@ -27,6 +28,7 @@ import org.orcid.persistence.jpa.entities.ProfileFundingEntity;
         SourceMapperV2.class, 
         VisibilityMapperV2.class, 
         FuzzyDateMapperV2.class,
+        UrlMapperV2.class,
         JSONFundingExternalIdentifiersMapperV2.class, 
         FundingContributorsMapperV2.class
     }
@@ -45,7 +47,7 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = "title.translatedTitle.languageCode", target = "translatedTitleLanguageCode")
     @Mapping(source = "amount.content", target = "numericAmount", qualifiedByName = "amountContentToNumericAmount")
     @Mapping(source = "amount.currencyCode", target = "currencyCode")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "contributors", target = "contributorsJson")
     // Orika mapped these as fieldBToA (Database -> API only)
@@ -75,7 +77,7 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = "translatedTitleLanguageCode", target = "title.translatedTitle.languageCode")
     @Mapping(source = "numericAmount", target = "amount.content")
     @Mapping(source = "currencyCode", target = "amount.currencyCode")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "contributorsJson", target = "contributors")
     // Nested org mappings
@@ -129,7 +131,7 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = "title.translatedTitle.languageCode", target = "translatedTitleLanguageCode")
     @Mapping(source = "amount.content", target = "numericAmount", qualifiedByName = "amountContentToNumericAmount")
     @Mapping(source = "amount.currencyCode", target = "currencyCode")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "contributors", target = "contributorsJson")
     // Ignore security-sensitive fields on update

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbPeerReviewAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbPeerReviewAdapterImpl.java
@@ -13,6 +13,7 @@ import org.orcid.core.adapter.mapstruct.JSONPeerReviewWorkExternalIdentifierMapp
 import org.orcid.core.adapter.mapstruct.JSONWorkExternalIdentifiersMapperV2;
 import org.orcid.core.adapter.mapstruct.OrgMapperV2;
 import org.orcid.core.adapter.mapstruct.SourceMapperV2;
+import org.orcid.core.adapter.mapstruct.UrlMapperV2;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV2;
 import org.orcid.jaxb.model.record.summary_v2.PeerReviewSummary;
 import org.orcid.jaxb.model.record_v2.PeerReview;
@@ -28,6 +29,7 @@ import org.orcid.persistence.jpa.entities.PeerReviewEntity;
         OrgMapperV2.class,
         JSONWorkExternalIdentifiersMapperV2.class,
         JSONPeerReviewWorkExternalIdentifierMapperV2.class
+        , UrlMapperV2.class
     }
 )
 public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewAdapter {
@@ -58,7 +60,7 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
     @Override
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "role", target = "role")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "type", target = "type")
     @Mapping(source = "groupId", target = "groupId")
     @Mapping(source = "subjectExternalIdentifier", target = "subjectExternalIdentifiersJson")
@@ -67,7 +69,7 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
     @Mapping(source = "subjectName.title.content", target = "subjectName")
     @Mapping(source = "subjectName.translatedTitle.content", target = "subjectTranslatedName")
     @Mapping(source = "subjectName.translatedTitle.languageCode", target = "subjectTranslatedNameLanguageCode")
-    @Mapping(source = "subjectUrl.value", target = "subjectUrl")
+    @Mapping(source = "subjectUrl", target = "subjectUrl")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "completionDate", target = "completionDate")
     @Mapping(source = "organization", target = "org")
@@ -85,7 +87,7 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
     @Mapping(source = "dateCreated", target = "createdDate.value")
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
     @Mapping(source = "role", target = "role")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "type", target = "type")
     @Mapping(source = "groupId", target = "groupId")
     @Mapping(source = "subjectExternalIdentifiersJson", target = "subjectExternalIdentifier")
@@ -94,7 +96,7 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
     @Mapping(source = "subjectName", target = "subjectName.title.content")
     @Mapping(source = "subjectTranslatedName", target = "subjectName.translatedTitle.content")
     @Mapping(source = "subjectTranslatedNameLanguageCode", target = "subjectName.translatedTitle.languageCode")
-    @Mapping(source = "subjectUrl", target = "subjectUrl.value")
+    @Mapping(source = "subjectUrl", target = "subjectUrl")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "completionDate", target = "completionDate")
     @Mapping(source = "org", target = "organization")
@@ -131,7 +133,7 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
     @Override
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "role", target = "role")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "type", target = "type")
     @Mapping(source = "groupId", target = "groupId")
     @Mapping(source = "subjectExternalIdentifier", target = "subjectExternalIdentifiersJson")
@@ -140,7 +142,7 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
     @Mapping(source = "subjectName.title.content", target = "subjectName")
     @Mapping(source = "subjectName.translatedTitle.content", target = "subjectTranslatedName")
     @Mapping(source = "subjectName.translatedTitle.languageCode", target = "subjectTranslatedNameLanguageCode")
-    @Mapping(source = "subjectUrl.value", target = "subjectUrl")
+    @Mapping(source = "subjectUrl", target = "subjectUrl")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "completionDate", target = "completionDate")
     @Mapping(source = "organization", target = "org")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbResearcherUrlAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbResearcherUrlAdapterImpl.java
@@ -3,22 +3,21 @@ package org.orcid.core.adapter.mapstruct.impl;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 import org.orcid.core.adapter.JpaJaxbResearcherUrlAdapter;
 import org.orcid.core.adapter.mapstruct.SourceMapperV2;
+import org.orcid.core.adapter.mapstruct.UrlMapperV2;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV2;
-import org.orcid.jaxb.model.common_v2.Url;
 import org.orcid.jaxb.model.record_v2.ResearcherUrl;
 import org.orcid.jaxb.model.record_v2.ResearcherUrls;
 import org.orcid.persistence.jpa.entities.ResearcherUrlEntity;
 
 @Mapper(
     componentModel = "spring", 
-    uses = {SourceMapperV2.class, VisibilityMapperV2.class}
+    uses = {SourceMapperV2.class, VisibilityMapperV2.class, UrlMapperV2.class}
 )
 public abstract class JpaJaxbResearcherUrlAdapterImpl implements JpaJaxbResearcherUrlAdapter {
 
@@ -55,19 +54,6 @@ public abstract class JpaJaxbResearcherUrlAdapterImpl implements JpaJaxbResearch
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
     @Mapping(source = ".", target = "source")
     public abstract ResearcherUrl toResearcherUrl(ResearcherUrlEntity entity);
-
-    protected String map(Url url) {
-        return url == null || StringUtils.isBlank(url.getValue()) ? null : url.getValue().trim();
-    }
-
-    protected Url mapUrl(String url) {
-        if (StringUtils.isBlank(url)) {
-            return null;
-        }
-        Url result = new Url();
-        result.setValue(url.trim());
-        return result;
-    }
 
     @Override
     public ResearcherUrls toResearcherUrlList(Collection<ResearcherUrlEntity> entities) {

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbWorkAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbWorkAdapterImpl.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.orcid.core.adapter.JpaJaxbWorkAdapter;
 import org.orcid.core.adapter.mapstruct.JSONWorkExternalIdentifiersMapperV2;
 import org.orcid.core.adapter.mapstruct.SourceMapperV2;
+import org.orcid.core.adapter.mapstruct.UrlMapperV2;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV2;
 import org.orcid.core.adapter.mapstruct.WorkContributorsMapperV2;
 import org.orcid.core.adapter.mapstruct.WorkMapperV2;
@@ -23,7 +24,6 @@ import org.orcid.jaxb.model.common_v2.Iso3166Country;
 import org.orcid.jaxb.model.common_v2.Month;
 import org.orcid.jaxb.model.common_v2.PublicationDate;
 import org.orcid.jaxb.model.common_v2.Subtitle;
-import org.orcid.jaxb.model.common_v2.Url;
 import org.orcid.jaxb.model.common_v2.Year;
 import org.orcid.jaxb.model.record.summary_v2.WorkSummary;
 import org.orcid.jaxb.model.record_v2.Work;
@@ -39,6 +39,7 @@ import org.orcid.persistence.jpa.entities.WorkEntity;
     uses = {
         SourceMapperV2.class,
         VisibilityMapperV2.class,
+        UrlMapperV2.class,
         JSONWorkExternalIdentifiersMapperV2.class,
         WorkContributorsMapperV2.class
     }
@@ -156,19 +157,6 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
         }
         Subtitle result = new Subtitle();
         result.setContent(subtitle.trim());
-        return result;
-    }
-
-    protected String map(Url url) {
-        return url == null || StringUtils.isBlank(url.getValue()) ? null : url.getValue().trim();
-    }
-
-    protected Url mapUrl(String url) {
-        if (StringUtils.isBlank(url)) {
-            return null;
-        }
-        Url result = new Url();
-        result.setValue(url.trim());
         return result;
     }
 

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbDistinctionAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbDistinctionAdapterImpl.java
@@ -12,6 +12,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.jaxb.model.v3.release.record.Distinction;
 import org.orcid.jaxb.model.v3.release.record.summary.DistinctionSummary;
@@ -25,7 +26,8 @@ import org.orcid.persistence.jpa.entities.OrgAffiliationRelationEntity;
         VisibilityMapperV3.class,
         JSONExternalIdentifiersMapperV3.class,
         OrgMapperV3.class,
-        FuzzyDateMapperV3.class
+        FuzzyDateMapperV3.class,
+        UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbDistinctionAdapterImpl implements JpaJaxbDistinctionAdapter {
@@ -34,7 +36,7 @@ public abstract class JpaJaxbDistinctionAdapterImpl implements JpaJaxbDistinctio
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -48,7 +50,7 @@ public abstract class JpaJaxbDistinctionAdapterImpl implements JpaJaxbDistinctio
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -61,7 +63,7 @@ public abstract class JpaJaxbDistinctionAdapterImpl implements JpaJaxbDistinctio
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")
@@ -75,7 +77,7 @@ public abstract class JpaJaxbDistinctionAdapterImpl implements JpaJaxbDistinctio
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbEducationAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbEducationAdapterImpl.java
@@ -11,6 +11,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbEducationAdapter;
 import org.orcid.jaxb.model.v3.release.record.Education;
@@ -27,7 +28,8 @@ import org.orcid.persistence.jpa.entities.OrgAffiliationRelationEntity;
         VisibilityMapperV3.class,
         JSONExternalIdentifiersMapperV3.class,
         OrgMapperV3.class,
-        FuzzyDateMapperV3.class
+        FuzzyDateMapperV3.class,
+        UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbEducationAdapterImpl implements JpaJaxbEducationAdapter {
@@ -36,7 +38,7 @@ public abstract class JpaJaxbEducationAdapterImpl implements JpaJaxbEducationAda
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -49,7 +51,7 @@ public abstract class JpaJaxbEducationAdapterImpl implements JpaJaxbEducationAda
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -62,7 +64,7 @@ public abstract class JpaJaxbEducationAdapterImpl implements JpaJaxbEducationAda
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")
@@ -76,7 +78,7 @@ public abstract class JpaJaxbEducationAdapterImpl implements JpaJaxbEducationAda
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbEmploymentAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbEmploymentAdapterImpl.java
@@ -11,6 +11,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbEmploymentAdapter;
 import org.orcid.jaxb.model.v3.release.record.Employment;
@@ -24,7 +25,8 @@ import org.orcid.persistence.jpa.entities.OrgAffiliationRelationEntity;
         VisibilityMapperV3.class,
         JSONExternalIdentifiersMapperV3.class,
         OrgMapperV3.class,
-        FuzzyDateMapperV3.class
+        FuzzyDateMapperV3.class,
+        UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbEmploymentAdapterImpl implements JpaJaxbEmploymentAdapter {
@@ -33,7 +35,7 @@ public abstract class JpaJaxbEmploymentAdapterImpl implements JpaJaxbEmploymentA
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -46,7 +48,7 @@ public abstract class JpaJaxbEmploymentAdapterImpl implements JpaJaxbEmploymentA
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -60,7 +62,7 @@ public abstract class JpaJaxbEmploymentAdapterImpl implements JpaJaxbEmploymentA
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")
@@ -74,7 +76,7 @@ public abstract class JpaJaxbEmploymentAdapterImpl implements JpaJaxbEmploymentA
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbExternalIdentifierAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbExternalIdentifierAdapterImpl.java
@@ -9,6 +9,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbExternalIdentifierAdapter;
 import org.orcid.jaxb.model.common.Relationship;
@@ -20,6 +21,7 @@ import org.orcid.persistence.jpa.entities.ExternalIdentifierEntity;
     componentModel = "spring",
     uses = {
         SourceMapperV3.class,
+        UrlMapperV3.class,
         VisibilityMapperV3.class
     }
 )
@@ -43,7 +45,7 @@ public abstract class JpaJaxbExternalIdentifierAdapterImpl implements JpaJaxbExt
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "type", target = "externalIdCommonName")
     @Mapping(source = "value", target = "externalIdReference")
-    @Mapping(source = "url.value", target = "externalIdUrl")
+    @Mapping(source = "url", target = "externalIdUrl")
     @Mapping(target = "dateCreated", ignore = true)
     @Mapping(target = "lastModified", ignore = true)
     @Mapping(target = "displayIndex", ignore = true)
@@ -53,7 +55,7 @@ public abstract class JpaJaxbExternalIdentifierAdapterImpl implements JpaJaxbExt
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "type", target = "externalIdCommonName")
     @Mapping(source = "value", target = "externalIdReference")
-    @Mapping(source = "url.value", target = "externalIdUrl")
+    @Mapping(source = "url", target = "externalIdUrl")
     @Mapping(target = "dateCreated", ignore = true)
     @Mapping(target = "lastModified", ignore = true)
     @Mapping(target = "displayIndex", ignore = true)
@@ -63,7 +65,7 @@ public abstract class JpaJaxbExternalIdentifierAdapterImpl implements JpaJaxbExt
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "externalIdCommonName", target = "type")
     @Mapping(source = "externalIdReference", target = "value")
-    @Mapping(source = "externalIdUrl", target = "url.value")
+    @Mapping(source = "externalIdUrl", target = "url")
     @Mapping(source = "dateCreated", target = "createdDate.value")
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
     @Mapping(source = ".", target = "source")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbFundingAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbFundingAdapterImpl.java
@@ -15,6 +15,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONFundingExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbFundingAdapter;
 import org.orcid.jaxb.model.v3.release.record.Funding;
@@ -28,6 +29,7 @@ import org.orcid.persistence.jpa.entities.ProfileFundingEntity;
         VisibilityMapperV3.class,
         OrgMapperV3.class,
         FuzzyDateMapperV3.class,
+        UrlMapperV3.class,
         JSONFundingExternalIdentifiersMapperV3.class,
         FundingContributorsMapperV3.class
     }
@@ -42,7 +44,7 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = "title.translatedTitle.languageCode", target = "translatedTitleLanguageCode")
     @Mapping(source = "amount.content", target = "numericAmount", qualifiedByName = "amountContentToNumericAmount")
     @Mapping(source = "amount.currencyCode", target = "currencyCode")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "contributors", target = "contributorsJson")
@@ -66,7 +68,7 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = "title.translatedTitle.languageCode", target = "translatedTitleLanguageCode")
     @Mapping(source = "amount.content", target = "numericAmount", qualifiedByName = "amountContentToNumericAmount")
     @Mapping(source = "amount.currencyCode", target = "currencyCode")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "contributors", target = "contributorsJson")
@@ -85,7 +87,7 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = "translatedTitleLanguageCode", target = "title.translatedTitle.languageCode")
     @Mapping(source = "numericAmount", target = "amount.content")
     @Mapping(source = "currencyCode", target = "amount.currencyCode")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "contributorsJson", target = "contributors")
@@ -101,7 +103,7 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = "title", target = "title.title.content")
     @Mapping(source = "translatedTitle", target = "title.translatedTitle.content")
     @Mapping(source = "translatedTitleLanguageCode", target = "title.translatedTitle.languageCode")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "startDate", target = "startDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbInvitedPositionAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbInvitedPositionAdapterImpl.java
@@ -11,6 +11,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbInvitedPositionAdapter;
 import org.orcid.jaxb.model.v3.release.record.InvitedPosition;
@@ -24,7 +25,8 @@ import org.orcid.persistence.jpa.entities.OrgAffiliationRelationEntity;
         VisibilityMapperV3.class,
         JSONExternalIdentifiersMapperV3.class,
         OrgMapperV3.class,
-        FuzzyDateMapperV3.class
+        FuzzyDateMapperV3.class,
+        UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbInvitedPositionAdapterImpl implements JpaJaxbInvitedPositionAdapter {
@@ -33,7 +35,7 @@ public abstract class JpaJaxbInvitedPositionAdapterImpl implements JpaJaxbInvite
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -46,7 +48,7 @@ public abstract class JpaJaxbInvitedPositionAdapterImpl implements JpaJaxbInvite
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -59,7 +61,7 @@ public abstract class JpaJaxbInvitedPositionAdapterImpl implements JpaJaxbInvite
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")
@@ -73,7 +75,7 @@ public abstract class JpaJaxbInvitedPositionAdapterImpl implements JpaJaxbInvite
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbMembershipAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbMembershipAdapterImpl.java
@@ -11,6 +11,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbMembershipAdapter;
 import org.orcid.jaxb.model.v3.release.record.Membership;
@@ -24,7 +25,8 @@ import org.orcid.persistence.jpa.entities.OrgAffiliationRelationEntity;
         VisibilityMapperV3.class,
         JSONExternalIdentifiersMapperV3.class,
         OrgMapperV3.class,
-        FuzzyDateMapperV3.class
+        FuzzyDateMapperV3.class,
+        UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbMembershipAdapterImpl implements JpaJaxbMembershipAdapter {
@@ -33,7 +35,7 @@ public abstract class JpaJaxbMembershipAdapterImpl implements JpaJaxbMembershipA
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -46,7 +48,7 @@ public abstract class JpaJaxbMembershipAdapterImpl implements JpaJaxbMembershipA
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -64,7 +66,7 @@ public abstract class JpaJaxbMembershipAdapterImpl implements JpaJaxbMembershipA
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")
@@ -78,7 +80,7 @@ public abstract class JpaJaxbMembershipAdapterImpl implements JpaJaxbMembershipA
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbNotificationAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbNotificationAdapterImpl.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import org.orcid.core.adapter.mapstruct.ExternalIdentifierTypeMapper;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbNotificationAdapter;
 import org.orcid.core.exception.OrcidValidationException;
 import org.orcid.core.manager.IdentityProviderManager;
@@ -52,7 +53,7 @@ import org.orcid.pojo.ajaxForm.PojoUtil;
 
 @Mapper(
     componentModel = "spring", 
-    uses = {SourceMapperV3.class, ExternalIdentifierTypeMapper.class}
+    uses = {SourceMapperV3.class, ExternalIdentifierTypeMapper.class, UrlMapperV3.class}
 )
 public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificationAdapter {
 
@@ -269,14 +270,14 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
     // Notification Items Mapping
     @Mapping(source = "externalIdentifier.type", target = "externalIdType", qualifiedByName = "apiToDb")
     @Mapping(source = "externalIdentifier.value", target = "externalIdValue")
-    @Mapping(source = "externalIdentifier.url.value", target = "externalIdUrl")
+    @Mapping(source = "externalIdentifier.url", target = "externalIdUrl")
     @Mapping(source = "externalIdentifier.relationship", target = "externalIdRelationship")
     @Mapping(source = "additionalInfo", target = "additionalInfo")
     protected abstract NotificationItemEntity mapItem(Item item);
 
     @Mapping(source = "externalIdType", target = "externalIdentifier.type", qualifiedByName = "dbToApi")
     @Mapping(source = "externalIdValue", target = "externalIdentifier.value")
-    @Mapping(source = "externalIdUrl", target = "externalIdentifier.url.value")
+    @Mapping(source = "externalIdUrl", target = "externalIdentifier.url")
     @Mapping(source = "externalIdRelationship", target = "externalIdentifier.relationship")
     @Mapping(source = "additionalInfo", target = "additionalInfo")
     protected abstract Item mapItem(NotificationItemEntity entity);

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbPeerReviewAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbPeerReviewAdapterImpl.java
@@ -12,6 +12,7 @@ import org.orcid.core.adapter.mapstruct.JSONPeerReviewWorkExternalIdentifierMapp
 import org.orcid.core.adapter.mapstruct.JSONWorkExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbPeerReviewAdapter;
 import org.orcid.jaxb.model.v3.release.record.PeerReview;
@@ -27,6 +28,7 @@ import org.orcid.persistence.jpa.entities.PeerReviewEntity;
         FuzzyDateMapperV3.class,
         JSONWorkExternalIdentifiersMapperV3.class,
         JSONPeerReviewWorkExternalIdentifierMapperV3.class
+        , UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewAdapter {
@@ -37,8 +39,8 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
 
     @Override
     @Mapping(source = "putCode", target = "id")
-    @Mapping(source = "url.value", target = "url")
-    @Mapping(source = "subjectUrl.value", target = "subjectUrl")
+    @Mapping(source = "url", target = "url")
+    @Mapping(source = "subjectUrl", target = "subjectUrl")
     @Mapping(source = "subjectName.title.content", target = "subjectName")
     @Mapping(source = "subjectName.translatedTitle.content", target = "subjectTranslatedName")
     @Mapping(source = "subjectName.translatedTitle.languageCode", target = "subjectTranslatedNameLanguageCode")
@@ -53,8 +55,8 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
 
     @Override
     @Mapping(source = "putCode", target = "id")
-    @Mapping(source = "url.value", target = "url")
-    @Mapping(source = "subjectUrl.value", target = "subjectUrl")
+    @Mapping(source = "url", target = "url")
+    @Mapping(source = "subjectUrl", target = "subjectUrl")
     @Mapping(source = "subjectName.title.content", target = "subjectName")
     @Mapping(source = "subjectName.translatedTitle.content", target = "subjectTranslatedName")
     @Mapping(source = "subjectName.translatedTitle.languageCode", target = "subjectTranslatedNameLanguageCode")
@@ -74,8 +76,8 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
 
     @Override
     @Mapping(source = "id", target = "putCode")
-    @Mapping(source = "url", target = "url.value")
-    @Mapping(source = "subjectUrl", target = "subjectUrl.value")
+    @Mapping(source = "url", target = "url")
+    @Mapping(source = "subjectUrl", target = "subjectUrl")
     @Mapping(source = "subjectName", target = "subjectName.title.content")
     @Mapping(source = "subjectTranslatedName", target = "subjectName.translatedTitle.content")
     @Mapping(source = "subjectTranslatedNameLanguageCode", target = "subjectName.translatedTitle.languageCode")
@@ -91,7 +93,7 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
 
     @Override
     @Mapping(source = "id", target = "putCode")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "completionDate", target = "completionDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbQualificationAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbQualificationAdapterImpl.java
@@ -11,6 +11,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbQualificationAdapter;
 import org.orcid.jaxb.model.v3.release.record.Qualification;
@@ -25,6 +26,7 @@ import org.orcid.persistence.jpa.entities.OrgAffiliationRelationEntity;
         JSONExternalIdentifiersMapperV3.class,
         OrgMapperV3.class,
         FuzzyDateMapperV3.class
+        , UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbQualificationAdapterImpl implements JpaJaxbQualificationAdapter {
@@ -33,7 +35,7 @@ public abstract class JpaJaxbQualificationAdapterImpl implements JpaJaxbQualific
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -46,7 +48,7 @@ public abstract class JpaJaxbQualificationAdapterImpl implements JpaJaxbQualific
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -59,7 +61,7 @@ public abstract class JpaJaxbQualificationAdapterImpl implements JpaJaxbQualific
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")
@@ -73,7 +75,7 @@ public abstract class JpaJaxbQualificationAdapterImpl implements JpaJaxbQualific
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbResearchResourceAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbResearchResourceAdapterImpl.java
@@ -14,6 +14,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONWorkExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbResearchResourceAdapter;
 import org.orcid.jaxb.model.v3.release.common.Organization;
@@ -37,6 +38,7 @@ import org.orcid.persistence.jpa.entities.ResearchResourceItemEntity;
         OrgMapperV3.class,
         FuzzyDateMapperV3.class,
         JSONWorkExternalIdentifiersMapperV3.class
+        , UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbResearchResourceAdapterImpl implements JpaJaxbResearchResourceAdapter {
@@ -57,7 +59,7 @@ public abstract class JpaJaxbResearchResourceAdapterImpl implements JpaJaxbResea
     @Mapping(source = "proposal.title.translatedTitle.content", target = "translatedTitle")
     @Mapping(source = "proposal.title.translatedTitle.languageCode", target = "translatedTitleLanguageCode")
     @Mapping(source = "proposal.externalIdentifiers", target = "externalIdentifiersJson")
-    @Mapping(source = "proposal.url.value", target = "url")
+    @Mapping(source = "proposal.url", target = "url")
     @Mapping(source = "proposal.startDate", target = "startDate")
     @Mapping(source = "proposal.endDate", target = "endDate")
     @Mapping(source = "proposal.hosts", target = "hosts")
@@ -72,7 +74,7 @@ public abstract class JpaJaxbResearchResourceAdapterImpl implements JpaJaxbResea
     @Mapping(source = "proposal.title.translatedTitle.content", target = "translatedTitle")
     @Mapping(source = "proposal.title.translatedTitle.languageCode", target = "translatedTitleLanguageCode")
     @Mapping(source = "proposal.externalIdentifiers", target = "externalIdentifiersJson")
-    @Mapping(source = "proposal.url.value", target = "url")
+    @Mapping(source = "proposal.url", target = "url")
     @Mapping(source = "proposal.startDate", target = "startDate")
     @Mapping(source = "proposal.endDate", target = "endDate")
     @Mapping(source = "proposal.hosts", target = "hosts")
@@ -100,7 +102,7 @@ public abstract class JpaJaxbResearchResourceAdapterImpl implements JpaJaxbResea
     @Mapping(source = "translatedTitle", target = "proposal.title.translatedTitle.content")
     @Mapping(source = "translatedTitleLanguageCode", target = "proposal.title.translatedTitle.languageCode")
     @Mapping(source = "externalIdentifiersJson", target = "proposal.externalIdentifiers")
-    @Mapping(source = "url", target = "proposal.url.value")
+    @Mapping(source = "url", target = "proposal.url")
     @Mapping(source = "startDate", target = "proposal.startDate")
     @Mapping(source = "endDate", target = "proposal.endDate")
     @Mapping(source = "hosts", target = "proposal.hosts")
@@ -116,7 +118,7 @@ public abstract class JpaJaxbResearchResourceAdapterImpl implements JpaJaxbResea
     @Mapping(source = "translatedTitle", target = "proposal.title.translatedTitle.content")
     @Mapping(source = "translatedTitleLanguageCode", target = "proposal.title.translatedTitle.languageCode")
     @Mapping(source = "externalIdentifiersJson", target = "proposal.externalIdentifiers")
-    @Mapping(source = "url", target = "proposal.url.value")
+    @Mapping(source = "url", target = "proposal.url")
     @Mapping(source = "startDate", target = "proposal.startDate")
     @Mapping(source = "endDate", target = "proposal.endDate")
     @Mapping(source = "hosts", target = "proposal.hosts")
@@ -162,14 +164,14 @@ public abstract class JpaJaxbResearchResourceAdapterImpl implements JpaJaxbResea
     // ========================================================================
 
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(target = "researchResourceEntity", ignore = true)
     public abstract ResearchResourceItemEntity toItemEntity(ResearchResourceItem item);
 
     @Mapping(source = "resourceName", target = "resourceName")
     @Mapping(source = "resourceType", target = "resourceType")
     @Mapping(source = "hosts", target = "hosts")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     public abstract ResearchResourceItem toItem(ResearchResourceItemEntity entity);
 

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbResearcherUrlAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbResearcherUrlAdapterImpl.java
@@ -3,15 +3,14 @@ package org.orcid.core.adapter.mapstruct.v3.impl;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbResearcherUrlAdapter;
-import org.orcid.jaxb.model.v3.release.common.Url;
 import org.orcid.jaxb.model.v3.release.record.ResearcherUrl;
 import org.orcid.jaxb.model.v3.release.record.ResearcherUrls;
 import org.orcid.persistence.jpa.entities.ResearcherUrlEntity;
@@ -20,6 +19,7 @@ import org.orcid.persistence.jpa.entities.ResearcherUrlEntity;
     componentModel = "spring",
     uses = {
         SourceMapperV3.class,
+        UrlMapperV3.class,
         VisibilityMapperV3.class
     }
 )
@@ -65,19 +65,6 @@ public abstract class JpaJaxbResearcherUrlAdapterImpl implements JpaJaxbResearch
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
     @Mapping(source = ".", target = "source")
     public abstract ResearcherUrl toResearcherUrl(ResearcherUrlEntity entity);
-
-    protected String map(Url url) {
-        return url == null || StringUtils.isBlank(url.getValue()) ? null : url.getValue().trim();
-    }
-
-    protected Url mapUrl(String url) {
-        if (StringUtils.isBlank(url)) {
-            return null;
-        }
-        Url result = new Url();
-        result.setValue(url.trim());
-        return result;
-    }
 
     @Override
     public ResearcherUrls toResearcherUrlList(Collection<ResearcherUrlEntity> entities) {

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbServiceAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbServiceAdapterImpl.java
@@ -11,6 +11,7 @@ import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.OrgMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbServiceAdapter;
 import org.orcid.jaxb.model.v3.release.record.Service;
@@ -24,7 +25,8 @@ import org.orcid.persistence.jpa.entities.OrgAffiliationRelationEntity;
         VisibilityMapperV3.class,
         JSONExternalIdentifiersMapperV3.class,
         OrgMapperV3.class,
-        FuzzyDateMapperV3.class
+        FuzzyDateMapperV3.class,
+        UrlMapperV3.class
     }
 )
 public abstract class JpaJaxbServiceAdapterImpl implements JpaJaxbServiceAdapter {
@@ -33,7 +35,7 @@ public abstract class JpaJaxbServiceAdapterImpl implements JpaJaxbServiceAdapter
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -46,7 +48,7 @@ public abstract class JpaJaxbServiceAdapterImpl implements JpaJaxbServiceAdapter
     @Mapping(source = "putCode", target = "id")
     @Mapping(source = "departmentName", target = "department")
     @Mapping(source = "roleTitle", target = "title")
-    @Mapping(source = "url.value", target = "url")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiers", target = "externalIdentifiersJson")
     @Mapping(source = "organization", target = "org")
     @Mapping(source = "startDate", target = "startDate")
@@ -59,7 +61,7 @@ public abstract class JpaJaxbServiceAdapterImpl implements JpaJaxbServiceAdapter
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")
@@ -73,7 +75,7 @@ public abstract class JpaJaxbServiceAdapterImpl implements JpaJaxbServiceAdapter
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "department", target = "departmentName")
     @Mapping(source = "title", target = "roleTitle")
-    @Mapping(source = "url", target = "url.value")
+    @Mapping(source = "url", target = "url")
     @Mapping(source = "externalIdentifiersJson", target = "externalIdentifiers")
     @Mapping(source = "org", target = "organization")
     @Mapping(source = "startDate", target = "startDate")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbWorkAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbWorkAdapterImpl.java
@@ -16,6 +16,7 @@ import org.orcid.core.adapter.mapstruct.ContributorsRolesAndSequencesMapperV3;
 import org.orcid.core.adapter.mapstruct.FuzzyDateMapperV3;
 import org.orcid.core.adapter.mapstruct.JSONWorkExternalIdentifiersMapperV3;
 import org.orcid.core.adapter.mapstruct.SourceMapperV3;
+import org.orcid.core.adapter.mapstruct.UrlMapperV3;
 import org.orcid.core.adapter.mapstruct.VisibilityMapperV3;
 import org.orcid.core.adapter.mapstruct.WorkContributorsMapperV3;
 import org.orcid.core.adapter.v3.JpaJaxbWorkAdapter;
@@ -27,7 +28,6 @@ import org.orcid.jaxb.model.v3.release.common.Source;
 import org.orcid.jaxb.model.v3.release.common.Subtitle;
 import org.orcid.jaxb.model.v3.release.common.Title;
 import org.orcid.jaxb.model.v3.release.common.Year;
-import org.orcid.jaxb.model.v3.release.common.Url;
 import org.orcid.jaxb.model.v3.release.record.Work;
 import org.orcid.jaxb.model.v3.release.record.summary.WorkSummary;
 import org.orcid.persistence.jpa.entities.MinimizedExtendedWorkEntity;
@@ -41,6 +41,7 @@ import org.orcid.pojo.WorkSummaryExtended;
     componentModel = "spring",
     uses = {
         SourceMapperV3.class,
+        UrlMapperV3.class,
         VisibilityMapperV3.class,
         FuzzyDateMapperV3.class
     }
@@ -97,14 +98,6 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
         return result;
     }
 
-    protected Url mapStringToUrl(String url) {
-        return StringUtils.isBlank(url) ? null : new Url(url.trim());
-    }
-
-    protected String mapUrlToString(Url url) {
-        return url == null || StringUtils.isBlank(url.getValue()) ? null : url.getValue().trim();
-    }
-
     protected org.orcid.jaxb.model.v3.release.common.Country mapStringToCountry(String country) {
         if (country == null) return null;
         try {
@@ -152,7 +145,7 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
     @Mapping(target = "workType", expression = "java( mapWorkTypeToString(work.getWorkType()) )")
     @Mapping(source = "publicationDate", target = "publicationDate")
     @Mapping(target = "externalIdentifiersJson", expression = "java( extIdMapper.convertTo(work.getWorkExternalIdentifiers()) )")
-    @Mapping(target = "workUrl", expression = "java( mapUrlToString(work.getUrl()) )")
+    @Mapping(source = "url", target = "workUrl")
     @Mapping(target = "contributorsJson", expression = "java( contributorsMapper.convertTo(work.getWorkContributors()) )")
     @Mapping(source = "languageCode", target = "languageCode")
     @Mapping(target = "iso2Country", expression = "java( mapCountryToString(work.getCountry()) )")
@@ -174,7 +167,7 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
     @Mapping(target = "workType", expression = "java( mapWorkTypeToString(work.getWorkType()) )")
     @Mapping(source = "publicationDate", target = "publicationDate")
     @Mapping(target = "externalIdentifiersJson", expression = "java( extIdMapper.convertTo(work.getWorkExternalIdentifiers()) )")
-    @Mapping(target = "workUrl", expression = "java( mapUrlToString(work.getUrl()) )")
+    @Mapping(source = "url", target = "workUrl")
     @Mapping(target = "contributorsJson", expression = "java( contributorsMapper.convertTo(work.getWorkContributors()) )")
     @Mapping(source = "languageCode", target = "languageCode")
     @Mapping(target = "iso2Country", expression = "java( mapCountryToString(work.getCountry()) )")
@@ -200,7 +193,7 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
     @Mapping(target = "workType", expression = "java( mapStringToWorkType(workEntity.getWorkType()) )")
     @Mapping(source = "publicationDate", target = "publicationDate")
     @Mapping(target = "workExternalIdentifiers", expression = "java( extIdMapper.convertFrom(workEntity.getExternalIdentifiersJson()) )")
-    @Mapping(target = "url", expression = "java( mapStringToUrl(workEntity.getWorkUrl()) )")
+    @Mapping(source = "workUrl", target = "url")
     @Mapping(target = "workContributors", expression = "java( contributorsMapper.convertFrom(workEntity.getContributorsJson()) )")
     @Mapping(source = "languageCode", target = "languageCode")
     @Mapping(target = "country", expression = "java( mapStringToCountry(workEntity.getIso2Country()) )")
@@ -257,7 +250,7 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
     @Mapping(target = "workType", expression = "java( mapStringToWorkType(workEntity.getWorkType()) )")
     @Mapping(source = "publicationDate", target = "publicationDate")
     @Mapping(target = "workExternalIdentifiers", expression = "java( extIdMapper.convertFrom(workEntity.getExternalIdentifiersJson()) )")
-    @Mapping(target = "url", expression = "java( mapStringToUrl(workEntity.getWorkUrl()) )")
+    @Mapping(source = "workUrl", target = "url")
     @Mapping(target = "workContributors", ignore = true) // CRITICAL: Explicitly ignored to match Orika and pass equality checks![cite: 9]
     @Mapping(source = "languageCode", target = "languageCode")
     @Mapping(target = "country", expression = "java( mapStringToCountry(workEntity.getIso2Country()) )")
@@ -278,7 +271,7 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
     @Mapping(target = "type", expression = "java( mapStringToWorkType(workEntity.getWorkType()) )")
     @Mapping(source = "publicationDate", target = "publicationDate")
     @Mapping(target = "externalIdentifiers", expression = "java( extIdMapper.convertFrom(workEntity.getExternalIdentifiersJson()) )")
-    @Mapping(target = "url", expression = "java( mapStringToUrl(workEntity.getWorkUrl()) )")
+    @Mapping(source = "workUrl", target = "url")
     @Mapping(source = "visibility", target = "visibility")
     @Mapping(source = "dateCreated", target = "createdDate.value")
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
@@ -295,7 +288,7 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
     @Mapping(target = "type", expression = "java( mapStringToWorkType(minimizedWorkEntity.getWorkType()) )")
     @Mapping(target = "publicationDate", expression = "java( mapPublicationDate(minimizedWorkEntity.getPublicationDate()) )")
     @Mapping(target = "externalIdentifiers", expression = "java( extIdMapper.convertFrom(minimizedWorkEntity.getExternalIdentifiersJson()) )")
-    @Mapping(target = "url", expression = "java( mapStringToUrl(minimizedWorkEntity.getWorkUrl()) )")
+    @Mapping(source = "workUrl", target = "url")
     @Mapping(source = "visibility", target = "visibility")
     @Mapping(source = "dateCreated", target = "createdDate.value")
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
@@ -312,7 +305,7 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
     @Mapping(target = "workType", expression = "java( mapStringToWorkType(minimizedWorkEntity.getWorkType()) )")
     @Mapping(target = "publicationDate", expression = "java( mapPublicationDate(minimizedWorkEntity.getPublicationDate()) )")
     @Mapping(target = "workExternalIdentifiers", expression = "java( extIdMapper.convertFrom(minimizedWorkEntity.getExternalIdentifiersJson()) )")
-    @Mapping(target = "url", expression = "java( mapStringToUrl(minimizedWorkEntity.getWorkUrl()) )")
+    @Mapping(source = "workUrl", target = "url")
     @Mapping(source = "visibility", target = "visibility")
     @Mapping(source = "dateCreated", target = "createdDate.value")
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
@@ -328,7 +321,7 @@ public abstract class JpaJaxbWorkAdapterImpl implements JpaJaxbWorkAdapter {
     @Mapping(target = "type", expression = "java( mapStringToWorkType(minimizedExtendedWorkEntity.getWorkType()) )")
     @Mapping(target = "publicationDate", expression = "java( mapPublicationDate(minimizedExtendedWorkEntity.getPublicationDate()) )")
     @Mapping(target = "externalIdentifiers", expression = "java( extIdMapper.convertFrom(minimizedExtendedWorkEntity.getExternalIdentifiersJson()) )")
-    @Mapping(target = "url", expression = "java( mapStringToUrl(minimizedExtendedWorkEntity.getWorkUrl()) )")
+    @Mapping(source = "workUrl", target = "url")
     @Mapping(source = "visibility", target = "visibility")
     @Mapping(source = "dateCreated", target = "createdDate.value")
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")

--- a/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/UrlMapperV2Test.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/UrlMapperV2Test.java
@@ -1,0 +1,31 @@
+package org.orcid.core.adapter.mapstruct;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.mapstruct.factory.Mappers;
+import org.orcid.jaxb.model.common_v2.Url;
+
+public class UrlMapperV2Test {
+
+    private final UrlMapperV2 mapper = Mappers.getMapper(UrlMapperV2.class);
+
+    @Test
+    public void blankValuesMapToNull() {
+        Url url = new Url();
+        url.setValue(" ");
+
+        assertNull(mapper.map(url));
+        assertNull(mapper.map(" "));
+    }
+
+    @Test
+    public void valuesAreTrimmedInBothDirections() {
+        Url url = new Url();
+        url.setValue(" https://orcid.org ");
+
+        assertEquals("https://orcid.org", mapper.map(url));
+        assertEquals("https://orcid.org", mapper.map(" https://orcid.org ").getValue());
+    }
+}

--- a/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/UrlMapperV3Test.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/UrlMapperV3Test.java
@@ -1,0 +1,31 @@
+package org.orcid.core.adapter.mapstruct;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.mapstruct.factory.Mappers;
+import org.orcid.jaxb.model.v3.release.common.Url;
+
+public class UrlMapperV3Test {
+
+    private final UrlMapperV3 mapper = Mappers.getMapper(UrlMapperV3.class);
+
+    @Test
+    public void blankValuesMapToNull() {
+        Url url = new Url();
+        url.setValue(" ");
+
+        assertNull(mapper.map(url));
+        assertNull(mapper.map(" "));
+    }
+
+    @Test
+    public void valuesAreTrimmedInBothDirections() {
+        Url url = new Url();
+        url.setValue(" https://orcid.org ");
+
+        assertEquals("https://orcid.org", mapper.map(url));
+        assertEquals("https://orcid.org", mapper.map(" https://orcid.org ").getValue());
+    }
+}


### PR DESCRIPTION
Created reusable UrlMapperV2.java and UrlMapperV3.java.

They normalize both directions:
blank/whitespace URL values become null
valid URLs are trimmed
no empty JAXB Url wrappers are emitted
Migrated all direct url.value mappings in the v2/v3 MapStruct adapter implementations, including work, researcher URL, affiliations, funding, peer review, research resource, external identifiers, and notification items.