### PR TITLE
PD-13438  added the mapping for source in notifications

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbNotificationAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbNotificationAdapterImpl.java
@@ -100,6 +100,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
 
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationCustom map(NotificationCustomEntity e);
 
     // 2. Notification Service Announcement
@@ -109,6 +110,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
 
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationServiceAnnouncement map(NotificationServiceAnnouncementEntity e);
 
     // 3. Notification Tip
@@ -118,6 +120,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
 
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationTip map(NotificationTipEntity e);
 
     // 4. Notification Administrative
@@ -127,6 +130,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
 
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationAdministrative map(NotificationAdministrativeEntity e);
 
     // 5. Notification Permission
@@ -140,6 +144,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
     @Mapping(source = "dateCreated", target = "createdDate")
     @Mapping(source = "authorizationUrl", target = "authorizationUrl.uri")
     @Mapping(source = "notificationItems", target = "items.items")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationPermission map(NotificationAddItemsEntity e);
 
     @AfterMapping
@@ -169,6 +174,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
     @Mapping(source = "authorizationUrl", target = "authorizationUrl.uri")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationInstitutionalConnection map(NotificationInstitutionalConnectionEntity e);
 
     @AfterMapping
@@ -208,6 +214,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
     @Mapping(source = "dateCreated", target = "createdDate")
     @Mapping(source = "notificationItems", target = "items.items")
     @Mapping(source = "amendedSection", target = "amendedSection")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationAmended map(NotificationAmendedEntity e);
 
     // Custom AmendedSection Enum Converters

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbNotificationAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbNotificationAdapterImpl.java
@@ -111,6 +111,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
 
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationCustom map(NotificationCustomEntity e);
 
     // 2. Notification Service Announcement
@@ -120,6 +121,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
 
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationServiceAnnouncement map(NotificationServiceAnnouncementEntity e);
 
     // 3. Notification Tip
@@ -129,6 +131,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
 
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationTip map(NotificationTipEntity e);
 
     // 4. Notification Administrative
@@ -138,6 +141,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
 
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationAdministrative map(NotificationAdministrativeEntity e);
 
     // 5. Notification Permission
@@ -151,6 +155,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
     @Mapping(source = "dateCreated", target = "createdDate")
     @Mapping(source = "authorizationUrl", target = "authorizationUrl.uri")
     @Mapping(source = "notificationItems", target = "items.items")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationPermission map(NotificationAddItemsEntity e);
 
     @AfterMapping
@@ -180,6 +185,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
     @Mapping(source = "authorizationUrl", target = "authorizationUrl.uri")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationInstitutionalConnection map(NotificationInstitutionalConnectionEntity e);
 
     @AfterMapping
@@ -219,6 +225,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
     @Mapping(source = "dateCreated", target = "createdDate")
     @Mapping(source = "notificationItems", target = "items.items")
     @Mapping(source = "amendedSection", target = "amendedSection")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationAmended map(NotificationAmendedEntity e);
 
     // 8. Notification Find My Stuff (V3 specific)
@@ -230,6 +237,7 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate")
     @Mapping(source = "authorizationUrl", target = "authorizationUrl.uri")
+    @Mapping(source = ".", target = "source")
     protected abstract NotificationFindMyStuff map(NotificationFindMyStuffEntity e);
 
     @AfterMapping

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbNotificationAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbNotificationAdapterTest.java
@@ -31,6 +31,7 @@ import org.orcid.persistence.jpa.entities.NotificationCustomEntity;
 import org.orcid.persistence.jpa.entities.NotificationEntity;
 import org.orcid.persistence.jpa.entities.NotificationItemEntity;
 import org.orcid.test.OrcidJUnit4ClassRunner;
+import org.orcid.core.adapter.MockSourceNameCache;
 import org.orcid.core.utils.DateFieldsOnBaseEntityUtils;
 import org.orcid.utils.DateUtils;
 import org.springframework.test.context.ContextConfiguration;
@@ -42,7 +43,7 @@ import org.springframework.test.context.ContextConfiguration;
  */
 @RunWith(OrcidJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-orcid-core-context.xml" })
-public class JpaJaxbNotificationAdapterTest {
+public class JpaJaxbNotificationAdapterTest extends MockSourceNameCache {
 
     @Resource
     private JpaJaxbNotificationAdapter jpaJaxbNotificationAdapter;
@@ -81,6 +82,53 @@ public class JpaJaxbNotificationAdapterTest {
         assertEquals("Test subject", notificationCustom.getSubject());
         assertTrue(notification.getCreatedDate().toXMLFormat().startsWith("2014-01-01T09:17:56"));
         assertTrue(notification.getReadDate().toXMLFormat().startsWith("2014-03-04T17:43:06"));
+    }
+
+    @Test
+    public void testEntityToNotificationWithSource() {
+        NotificationCustomEntity notificationEntity = new NotificationCustomEntity();
+        notificationEntity.setId(123L);
+        notificationEntity.setNotificationType(NotificationType.CUSTOM.name());
+        notificationEntity.setSubject("Test subject");
+        notificationEntity.setClientSourceId(CLIENT_SOURCE_ID);
+
+        Notification notification = jpaJaxbNotificationAdapter.toNotification(notificationEntity);
+
+        assertNotNull(notification);
+        assertNotNull(notification.getSource());
+        assertNotNull(notification.getSource().getSourceClientId());
+        assertEquals(CLIENT_SOURCE_ID, notification.getSource().getSourceClientId().getPath());
+        assertNotNull(notification.getSource().getSourceName());
+        assertEquals("Client name", notification.getSource().getSourceName().getContent());
+
+        NotificationAmendedEntity amendedEntity = new NotificationAmendedEntity();
+        amendedEntity.setId(124L);
+        amendedEntity.setNotificationType(NotificationType.AMENDED.name());
+        amendedEntity.setClientSourceId(CLIENT_SOURCE_ID);
+        amendedEntity.setAmendedSection("WORK");
+
+        Notification amendedNotification = jpaJaxbNotificationAdapter.toNotification(amendedEntity);
+        assertNotNull(amendedNotification);
+        assertTrue(amendedNotification instanceof NotificationAmended);
+        assertNotNull(amendedNotification.getSource());
+        assertNotNull(amendedNotification.getSource().getSourceClientId());
+        assertEquals(CLIENT_SOURCE_ID, amendedNotification.getSource().getSourceClientId().getPath());
+        assertNotNull(amendedNotification.getSource().getSourceName());
+        assertEquals("Client name", amendedNotification.getSource().getSourceName().getContent());
+
+        NotificationAddItemsEntity addItemsEntity = new NotificationAddItemsEntity();
+        addItemsEntity.setId(125L);
+        addItemsEntity.setNotificationType(NotificationType.PERMISSION.name());
+        addItemsEntity.setClientSourceId(CLIENT_SOURCE_ID);
+
+        Notification permissionNotification = jpaJaxbNotificationAdapter.toNotification(addItemsEntity);
+        assertNotNull(permissionNotification);
+        assertTrue(permissionNotification instanceof NotificationPermission);
+        assertNotNull(permissionNotification.getSource());
+        assertNotNull(permissionNotification.getSource().getSourceClientId());
+        assertEquals(CLIENT_SOURCE_ID, permissionNotification.getSource().getSourceClientId().getPath());
+        assertNotNull(permissionNotification.getSource().getSourceName());
+        assertEquals("Client name", permissionNotification.getSource().getSourceName().getContent());
     }
 
     @Test

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbNotificationAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbNotificationAdapterTest.java
@@ -10,8 +10,15 @@ import java.util.Set;
 
 import jakarta.annotation.Resource;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.orcid.core.adapter.MockSourceNameCache;
+import org.orcid.core.manager.ClientDetailsEntityCacheManager;
+import org.orcid.core.manager.ClientDetailsManager;
 import org.orcid.jaxb.model.common.Relationship;
 import org.orcid.jaxb.model.v3.release.common.Source;
 import org.orcid.jaxb.model.v3.release.common.SourceClientId;
@@ -26,6 +33,7 @@ import org.orcid.jaxb.model.v3.release.notification.permission.ItemType;
 import org.orcid.jaxb.model.v3.release.notification.permission.Items;
 import org.orcid.jaxb.model.v3.release.notification.permission.NotificationPermission;
 import org.orcid.jaxb.model.v3.release.record.ExternalID;
+import org.orcid.persistence.jpa.entities.ClientDetailsEntity;
 import org.orcid.persistence.jpa.entities.NotificationAddItemsEntity;
 import org.orcid.persistence.jpa.entities.NotificationAmendedEntity;
 import org.orcid.persistence.jpa.entities.NotificationCustomEntity;
@@ -35,6 +43,7 @@ import org.orcid.test.OrcidJUnit4ClassRunner;
 import org.orcid.core.utils.DateFieldsOnBaseEntityUtils;
 import org.orcid.utils.DateUtils;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * 
@@ -43,10 +52,30 @@ import org.springframework.test.context.ContextConfiguration;
  */
 @RunWith(OrcidJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-orcid-core-context.xml" })
-public class JpaJaxbNotificationAdapterTest {
+public class JpaJaxbNotificationAdapterTest extends MockSourceNameCache {
 
     @Resource(name = "jpaJaxbNotificationAdapterV3")
     private JpaJaxbNotificationAdapter jpaJaxbNotificationAdapter;
+
+    @Resource
+    private ClientDetailsEntityCacheManager clientDetailsEntityCacheManager;
+
+    @Resource
+    private ClientDetailsManager clientDetailsManager;
+
+    @Mock
+    private ClientDetailsManager mockClientDetailsManager;
+
+    @Before
+    public void before() {
+        Mockito.when(mockClientDetailsManager.findByClientId(Mockito.eq(CLIENT_SOURCE_ID))).thenReturn(new ClientDetailsEntity());
+        ReflectionTestUtils.setField(clientDetailsEntityCacheManager, "clientDetailsManager", mockClientDetailsManager);
+    }
+
+    @After
+    public void tearDown() {
+        ReflectionTestUtils.setField(clientDetailsEntityCacheManager, "clientDetailsManager", clientDetailsManager);
+    }
 
     @Test
     public void testToNotificationCustomEntity() {
@@ -84,6 +113,53 @@ public class JpaJaxbNotificationAdapterTest {
         assertEquals("Test subject", notificationCustom.getSubject());
         assertTrue(notification.getCreatedDate().toXMLFormat().startsWith("2015-06-05T10:15:20.000"));
         assertTrue(notification.getReadDate().toXMLFormat().startsWith("2014-03-04T17:43:06.000"));
+    }
+
+    @Test
+    public void testEntityToNotificationWithSource() {
+        NotificationCustomEntity notificationEntity = new NotificationCustomEntity();
+        notificationEntity.setId(123L);
+        notificationEntity.setNotificationType(org.orcid.jaxb.model.notification_v2.NotificationType.CUSTOM.name());
+        notificationEntity.setSubject("Test subject");
+        notificationEntity.setClientSourceId(CLIENT_SOURCE_ID);
+
+        Notification notification = jpaJaxbNotificationAdapter.toNotification(notificationEntity);
+
+        assertNotNull(notification);
+        assertNotNull(notification.getSource());
+        assertNotNull(notification.getSource().getSourceClientId());
+        assertEquals(CLIENT_SOURCE_ID, notification.getSource().getSourceClientId().getPath());
+        assertNotNull(notification.getSource().getSourceName());
+        assertEquals("Client name", notification.getSource().getSourceName().getContent());
+
+        NotificationAmendedEntity amendedEntity = new NotificationAmendedEntity();
+        amendedEntity.setId(124L);
+        amendedEntity.setNotificationType(org.orcid.jaxb.model.notification_v2.NotificationType.AMENDED.name());
+        amendedEntity.setClientSourceId(CLIENT_SOURCE_ID);
+        amendedEntity.setAmendedSection("WORK");
+
+        Notification amendedNotification = jpaJaxbNotificationAdapter.toNotification(amendedEntity);
+        assertNotNull(amendedNotification);
+        assertTrue(amendedNotification instanceof NotificationAmended);
+        assertNotNull(amendedNotification.getSource());
+        assertNotNull(amendedNotification.getSource().getSourceClientId());
+        assertEquals(CLIENT_SOURCE_ID, amendedNotification.getSource().getSourceClientId().getPath());
+        assertNotNull(amendedNotification.getSource().getSourceName());
+        assertEquals("Client name", amendedNotification.getSource().getSourceName().getContent());
+
+        NotificationAddItemsEntity addItemsEntity = new NotificationAddItemsEntity();
+        addItemsEntity.setId(125L);
+        addItemsEntity.setNotificationType(org.orcid.jaxb.model.notification_v2.NotificationType.PERMISSION.name());
+        addItemsEntity.setClientSourceId(CLIENT_SOURCE_ID);
+
+        Notification permissionNotification = jpaJaxbNotificationAdapter.toNotification(addItemsEntity);
+        assertNotNull(permissionNotification);
+        assertTrue(permissionNotification instanceof NotificationPermission);
+        assertNotNull(permissionNotification.getSource());
+        assertNotNull(permissionNotification.getSource().getSourceClientId());
+        assertEquals(CLIENT_SOURCE_ID, permissionNotification.getSource().getSourceClientId().getPath());
+        assertNotNull(permissionNotification.getSource().getSourceName());
+        assertEquals("Client name", permissionNotification.getSource().getSourceName().getContent());
     }
 
     @Test


### PR DESCRIPTION
Fixed missing client name and source details in email notifications by adding missing source mappings to JpaJaxbNotificationAdapterImpl.