### PR TITLE
Camelia orcid/mapstruct fixes9

### DIFF
--- a/orcid-api-common/src/main/java/org/orcid/api/common/exception/JSONInputValidator.java
+++ b/orcid-api-common/src/main/java/org/orcid/api/common/exception/JSONInputValidator.java
@@ -181,9 +181,10 @@ public class JSONInputValidator {
                 throw new InvalidJSONException(e.getCause().getCause().getMessage(), e);
             }
         } catch (Exception e) {
-            LOGGER.error("Unable to find validator for class " + clazz.getName());
-            Map<String, String> params = new HashMap<>();
             Throwable rootCause = ExceptionUtils.getRootCause(e);
+            LOGGER.error("Error validating class " + clazz.getName() + ": " + e.getClass().getName() + " - "
+                    + (rootCause != null ? rootCause.getMessage() : e.getMessage()), e);
+            Map<String, String> params = new HashMap<>();
             if(rootCause != null) {
                 throw new InvalidJSONException(rootCause.getMessage(), e);
             } else {

--- a/orcid-core/src/main/java/org/orcid/core/manager/impl/ClientDetailsEntityCacheManagerImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/impl/ClientDetailsEntityCacheManagerImpl.java
@@ -34,6 +34,12 @@ public class ClientDetailsEntityCacheManagerImpl implements ClientDetailsEntityC
     @Resource(name = "clientDetailsEntityIdPCache")
     private Cache<Object, ClientDetailsEntity> clientDetailsIdPCache;
 
+    // Short-lived ehcache for the last-modified freshness check itself, to collapse bursts of
+    // repeated retrieve() calls for the same client (e.g. one per activity in a record/list response)
+    // into a single DB round-trip instead of one per call.
+    @Resource(name = "clientDetailsLastModifiedCache")
+    private Cache<String, Date> clientDetailsLastModifiedCache;
+
     private final String releaseName = ReleaseNameUtils.getReleaseName();
 
     @Override
@@ -117,24 +123,35 @@ public class ClientDetailsEntityCacheManagerImpl implements ClientDetailsEntityC
     public void put(String clientId, ClientDetailsEntity client) {
         Object key = new ClientIdCacheKey(clientId, releaseName);
         clientDetailsCache.put(key, client);
+        clientDetailsLastModifiedCache.remove(clientId);
     }
 
     @Override
     public void removeAll() {
         clientDetailsCache.clear();
+        clientDetailsLastModifiedCache.clear();
     }
 
     @Override
     public void remove(String clientId) {
         clientDetailsCache.remove(new ClientIdCacheKey(clientId, releaseName));
+        clientDetailsLastModifiedCache.remove(clientId);
     }
 
     private Date retrieveLastModifiedDate(String clientId) {
+        Date cached = clientDetailsLastModifiedCache.get(clientId);
+        if (cached != null) {
+            return cached;
+        }
         Date date = null;
         try {
             date = clientDetailsManager.getLastModified(clientId);
         } catch (jakarta.persistence.NoResultException e) {
             LOG.debug("Missing lastModifiedDate clientId:" + clientId);
+        }
+        // ehcache rejects null values, so only cache a real hit; unknown clients keep hitting the DB
+        if (date != null) {
+            clientDetailsLastModifiedCache.put(clientId, date);
         }
         return date;
     }

--- a/orcid-core/src/main/resources/orcid-core-cache-config.xml
+++ b/orcid-core/src/main/resources/orcid-core-cache-config.xml
@@ -87,6 +87,16 @@
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.client_details.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.client_details.maxMegaBytesOnDisk:128}" />
 	</bean>		       
+
+	<!-- Short-lived cache for the client-details freshness (last-modified) check, to collapse
+	     bursts of repeated retrieve() calls for the same client within one request into a single DB hit -->
+	<bean id="clientDetailsLastModifiedCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
+		<property name="cacheName" value="client-details-last-modified" />
+		<property name="cacheManager" ref="coreCacheManager" />
+		<property name="timeToIdleSeconds" value="${org.orcid.core.cache.client_details_last_modified.timeToIdleSeconds:3}" />
+        <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.client_details_last_modified.maxMegaBytesInMemory:4}" />
+        <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.client_details_last_modified.maxMegaBytesOnDisk:0}" />
+	</bean>
     
     <bean id="identityProviderNameCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
         <property name="cacheName" value="identity-provider-name" />


### PR DESCRIPTION
client details entity cache
Despite the property being named timeToIdleSeconds, it's actually wired to timeToLiveExpiration — a true TTL from write time, not idle/last-access time. So every cached (clientId → lastModified) entry expires exactly 3 seconds after it was written, regardless of how often it's read in between. This bounds staleness: worst case, a client-details DB update takes up to 3s to be picked up by a burst of retrieve() calls that haven't otherwise touched the cache. (This mismatch between property name and actual behavior applies to every cache built by this factory bean

Size-based eviction.  capped the heap tier at maxMegaBytesInMemory: 4 (4MB). If enough distinct client IDs get cached that the pool fills before their 3s TTL elapses, Ehcache's default eviction advisor (a sampling-based approximate-LRU) evicts entries early to stay within budget — bounds memory regardless of how many unique clients pass through. maxMegaBytesOnDisk is 0, so it's heap-only, no disk spill.