### PR TITLE
PD-13450 Fixed administrative type for notifications

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbNotificationAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbNotificationAdapterImpl.java
@@ -62,10 +62,10 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
         if (notification == null) return null;
         
         if (notification instanceof NotificationPermission) return map((NotificationPermission) notification);
+        if (notification instanceof NotificationAdministrative) return map((NotificationAdministrative) notification);
         if (notification instanceof NotificationCustom) return map((NotificationCustom) notification);
         if (notification instanceof NotificationAmended) return map((NotificationAmended) notification);
         if (notification instanceof NotificationInstitutionalConnection) return map((NotificationInstitutionalConnection) notification);
-        if (notification instanceof NotificationAdministrative) return map((NotificationAdministrative) notification);
         if (notification instanceof NotificationServiceAnnouncement) return map((NotificationServiceAnnouncement) notification);
         if (notification instanceof NotificationTip) return map((NotificationTip) notification);
         
@@ -77,10 +77,10 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
         if (entity == null) return null;
         
         if (entity instanceof NotificationAddItemsEntity) return map((NotificationAddItemsEntity) entity);
+        if (entity instanceof NotificationAdministrativeEntity) return map((NotificationAdministrativeEntity) entity);
         if (entity instanceof NotificationCustomEntity) return map((NotificationCustomEntity) entity);
         if (entity instanceof NotificationAmendedEntity) return map((NotificationAmendedEntity) entity);
         if (entity instanceof NotificationInstitutionalConnectionEntity) return map((NotificationInstitutionalConnectionEntity) entity);
-        if (entity instanceof NotificationAdministrativeEntity) return map((NotificationAdministrativeEntity) entity);
         if (entity instanceof NotificationServiceAnnouncementEntity) return map((NotificationServiceAnnouncementEntity) entity);
         if (entity instanceof NotificationTipEntity) return map((NotificationTipEntity) entity);
         

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbNotificationAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbNotificationAdapterImpl.java
@@ -71,10 +71,10 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
         if (notification == null) return null;
 
         if (notification instanceof NotificationPermission) return map((NotificationPermission) notification);
+        if (notification instanceof NotificationAdministrative) return map((NotificationAdministrative) notification);
         if (notification instanceof NotificationCustom) return map((NotificationCustom) notification);
         if (notification instanceof NotificationAmended) return map((NotificationAmended) notification);
         if (notification instanceof NotificationInstitutionalConnection) return map((NotificationInstitutionalConnection) notification);
-        if (notification instanceof NotificationAdministrative) return map((NotificationAdministrative) notification);
         if (notification instanceof NotificationServiceAnnouncement) return map((NotificationServiceAnnouncement) notification);
         if (notification instanceof NotificationTip) return map((NotificationTip) notification);
         if (notification instanceof NotificationFindMyStuff) return map((NotificationFindMyStuff) notification);
@@ -87,10 +87,10 @@ public abstract class JpaJaxbNotificationAdapterImpl implements JpaJaxbNotificat
         if (entity == null) return null;
 
         if (entity instanceof NotificationAddItemsEntity) return map((NotificationAddItemsEntity) entity);
+        if (entity instanceof NotificationAdministrativeEntity) return map((NotificationAdministrativeEntity) entity);
         if (entity instanceof NotificationCustomEntity) return map((NotificationCustomEntity) entity);
         if (entity instanceof NotificationAmendedEntity) return map((NotificationAmendedEntity) entity);
         if (entity instanceof NotificationInstitutionalConnectionEntity) return map((NotificationInstitutionalConnectionEntity) entity);
-        if (entity instanceof NotificationAdministrativeEntity) return map((NotificationAdministrativeEntity) entity);
         if (entity instanceof NotificationServiceAnnouncementEntity) return map((NotificationServiceAnnouncementEntity) entity);
         if (entity instanceof NotificationTipEntity) return map((NotificationTipEntity) entity);
         if (entity instanceof NotificationFindMyStuffEntity) return map((NotificationFindMyStuffEntity) entity);

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbNotificationAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbNotificationAdapterTest.java
@@ -16,6 +16,7 @@ import org.orcid.core.adapter.JpaJaxbNotificationAdapter;
 import org.orcid.jaxb.model.common_v2.Source;
 import org.orcid.jaxb.model.common_v2.SourceClientId;
 import org.orcid.jaxb.model.notification.amended_v2.NotificationAmended;
+import org.orcid.jaxb.model.notification.custom_v2.NotificationAdministrative;
 import org.orcid.jaxb.model.notification.custom_v2.NotificationCustom;
 import org.orcid.jaxb.model.notification.permission_v2.AuthorizationUrl;
 import org.orcid.jaxb.model.notification.permission_v2.Item;
@@ -26,6 +27,7 @@ import org.orcid.jaxb.model.notification_v2.Notification;
 import org.orcid.jaxb.model.notification_v2.NotificationType;
 import org.orcid.jaxb.model.record_v2.ExternalID;
 import org.orcid.persistence.jpa.entities.NotificationAddItemsEntity;
+import org.orcid.persistence.jpa.entities.NotificationAdministrativeEntity;
 import org.orcid.persistence.jpa.entities.NotificationAmendedEntity;
 import org.orcid.persistence.jpa.entities.NotificationCustomEntity;
 import org.orcid.persistence.jpa.entities.NotificationEntity;
@@ -82,6 +84,18 @@ public class JpaJaxbNotificationAdapterTest extends MockSourceNameCache {
         assertEquals("Test subject", notificationCustom.getSubject());
         assertTrue(notification.getCreatedDate().toXMLFormat().startsWith("2014-01-01T09:17:56"));
         assertTrue(notification.getReadDate().toXMLFormat().startsWith("2014-03-04T17:43:06"));
+    }
+
+    @Test
+    public void testAdministrativeSubtypeIsPreserved() {
+        NotificationAdministrative notification = new NotificationAdministrative();
+        notification.setNotificationType(NotificationType.ADMINISTRATIVE);
+
+        NotificationEntity notificationEntity = jpaJaxbNotificationAdapter.toNotificationEntity(notification);
+
+        assertTrue(notificationEntity instanceof NotificationAdministrativeEntity);
+        assertEquals(NotificationType.ADMINISTRATIVE.name(), notificationEntity.getNotificationType());
+        assertTrue(jpaJaxbNotificationAdapter.toNotification(notificationEntity) instanceof NotificationAdministrative);
     }
 
     @Test

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbNotificationAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbNotificationAdapterTest.java
@@ -26,6 +26,7 @@ import org.orcid.jaxb.model.v3.release.common.Url;
 import org.orcid.jaxb.model.v3.release.notification.Notification;
 import org.orcid.jaxb.model.v3.release.notification.NotificationType;
 import org.orcid.jaxb.model.v3.release.notification.amended.NotificationAmended;
+import org.orcid.jaxb.model.v3.release.notification.custom.NotificationAdministrative;
 import org.orcid.jaxb.model.v3.release.notification.custom.NotificationCustom;
 import org.orcid.jaxb.model.v3.release.notification.permission.AuthorizationUrl;
 import org.orcid.jaxb.model.v3.release.notification.permission.Item;
@@ -35,6 +36,7 @@ import org.orcid.jaxb.model.v3.release.notification.permission.NotificationPermi
 import org.orcid.jaxb.model.v3.release.record.ExternalID;
 import org.orcid.persistence.jpa.entities.ClientDetailsEntity;
 import org.orcid.persistence.jpa.entities.NotificationAddItemsEntity;
+import org.orcid.persistence.jpa.entities.NotificationAdministrativeEntity;
 import org.orcid.persistence.jpa.entities.NotificationAmendedEntity;
 import org.orcid.persistence.jpa.entities.NotificationCustomEntity;
 import org.orcid.persistence.jpa.entities.NotificationEntity;
@@ -113,6 +115,18 @@ public class JpaJaxbNotificationAdapterTest extends MockSourceNameCache {
         assertEquals("Test subject", notificationCustom.getSubject());
         assertTrue(notification.getCreatedDate().toXMLFormat().startsWith("2015-06-05T10:15:20.000"));
         assertTrue(notification.getReadDate().toXMLFormat().startsWith("2014-03-04T17:43:06.000"));
+    }
+
+    @Test
+    public void testAdministrativeSubtypeIsPreserved() {
+        NotificationAdministrative notification = new NotificationAdministrative();
+        notification.setNotificationType(NotificationType.ADMINISTRATIVE);
+
+        NotificationEntity notificationEntity = jpaJaxbNotificationAdapter.toNotificationEntity(notification);
+
+        assertTrue(notificationEntity instanceof NotificationAdministrativeEntity);
+        assertEquals(org.orcid.jaxb.model.notification_v2.NotificationType.ADMINISTRATIVE.name(), notificationEntity.getNotificationType());
+        assertTrue(jpaJaxbNotificationAdapter.toNotification(notificationEntity) instanceof NotificationAdministrative);
     }
 
     @Test


### PR DESCRIPTION
MapStruct used instanceof NotificationCustom before NotificationAdministrative. Since administrative notifications inherit from custom notifications, they were converted as NotificationCustomEntity and returned as Custom.

Fixed both V2 and V3 adapters by checking NotificationAdministrative before NotificationCustom, in both API-to-entity and entity-to-API dispatch.

Added subtype-preservation tests in:

V2 notification adapter test
V3 notification adapter test