### PR TITLE
Pd-6145 More serialization fixes

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/utils/OrcidEhCacheFactoryBean.java
+++ b/orcid-core/src/main/java/org/orcid/core/utils/OrcidEhCacheFactoryBean.java
@@ -38,7 +38,7 @@ public class OrcidEhCacheFactoryBean implements FactoryBean<Cache<?, ?>>, Initia
 
     private long maxMegaBytesOnDisk = 0;
 
-    private boolean copyValues = true;
+    private boolean copyValues = false;
 
     private CacheLoaderWriter<Serializable, Serializable> cacheLoaderWriter;
 

--- a/orcid-core/src/main/resources/orcid-core-cache-config.xml
+++ b/orcid-core/src/main/resources/orcid-core-cache-config.xml
@@ -29,7 +29,8 @@
 		<!-- Enough to store 1M ids -->
 		<property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.recent_orcid.maxMegaBytesInMemory:128}" />		
 		<property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.recent_orcid.maxMegaBytesOnDisk:256}" />
-	</bean>
+		<property name="copyValues" value="false" />
+	</bean>	
 	
 	<bean id="profileEntityCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
 		<property name="cacheName" value="profile-entity" />
@@ -46,6 +47,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.profile.timeToIdleSeconds:1800}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.profile.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.profile.maxMegaBytesOnDisk:128}" />
+        <property name="copyValues" value="false" />
     </bean>
     
     <bean id="publicBioCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -54,6 +56,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.bio.timeToIdleSeconds:1800}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.bio.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.bio.maxMegaBytesOnDisk:128}" />
+        <property name="copyValues" value="false" />
     </bean>
 
     <bean id="profileBioAndInternalCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -62,6 +65,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.bio.timeToIdleSeconds:1800}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.bio.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.bio.maxMegaBytesOnDisk:128}" />
+        <property name="copyValues" value="false" />
     </bean>
 	
 	<bean id="sourceNameCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean"> 
@@ -132,6 +136,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.grouping_suggestions.timeToIdleSeconds:300}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.grouping_suggestions.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.grouping_suggestions.maxMegaBytesOnDisk:128}" />
+        <property name="copyValues" value="false" />
     </bean>
     
     <bean id="contributorsNameCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -150,6 +155,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.affiliation_groups.timeToIdleSeconds:300}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.affiliation_groups.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.affiliation_groups.maxMegaBytesOnDisk:128}" />        
+        <property name="copyValues" value="false" />
     </bean>
     
     <bean id="groupedWorksCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -158,6 +164,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.grouped_works.timeToIdleSeconds:300}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.grouped_works.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.grouped_works.maxMegaBytesOnDisk:128}" />
+        <property name="copyValues" value="false" />
     </bean>
 
 	<bean id="groupedWorksExtendedCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -166,6 +173,7 @@
 		<property name="timeToIdleSeconds" value="${org.orcid.core.cache.grouped_works.timeToIdleSeconds:300}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.grouped_works.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.grouped_works.maxMegaBytesOnDisk:128}" />
+        <property name="copyValues" value="false" />
 	</bean>
 
     <bean id="featuredGroupedWorksExtendedCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -174,6 +182,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.grouped_works.timeToIdleSeconds:60}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.grouped_works.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.grouped_works.maxMegaBytesOnDisk:128}" />
+        <property name="copyValues" value="false" />
     </bean>
     
      <bean id="worksTitleCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -182,6 +191,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.work_titles.timeToIdleSeconds:600}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.work_titles.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.work_titles.maxMegaBytesOnDisk:128}" />
+        <property name="copyValues" value="false" />
     </bean>
     
     <bean id="workLastModifiedCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -208,7 +218,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.minimized_work_entity.timeToIdleSeconds:300}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.minimized_work_entity.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.minimized_work_entity.maxMegaBytesOnDisk:128}" />
-        <property name="copyValues" value="true" />
+        <property name="copyValues" value="false" />
     </bean>
 
 	<bean id="minimizedExtendedWorkEntityCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -217,7 +227,7 @@
 		<property name="timeToIdleSeconds" value="${org.orcid.core.cache.minimized_work_extended_entity.timeToIdleSeconds:300}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.minimized_work_extended_entity.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.minimized_work_extended_entity.maxMegaBytesOnDisk:128}" />
-		<property name="copyValues" value="true" />
+		<property name="copyValues" value="false" />
 	</bean>
     
     <bean id="fullWorkEntityCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">
@@ -226,7 +236,7 @@
         <property name="timeToIdleSeconds" value="${org.orcid.core.cache.full_work_entity.timeToIdleSeconds:300}" />
         <property name="maxMegaBytesInMemory" value="${org.orcid.core.cache.full_work_entity.maxMegaBytesInMemory:16}" />
         <property name="maxMegaBytesOnDisk" value="${org.orcid.core.cache.full_work_entity.maxMegaBytesOnDisk:128}" />
-        <property name="copyValues" value="true" />
+        <property name="copyValues" value="false" />
     </bean>
 
     <bean id="emailDomainCache" class="org.orcid.core.utils.OrcidEhCacheFactoryBean">


### PR DESCRIPTION
Eliminated CPU saturation and thread contention caused by Ehcache deep-cloning and serialization (CompactJavaSerializer.read and serialize) during WorkEntityCacheManagerImpl.retrieveWorkList and ClientDetailsEntityCacheManagerImpl.retrieve.