### PR TITLE
PD-13448  fixed null subject mapping for PeerReview

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbPeerReviewAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbPeerReviewAdapterImpl.java
@@ -3,6 +3,7 @@ package org.orcid.core.adapter.mapstruct.impl;
 import java.util.Collection;
 import java.util.List;
 
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -102,6 +103,16 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
     @Mapping(source = "org", target = "organization")
     @Mapping(source = ".", target = "source")
     public abstract PeerReview toPeerReview(PeerReviewEntity entity);
+
+    @AfterMapping
+    protected void removeEmptyOptionalSubjectFields(PeerReviewEntity entity, @MappingTarget PeerReview peerReview) {
+        if (entity.getSubjectContainerName() == null) {
+            peerReview.setSubjectContainerName(null);
+        }
+        if (entity.getSubjectName() == null && entity.getSubjectTranslatedName() == null && entity.getSubjectTranslatedNameLanguageCode() == null) {
+            peerReview.setSubjectName(null);
+        }
+    }
 
     @Override
     @Mapping(source = "id", target = "putCode")

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbPeerReviewAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbPeerReviewAdapterImpl.java
@@ -3,6 +3,7 @@ package org.orcid.core.adapter.mapstruct.v3.impl;
 import java.util.Collection;
 import java.util.List;
 
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -90,6 +91,16 @@ public abstract class JpaJaxbPeerReviewAdapterImpl implements JpaJaxbPeerReviewA
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
     @Mapping(source = ".", target = "source")
     public abstract PeerReview toPeerReview(PeerReviewEntity entity);
+
+    @AfterMapping
+    protected void removeEmptyOptionalSubjectFields(PeerReviewEntity entity, @MappingTarget PeerReview peerReview) {
+        if (entity.getSubjectContainerName() == null) {
+            peerReview.setSubjectContainerName(null);
+        }
+        if (entity.getSubjectName() == null && entity.getSubjectTranslatedName() == null && entity.getSubjectTranslatedNameLanguageCode() == null) {
+            peerReview.setSubjectName(null);
+        }
+    }
 
     @Override
     @Mapping(source = "id", target = "putCode")

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbPeerReviewAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbPeerReviewAdapterTest.java
@@ -251,6 +251,20 @@ public class JpaJaxbPeerReviewAdapterTest extends MockSourceNameCache {
     }
 
     @Test
+    public void fromPeerReviewEntityToPeerReviewDoesNotCreateEmptyOptionalSubjectFields() throws IllegalAccessException {
+        PeerReviewEntity entity = getPeerReviewEntity();
+        entity.setSubjectContainerName(null);
+        entity.setSubjectName(null);
+        entity.setSubjectTranslatedName(null);
+        entity.setSubjectTranslatedNameLanguageCode(null);
+
+        PeerReview peerReview = jpaJaxbPeerReviewAdapter.toPeerReview(entity);
+
+        assertNull(peerReview.getSubjectContainerName());
+        assertNull(peerReview.getSubjectName());
+    }
+
+    @Test
     public void fromPeerReviewEntityWithDissertationThesisSubjectTypeMapsToDissertation() throws IllegalAccessException {
         PeerReviewEntity entity = getPeerReviewEntity();
         entity.setSubjectType(org.orcid.jaxb.model.common.WorkType.DISSERTATION_THESIS.name());

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbPeerReviewAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbPeerReviewAdapterTest.java
@@ -308,6 +308,20 @@ public class JpaJaxbPeerReviewAdapterTest extends MockSourceNameCache {
     }
 
     @Test
+    public void fromPeerReviewEntityToPeerReviewDoesNotCreateEmptyOptionalSubjectFields() throws IllegalAccessException {
+        PeerReviewEntity entity = getPeerReviewEntity();
+        entity.setSubjectContainerName(null);
+        entity.setSubjectName(null);
+        entity.setSubjectTranslatedName(null);
+        entity.setSubjectTranslatedNameLanguageCode(null);
+
+        PeerReview peerReview = jpaJaxbPeerReviewAdapter.toPeerReview(entity);
+
+        assertNull(peerReview.getSubjectContainerName());
+        assertNull(peerReview.getSubjectName());
+    }
+
+    @Test
     public void fromPeerReviewEntityToPeerReviewSummary() throws IllegalAccessException {
         PeerReviewEntity entity = getPeerReviewEntity();
         assertNotNull(entity);


### PR DESCRIPTION
The V3 peer-review GET mapper created empty JAXB wrappers for absent optional fields, returning: "subject-name": { "title": { "value": null } } .That is invalid when sent back to the API.