### PR TITLE
PD-0000 pin Apache HttpClient 4.x to 4.5.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@ the software.
         <libphonenumber.version>9.0.30</libphonenumber.version>
         <twilio.version>12.1.1</twilio.version>
         <solr.version>8.0.0</solr.version>
+        <!-- Apache HttpClient 4.x. ORCID code is on httpclient5; the 4.x line is only here
+             because AWS SDK v1 (aws-java-sdk-s3) needs it and solr-solrj pulls in 4.5.6.
+             Anything below 4.5.8 lacks RequestConfig.Builder#setNormalizeUri. -->
+        <httpclient4.version>4.5.14</httpclient4.version>
+        <httpcore4.version>4.4.16</httpcore4.version>
         <junit.version>4.13.2</junit.version>
         <main.basedir>${project.basedir}</main.basedir>
         <branchVersion>1.1.5-SNAPSHOT</branchVersion>
@@ -717,6 +722,21 @@ the software.
                 <artifactId>httpcore5</artifactId>
                 <version>5.3.6</version>
                 <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpclient4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>${httpclient4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>${httpcore4.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
> PD-0000 is a placeholder ticket ID — happy to re-file under a real one.

## What

`orcid-message-listener` logs this a few times per process start, on the S3 dump path:

```
WARN [org.springframework.jms.listener.DefaultMessageListenerContainer#2-1] utils.ApacheUtils (ApacheUtils.java:246)
- NoSuchMethodException was thrown when disabling normalizeUri. This indicates you are using an old version (< 4.5.8)
of Apache http client...
```

## Why it happens

AWS SDK for Java v1 reflectively calls `RequestConfig.Builder#setNormalizeUri(false)` when it constructs its Apache HTTP client. That method only exists in Apache HttpClient >= 4.5.8. When it is missing, the SDK catches the `NoSuchMethodException`, logs this warning, and carries on with normalization left on.

`solr-solrj 8.0.0` declares httpclient/httpmime 4.5.6 and httpcore 4.4.10 directly, so they sit at depth 2 from the listener. The SDK's copy is one level further out — `aws-java-sdk-s3` → `aws-java-sdk-core` → httpclient 4.5.13, depth 3 — so Maven's nearest-wins resolution picks solrj's on depth alone, with declaration order never coming into it. Confirmed against a locally built WAR:

```
WEB-INF/lib/httpclient-4.5.6.jar
WEB-INF/lib/httpmime-4.5.6.jar
WEB-INF/lib/httpcore-4.4.10.jar
```

This is not a functional failure today. The normalization AWS wants disabled (collapsing `//`, resolving `..`, re-encoding) only corrupts S3 object keys that contain those sequences, and ours are plain `<orcid>.xml` under fixed prefixes. It is log noise plus a slow exception path once per HTTP client build — not per message, and unrelated to whether indexing succeeds.

## The change

Pin httpclient / httpmime / httpcore in the parent `dependencyManagement` (4.5.14 / 4.4.16) so the version is deterministic rather than a side effect of declaration order.

## Risk, and what still needs checking

- **Blast radius is wider than the listener.** Every module that gets httpclient 4.x transitively moves 4.5.6 → 4.5.14, solrj included. That is within the 4.5.x line and binary compatible (Solr 8.11 itself ships 4.5.13), but it does mean URI normalization becomes the default for solrj's own requests. Solr paths are flat and query params are unaffected, so no impact is expected — worth an indexing soak on QA before this leaves draft.
- **The three artifacts are pinned as a matched set on purpose.** Pinning httpclient alone would leave httpcore at 4.4.10 and risk `NoSuchMethodError` at runtime.
- **Not built or run locally.** CI here (`pr.yml` → `test_mvn`) runs a full reactor `mvn test`, which is what should confirm resolution and compilation. Runtime confirmation is simply that the warning stops appearing in `message_listener.log` after a deploy to a test environment.
- **Release line.** Raised from `main`. If the log that prompted this came from an environment on the other release line, this needs a cherry-pick there too.

## Longer term

Note that bumping the v1 SDK within 1.12.x would not help: its httpclient stays at depth 3 whatever version it declares, so solrj's 4.5.6 still wins. AWS SDK for Java v1 is end of support, and v2 is already in the tree (`software.amazon.awssdk` 2.46.21, added for the SMS work). v2 drops the Apache 4.x dependency entirely, so migrating `S3Manager` off v1 would remove this class of problem rather than pinning around it.
