### PR TITLE
PD-13463 fixed so readonly transactions read from readonlydb

### DIFF
--- a/orcid-core/src/main/resources/orcid-core-cache-config.xml
+++ b/orcid-core/src/main/resources/orcid-core-cache-config.xml
@@ -7,7 +7,7 @@
         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
         http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">	
 	
-	<cache:annotation-driven cache-manager="springCoreCacheManager"/>
+	<cache:annotation-driven cache-manager="springCoreCacheManager" order="1"/>
 	
 	<bean id="coreCacheManager"
 		class="org.orcid.core.utils.OrcidEhCacheManagerFactoryBean" >

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/AddressDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/AddressDao.java
@@ -16,16 +16,16 @@ import org.springframework.transaction.annotation.Transactional;
  * 
  */
 public interface AddressDao extends GenericDao<AddressEntity, Long> {
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     AddressEntity getAddress(String orcid, Long putCode);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<AddressEntity> getAddresses(String orcid, long lastModified);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<AddressEntity> getAddresses(String orcid, String visibility);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<Object[]> findAddressesToMigrate();
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -41,37 +41,37 @@ public interface AddressDao extends GenericDao<AddressEntity, Long> {
     @Transactional(propagation = Propagation.REQUIRED)
     void removeAllAddress(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<AddressEntity> getPublicAddresses(String orcid, long lastModified);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctClientSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctUserSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void revertUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(int max);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsOfAddressesReferencingClientProfiles(int max, List<String> ids);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/BiographyDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/BiographyDao.java
@@ -10,10 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
  * 
  */
 public interface BiographyDao extends GenericDao<BiographyEntity, Long> {
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean exists(String orcid);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     BiographyEntity getBiography(String orcid, long lastModified);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ClientDetailsDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ClientDetailsDao.java
@@ -16,19 +16,19 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface ClientDetailsDao extends GenericDao<ClientDetailsEntity, String> {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     ClientDetailsEntity findByClientId(String clientId, long lastModified);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Date getLastModified(String clientId);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Map<String, Date> getLastModifiedByClientIds(List<String> clientIds);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ClientDetailsEntity> findByClientIds(List<String> clientIds);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Date getLastModifiedByIdP(String idp);
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -46,37 +46,37 @@ public interface ClientDetailsDao extends GenericDao<ClientDetailsEntity, String
     @Transactional(propagation = Propagation.REQUIRED)
     boolean createClientSecret(String clientId, String clientSecret);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ClientSecretEntity> getClientSecretsByClientId(String clientId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean exists(String clientId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean belongsTo(String clientId, String groupId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ClientDetailsEntity> findByGroupId(String groupId);
     
     @Transactional(propagation = Propagation.REQUIRED)
     public void removeClient(String clientId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ClientDetailsEntity getPublicClient(String ownerId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String getMemberName(String clientId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean existsAndIsNotPublicClient(String clientId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Date getLastModifiedIfNotPublicClient(String clientId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     ClientDetailsEntity findByIdP(String idp);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> findLegacyClientIds();
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -97,7 +97,7 @@ public interface ClientDetailsDao extends GenericDao<ClientDetailsEntity, String
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateNotificationInfo(String clientId, boolean notificationEnabled, String notificationWebUrl, String notificationDomains);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ClientDetailsEntity> findMVPEnabled();
 
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ClientRedirectDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ClientRedirectDao.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface ClientRedirectDao extends GenericDao<ClientRedirectUriEntity, ClientRedirectUriPk> {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ClientRedirectUriEntity> findClientDetailsWithRedirectScope(String redirectUriType);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ClientSecretDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ClientSecretDao.java
@@ -34,7 +34,7 @@ public interface ClientSecretDao extends GenericDao<ClientSecretEntity, ClientSe
      * @param clientId
      * @return a list of all client secrets associated with a client
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ClientSecretEntity> getClientSecretsByClientId(String clientId);
 
     /**
@@ -61,7 +61,7 @@ public interface ClientSecretDao extends GenericDao<ClientSecretEntity, ClientSe
      * @param limit the amount of results fetched by the query
      * @return A list of client secrets with non-primary keys
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ClientSecretEntity> getNonPrimaryKeys(Integer limit);
     
     /**

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/CustomEmailDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/CustomEmailDao.java
@@ -21,7 +21,7 @@ public interface CustomEmailDao extends GenericDao<CustomEmailEntity, CustomEmai
      * @param clientDetailsId
      * @return a list containing all custom emails associated with a client
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<CustomEmailEntity> getCustomEmails(String clientDetailsId);
     
     /**
@@ -30,7 +30,7 @@ public interface CustomEmailDao extends GenericDao<CustomEmailEntity, CustomEmai
      * @param emailType
      * @return a CustomEmailEntity object if the email is found, null otherwise
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     CustomEmailEntity findByClientIdAndEmailType(String clientDetailsId, EmailType emailType, long lastModified);
     
     /**
@@ -75,7 +75,7 @@ public interface CustomEmailDao extends GenericDao<CustomEmailEntity, CustomEmai
      * @param emailType
      * @return true if a custom email with id=clientDetailsId and email type=emailType exists
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean exists(String clientDetailsId, EmailType emailType);
     
     /**
@@ -84,6 +84,6 @@ public interface CustomEmailDao extends GenericDao<CustomEmailEntity, CustomEmai
      * @param emailType
      * @return the last modified date of the custom email, null in case the email doesn't exists
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Date getLastModified(String clientDetailsId, EmailType emailType);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/EmailDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/EmailDao.java
@@ -13,16 +13,16 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface EmailDao extends GenericDao<EmailEntity, String> {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean emailExists(String emailHash);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     EmailEntity findByEmail(String email);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String findOrcidIdByEmailHash(String email);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String findOrcidByVerifiedEmail(String email);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -35,7 +35,7 @@ public interface EmailDao extends GenericDao<EmailEntity, String> {
     void removeEmail(String orcid, String email);
     
     @SuppressWarnings("rawtypes")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List findIdByCaseInsensitiveEmail(List<String> emails);
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -44,16 +44,16 @@ public interface EmailDao extends GenericDao<EmailEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean verifyEmail(String email);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean isVerified(String orcid, String email);
     
     @Transactional(propagation = Propagation.REQUIRED)
     boolean moveEmailToOtherAccountAsNonPrimary(String email, String origin, String destination);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<EmailEntity> findByOrcid(String orcid, long lastModified);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<EmailEntity> findByOrcid(String orcid, String visibility);
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -70,28 +70,28 @@ public interface EmailDao extends GenericDao<EmailEntity, String> {
      * @return true if the email exists, the owner is not claimed and the
      *         client source of the record allows auto deprecating records
      */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean isAutoDeprecateEnableForEmailUsingHash(String emailHash);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean isPrimaryEmail(String email);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean isPrimaryEmail(String orcid, String email);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     EmailEntity findPrimaryEmail(String orcid);
     
     @Transactional(propagation = Propagation.REQUIRED)
     boolean hideAllEmails(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<EmailEntity> findPublicEmails(String orcid, long lastModified);
     
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateVisibility(String orcid, String email, String visibility);   
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getEmailsToHash(Integer batchSize); 
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -100,10 +100,10 @@ public interface EmailDao extends GenericDao<EmailEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     Integer clearEmailsAfterReactivation(String orcid);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List getEmailAndHash(int iteration, int batchSize);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -114,42 +114,42 @@ public interface EmailDao extends GenericDao<EmailEntity, String> {
      * 
      * @return
      */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<EmailEntity> getMarch2019QuarterlyEmailRecipients(int offset, int batchSize);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getIdsForUserSourceCorrection(int limit, List<String> publicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctUserSource(List<String> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<EmailEntity> findPublicEmailsIncludeUnverified(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getIdsForUserOBOUpdate(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateUserOBODetails(List<String> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<EmailEntity> get2019VisibilityEmailRecipients(int offset, int batchSize);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getIdsForUserOBORecords(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void revertUserOBODetails(List<String> ids);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String findNewestVerifiedOrNewestEmail(String orcid);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String findNewestPrimaryEmail(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getIdsForUserOBORecords(int max);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getIdsOfEmailsReferencingClientProfiles(int max, List<String> ids);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/EmailDomainDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/EmailDomainDao.java
@@ -19,9 +19,9 @@ public interface EmailDomainDao extends GenericDao<EmailDomainEntity, Long> {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateRorId(long id, String rorId);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<EmailDomainEntity>  findByEmailDomain(String emailDomain);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<EmailDomainEntity> findByCategory(EmailDomainEntity.DomainCategory category);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/EmailFrequencyDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/EmailFrequencyDao.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
  * 
  */
 public interface EmailFrequencyDao extends GenericDao<EmailFrequencyEntity, String> {
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     EmailFrequencyEntity findByOrcid(String orcid);
     
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/EmailScheduleDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/EmailScheduleDao.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface EmailScheduleDao extends GenericDao<EmailScheduleEntity, Long> {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Long getValidScheduleId();
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ExternalIdentifierDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ExternalIdentifierDao.java
@@ -29,7 +29,7 @@ public interface ExternalIdentifierDao extends GenericDao<ExternalIdentifierEnti
      * @return a list of all external identifiers associated with the given
      *         profile
      */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ExternalIdentifierEntity> getExternalIdentifiers(String orcid, long lastModified);
 
     /**
@@ -41,7 +41,7 @@ public interface ExternalIdentifierDao extends GenericDao<ExternalIdentifierEnti
      * @return a list of all external identifiers associated with the given
      *         profile and that have the given visibility
      */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ExternalIdentifierEntity> getExternalIdentifiers(String orcid, String visibility);
 
     /**
@@ -51,7 +51,7 @@ public interface ExternalIdentifierDao extends GenericDao<ExternalIdentifierEnti
      * @param id
      * @return an external identifier that matches the given id and profile id
      */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     ExternalIdentifierEntity getExternalIdentifierEntity(String orcid, Long id);
     
     /**
@@ -76,7 +76,7 @@ public interface ExternalIdentifierDao extends GenericDao<ExternalIdentifierEnti
     @Transactional(propagation = Propagation.REQUIRED)
     void removeAllExternalIdentifiers(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ExternalIdentifierEntity> getPublicExternalIdentifiers(String orcid, long lastModified);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/GenericDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/GenericDao.java
@@ -24,13 +24,13 @@ public interface GenericDao<E extends OrcidEntity<I>, I extends Serializable> {
     @Transactional(propagation = Propagation.REQUIRED)
     void detatch(E e);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     E find(I id);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<E> findLastModifiedBefore(Date latestDate, int maxResults);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<E> getAll();
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -52,7 +52,7 @@ public interface GenericDao<E extends OrcidEntity<I>, I extends Serializable> {
     @Transactional(propagation = Propagation.REQUIRED)
     void persist(E e);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Long countAll();
 
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/GroupIdRecordDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/GroupIdRecordDao.java
@@ -7,24 +7,24 @@ import org.orcid.persistence.jpa.entities.GroupIdRecordEntity;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface GroupIdRecordDao extends GenericDao<GroupIdRecordEntity, Long> {
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<GroupIdRecordEntity> getGroupIdRecords(int pageSize, int page);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean exists(String groupId);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     GroupIdRecordEntity findByGroupId(String groupId);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     GroupIdRecordEntity findByName(String name);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean haveAnyPeerReview(String groupId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean duplicateExists(Long putCode, String groupId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<GroupIdRecordEntity> getIssnRecordsSortedBySyncDate(int batchSize, Date syncTime);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/IdentifierTypeDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/IdentifierTypeDao.java
@@ -14,10 +14,10 @@ public interface IdentifierTypeDao extends GenericDao<IdentifierTypeEntity, Long
     @Transactional(propagation = Propagation.REQUIRED)
     public IdentifierTypeEntity updateIdentifierType(IdentifierTypeEntity identifierType);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public IdentifierTypeEntity getEntityByName(String idName);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<IdentifierTypeEntity> getEntities();
     
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrcidOauth2AuthoriziationCodeDetailDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrcidOauth2AuthoriziationCodeDetailDao.java
@@ -14,7 +14,7 @@ public interface OrcidOauth2AuthoriziationCodeDetailDao extends GenericDao<Orcid
     @Transactional(propagation = Propagation.REQUIRED)
     OrcidOauth2AuthoriziationCodeDetail removeAndReturn(String code);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean isPersistentToken(String code);
 
     boolean removeArchivedAuthorizationCodes(Date maxArchiveDate);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrcidPropsDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrcidPropsDao.java
@@ -16,9 +16,9 @@ public interface OrcidPropsDao {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean update(String key, String value);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean exists(String key);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String getValue(String key);    
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrgDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrgDao.java
@@ -16,43 +16,43 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface OrgDao extends GenericDao<OrgEntity, Long> {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<AmbiguousOrgEntity> getAmbiguousOrgs(int firstResult, int maxResults);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgEntity> getOrgs(String searchTerm, int firstResult, int maxResults);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgEntity> getOrgsByName(String searchTerm);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     OrgEntity findByNameCityRegionAndCountry(String name, String city, String region, String country);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     OrgEntity findByNameCityRegionCountryAndType(String name, String city, String region, String country, String sourceType);
     
     @Transactional(propagation = Propagation.REQUIRED)
     void removeOrgsByClientSourceId(String clientSourceId);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     OrgEntity findByAddressAndDisambiguatedOrg(String name, String city, String region, String country, OrgDisambiguatedEntity orgDisambiguated);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctClientSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctUserSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<Object[]> findConstraintViolatingDuplicateOrgDetails();
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getOrgIdsForDuplicateOrgDetails(String name, String city, String region, String country, Long orgDisambiguatedId);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -64,10 +64,10 @@ public interface OrgDao extends GenericDao<OrgEntity, Long> {
     @Transactional(propagation = Propagation.REQUIRED)
     int convertNullRegionsToEmptyStrings(int batchSize);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsOfOrgsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgEntity> findByOrgDisambiguatedId(Long deprecated);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrgDisambiguatedDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrgDisambiguatedDao.java
@@ -15,34 +15,34 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface OrgDisambiguatedDao extends GenericDao<OrgDisambiguatedEntity, Long> {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgDisambiguatedEntity> getOrgs(String searchTerm, int firstResult, int maxResults);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgDisambiguatedEntity> getChunk(int firstResult, int maxResults);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgDisambiguatedEntity> findBySourceType(String sourceType,int firstResult, int maxResults);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     OrgDisambiguatedEntity findBySourceIdAndSourceType(String sourceId, String sourceType);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     OrgDisambiguatedEntity findByNameCityRegionCountryAndSourceType(String name, String city, String region, String country, String sourceType);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgDisambiguatedEntity> findByName(String name);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgDisambiguatedEntity> findOrgsToGroup(int firstResult, int maxResult);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<Long> findOrgsPendingIndexing(int maxResult);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateIndexingStatus(Long orgDisambiguatedId, IndexingStatus indexingStatus);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<Pair<Long, Integer>> findDisambuguatedOrgsWithIncorrectPopularity(int maxResults);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -54,7 +54,7 @@ public interface OrgDisambiguatedDao extends GenericDao<OrgDisambiguatedEntity, 
     @Transactional(propagation = Propagation.REQUIRED)
     void createUniqueConstraint();
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgDisambiguatedEntity> findDuplicates();
     
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrgDisambiguatedExternalIdentifierDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/OrgDisambiguatedExternalIdentifierDao.java
@@ -7,15 +7,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface OrgDisambiguatedExternalIdentifierDao extends GenericDao<OrgDisambiguatedExternalIdentifierEntity, Long> {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     OrgDisambiguatedExternalIdentifierEntity findByDetails(Long orgDisambiguatedId, String identifier, String identifierType);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean exists(Long orgDisambiguatedId, String identifier, String identifierType);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgDisambiguatedExternalIdentifierEntity> findISNIsOfIncorrectLength(int batchSize);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrgDisambiguatedExternalIdentifierEntity> findByIdentifierIdAndType(String identifier, String identifierType);    
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/OtherNameDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/OtherNameDao.java
@@ -16,7 +16,7 @@ public interface OtherNameDao extends GenericDao<OtherNameEntity, Long> {
      * @return
      * The list of other names related with the specified orcid profile
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OtherNameEntity> getOtherNames(String orcid, long lastModified);
 
     /**
@@ -25,7 +25,7 @@ public interface OtherNameDao extends GenericDao<OtherNameEntity, Long> {
      * @return
      * The list of other names related with the specified orcid profile
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OtherNameEntity> getOtherNames(String orcid, String visibility);
 
     
@@ -57,7 +57,7 @@ public interface OtherNameDao extends GenericDao<OtherNameEntity, Long> {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean deleteOtherName(OtherNameEntity otherName);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     OtherNameEntity getOtherName(String orcid, Long putCode);
     
     /**
@@ -70,37 +70,37 @@ public interface OtherNameDao extends GenericDao<OtherNameEntity, Long> {
     @Transactional(propagation = Propagation.REQUIRED)
     void removeAllOtherNames(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OtherNameEntity> getPublicOtherNames(String orcid, long lastModified);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctClientSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctUserSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void revertUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(int max);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsOfOtherNamesReferencingClientProfiles(int max, List<String> clientProfileOrcidIds);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/PeerReviewDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/PeerReviewDao.java
@@ -19,7 +19,7 @@ public interface PeerReviewDao extends GenericDao<PeerReviewEntity, Long> {
      *            The id of the element
      * @return a peer review entity that have the give id and belongs to the given user 
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     PeerReviewEntity getPeerReview(String userOrcid, Long peerReviewId);
     
     /**
@@ -43,13 +43,13 @@ public interface PeerReviewDao extends GenericDao<PeerReviewEntity, Long> {
      *            The owner of the peerReview
      * @return a list will all peer reviews associated with the given user 
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<PeerReviewEntity> getByUser(String userOrcid, long lastModified);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<Object[]> getPeerReviewsByOrcid(String orcid, boolean justPublic);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<PeerReviewEntity> getPeerReviewsByOrcidAndGroupId(String orcid, String groupId, boolean justPublic);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -67,7 +67,7 @@ public interface PeerReviewDao extends GenericDao<PeerReviewEntity, Long> {
      *          The batch number to fetch
      * @return a list of peer review ids with old ext ids          
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getPeerReviewWithOldExtIds(long limit);
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -88,9 +88,9 @@ public interface PeerReviewDao extends GenericDao<PeerReviewEntity, Long> {
      * 
      * @param orcid
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Boolean hasPublicPeerReviews(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<PeerReviewEntity> getPeerReviewsReferencingOrgs(List<Long> orgIds);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileDao.java
@@ -22,10 +22,10 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     ProfileEntity merge(ProfileEntity entity);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> findByMissingEventTypes(int maxResults, List<ProfileEventType> pet, Collection<String> orcidsToExclude, boolean not);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> findByMissingEventTypes(int maxResults, List<ProfileEventType> pet, Collection<String> orcidsToExclude, boolean not, boolean checkQuarterlyTipsEnabled);
 
     /**
@@ -42,7 +42,7 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
      * @return a list of object arrays where the object[0] contains the orcid id
      *         and object[1] contains the indexing status
      */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Map<String, Date> findOrcidsByIndexingStatus(IndexingStatus indexingStatus, int maxResults, Integer delay);
 
     /**
@@ -59,55 +59,55 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
      * @return a list of object arrays where the object[0] contains the orcid id
      *         and object[1] contains the indexing status
      */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Map<String, Date> findOrcidsByIndexingStatus(IndexingStatus indexingStatus, int maxResults, Collection<String> orcidsToExclude, Integer delay);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> findUnclaimedNotIndexedAfterWaitPeriod(int waitPeriodDays, int maxDaysBack, int maxResults, Collection<String> orcidsToExclude);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> findUnclaimedNeedingReminder(int reminderAfterDays, int maxResults, Collection<String> orcidsToExclude);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> findOrcidsNeedingEmailMigration(int maxResults);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileEntity> findProfilesThatMissedIndexing(int maxResults);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean orcidExists(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean hasBeenGivenPermissionTo(String giverOrcid, String receiverOrcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean existsAndNotClaimedAndBelongsTo(String messageOrcid, String clientId);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateIndexingStatus(String orcid, IndexingStatus indexingStatus);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     IndexingStatus retrieveIndexingStatus(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Long getConfirmedProfileCount();
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileEntity> findByOrcidType(String orcidType);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateLastModifiedDateAndIndexingStatusWithoutResult(String orcid, Date lastModified, IndexingStatus indexingStatus);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Triple<String, String, Boolean>> findEmailsUnverfiedDays(int daysUnverified, EmailEventType eventSent);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String retrieveOrcidType(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<Object[]> findInfoForDecryptionAnalysis();
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String retrieveLocale(String orcid);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -116,10 +116,10 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean deprecateProfile(String toDeprecate, String primaryOrcid, String deprecatedMethod, String adminUser);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String retrievePrimaryAccountOrcid(String deprecatedOrcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean isProfileDeprecated(String orcid);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -128,16 +128,16 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateDeveloperTools(String orcid, boolean enabled);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean getClaimedStatus(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean getClaimedStatusByEmailHash(String email);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String getClientType(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     String getGroupType(String orcid);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -149,10 +149,10 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     public boolean unlockProfile(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isLocked(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isDeactivated(String orcid);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -167,13 +167,13 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateDefaultVisibility(String orcid, String visibility);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getProfilesWithNoHashedOrcid(int limit);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void hashOrcidIds(String orcid, String hashedOrcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date getLastLogin(String orcid);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -188,32 +188,32 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean deactivate(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<OrcidGrantedAuthority> getGrantedAuthoritiesForProfile(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileEventEntity> getProfileEvents(String orcid, List<ProfileEventType> eventTypeNames);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     ProfileEntity getLockedReason(String orcid);
 
     @Transactional(propagation = Propagation.REQUIRED)
     int deleteProfilesOfType(String orcidType);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<String> getAllOrcidIdsForInvalidRecords();
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateIndexingStatus(List<String> ids, IndexingStatus reindex);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> registeredBetween(Date startDate, Date endDate);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean isOrcidValidAsDelegate(String orcid);
 
     // ********* Signin Lock Methods *********
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> getSigninLock(String orcid);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -225,16 +225,16 @@ public interface ProfileDao extends GenericDao<ProfileEntity, String> {
     @Transactional(propagation = Propagation.REQUIRED)
     public void updateSigninLock(String orcid, Integer count);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean haveMemberPushedWorksOrAffiliationsToRecord(String orcid, String clientId);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Pair<String, String>> findEmailsToSendAddWorksEmail(int profileCreatedNumberOfDaysAgo);
 
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateDeprecation(String deprecated, String primaryOrcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isReviewed(String orcid);
 
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileEmailDomainDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileEmailDomainDao.java
@@ -19,18 +19,18 @@ public interface ProfileEmailDomainDao extends GenericDao<ProfileEmailDomainEnti
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateVisibility(String orcid, String emailDomain, String visibility);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileEmailDomainEntity> findByOrcid(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileEmailDomainEntity> findPublicEmailDomains(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     ProfileEmailDomainEntity findByEmailDomain(String orcid, String emailDomain);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void moveEmailDomainToAnotherAccount(String emailDomain, String deprecatedOrcid, String primaryOrcid);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileEmailDomainEntity> findByEmailDomain(String emailDomain);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileFundingDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileFundingDao.java
@@ -19,7 +19,7 @@ public interface ProfileFundingDao extends GenericDao<ProfileFundingEntity, Long
      *            The id of the element
      * @return a profile funding entity that have the give id and belongs to the given user 
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ProfileFundingEntity getProfileFunding(String userOrcid, Long profileFundingId);
     
     /**
@@ -92,7 +92,7 @@ public interface ProfileFundingDao extends GenericDao<ProfileFundingEntity, Long
      * 
      * @return the ProfileFundingEntity object
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     ProfileFundingEntity getProfileFundingEntity(String orgId, String clientOrcid);
 
     /**
@@ -103,14 +103,14 @@ public interface ProfileFundingDao extends GenericDao<ProfileFundingEntity, Long
      * 
      * @return the ProfileFundingEntity object
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     ProfileFundingEntity getProfileFundingEntity(Long profileFundingId);
     
     /**
      * Get all the profile fundings where the amount is not null
      * @return a list of all profile fundings where the amount is not null 
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileFundingEntity> getProfileFundingWithAmount();
     
     /**
@@ -126,7 +126,7 @@ public interface ProfileFundingDao extends GenericDao<ProfileFundingEntity, Long
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateToMaxDisplay(String orcid, Long id);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> findFundingNeedingExternalIdentifiersMigration(int chunkSize);
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -135,7 +135,7 @@ public interface ProfileFundingDao extends GenericDao<ProfileFundingEntity, Long
     @Transactional(propagation = Propagation.REQUIRED)
     void removeFundingByClientSourceId(String clientSourceId);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileFundingEntity> getByUser(String userOrcid, long lastModified);
     
     /**
@@ -144,7 +144,7 @@ public interface ProfileFundingDao extends GenericDao<ProfileFundingEntity, Long
      *          The batch number to fetch
      * @return a list of funding ids with old ext ids          
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getFundingWithOldExtIds(long limit);
     
     @Transactional(propagation = Propagation.REQUIRED)
@@ -167,39 +167,39 @@ public interface ProfileFundingDao extends GenericDao<ProfileFundingEntity, Long
      *          the Id of the user
      * @return true if there is at least one public funding for a specific user
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Boolean hasPublicFunding(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctClientSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctUserSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileFundingEntity> getFundingsReferencingOrgs(List<Long> orgIds);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void revertUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfFundingsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileKeywordDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileKeywordDao.java
@@ -16,13 +16,13 @@ public interface ProfileKeywordDao extends GenericDao<ProfileKeywordEntity, Long
      * @return 
      *          the list of keywords associated with the orcid profile
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileKeywordEntity> getProfileKeywords(String orcid, long lastModified);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileKeywordEntity> getPublicProfileKeywords(String orcid, long lastModified);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ProfileKeywordEntity> getProfileKeywords(String orcid, String visibility);
 
     /**
@@ -46,7 +46,7 @@ public interface ProfileKeywordDao extends GenericDao<ProfileKeywordEntity, Long
     @Transactional(propagation = Propagation.REQUIRED)
     boolean deleteProfileKeyword(ProfileKeywordEntity entity);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     ProfileKeywordEntity getProfileKeyword(String orcid, Long putCode);
     
     /**
@@ -59,34 +59,34 @@ public interface ProfileKeywordDao extends GenericDao<ProfileKeywordEntity, Long
     @Transactional(propagation = Propagation.REQUIRED)
     void removeAllKeywords(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctClientSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctUserSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void revertUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(int max);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsOfKeywordsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileLastModifiedDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ProfileLastModifiedDao.java
@@ -20,7 +20,7 @@ public interface ProfileLastModifiedDao {
     
     boolean updateIndexingStatus(List<String> orcidIds, IndexingStatus indexingStatus);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Date retrieveLastModifiedDate(String orcid);
     
     

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/PublicApiDailyRateLimitDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/PublicApiDailyRateLimitDao.java
@@ -8,16 +8,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface PublicApiDailyRateLimitDao extends GenericDao<PublicApiDailyRateLimitEntity, Long> {
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     PublicApiDailyRateLimitEntity findByClientIdAndRequestDate(String clientId, LocalDate requestDate);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     PublicApiDailyRateLimitEntity findByIpAddressAndRequestDate(String ipAddress, LocalDate requestDate);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     int countClientRequestsWithLimitExceeded(LocalDate requestDate, int limit);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     int countAnonymousRequestsWithLimitExceeded(LocalDate requestDate, int limit);
     
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/RecordNameDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/RecordNameDao.java
@@ -13,21 +13,21 @@ import org.springframework.transaction.annotation.Transactional;
  * 
  */
 public interface RecordNameDao extends GenericDao<RecordNameEntity, Long> {
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean exists(String orcid);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     RecordNameEntity getRecordName(String orcid, long lastModified);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     RecordNameEntity findByCreditName(String creditName);
 
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateRecordName(RecordNameEntity recordName);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Date getLastModified(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<RecordNameEntity> getRecordNames(List<String> orcids);
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ResearchResourceDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ResearchResourceDao.java
@@ -13,10 +13,10 @@ public interface ResearchResourceDao extends GenericDao<ResearchResourceEntity, 
     @Transactional(propagation = Propagation.REQUIRED)
     boolean removeResearchResource(String userOrcid, Long researchResourceId);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<ResearchResourceEntity> getByUser(String userOrcid, long lastModified);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ResearchResourceEntity getResearchResource(String userOrcid, Long researchResourceId);
 
     @Transactional(propagation = Propagation.REQUIRED)
@@ -28,10 +28,10 @@ public interface ResearchResourceDao extends GenericDao<ResearchResourceEntity, 
     @Transactional(propagation = Propagation.REQUIRED)
     boolean updateToMaxDisplay(String orcid, Long researchResourceId);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     Boolean hasPublicResearchResources(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getResearchResourcesReferencingOrgs(List<Long> orgIds);
 
 }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/ResearcherUrlDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/ResearcherUrlDao.java
@@ -16,10 +16,10 @@ public interface ResearcherUrlDao extends GenericDao<ResearcherUrlEntity, Long> 
      * @return 
      *          the list of researcher urls associated with the orcid profile
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ResearcherUrlEntity> getResearcherUrls(String orcid, long lastModified);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ResearcherUrlEntity> getPublicResearcherUrls(String orcid, long lastModified);
 
     /**
@@ -29,7 +29,7 @@ public interface ResearcherUrlDao extends GenericDao<ResearcherUrlEntity, Long> 
      * @return 
      *          the list of researcher urls associated with the orcid profile
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ResearcherUrlEntity> getResearcherUrls(String orcid, String visibility);
     
     /**
@@ -47,7 +47,7 @@ public interface ResearcherUrlDao extends GenericDao<ResearcherUrlEntity, Long> 
      * @param id
      * @return the ResearcherUrlEntity associated with the parameter id
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ResearcherUrlEntity getResearcherUrl(String orcid, Long id);
     
     /**
@@ -69,34 +69,34 @@ public interface ResearcherUrlDao extends GenericDao<ResearcherUrlEntity, Long> 
     @Transactional(propagation = Propagation.REQUIRED)
     void removeAllResearcherUrls(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctClientSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctUserSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void revertUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsOfResearcherUrlsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/SpamDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/SpamDao.java
@@ -11,13 +11,13 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface SpamDao extends GenericDao<SpamEntity, Long>{
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean exists(String orcid);
     
     @Transactional(propagation = Propagation.REQUIRED)
     boolean removeSpam(String orcid);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     SpamEntity getSpam(String orcid);       
     
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/StatisticsDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/StatisticsDao.java
@@ -6,13 +6,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface StatisticsDao {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     long calculateLiveIds();
     
     @Transactional(propagation = Propagation.REQUIRED)
     Long createKey();
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     long getLatestLiveIds();
     
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/WebhookDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/WebhookDao.java
@@ -14,10 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface WebhookDao extends GenericDao<WebhookEntity, WebhookEntityPk> {
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<WebhookEntity> findWebhooksReadyToProcess(Date profileModifiedBefore, int retryDelayMinutes, int maxResults, Set<String> clientsToExclude);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     long countWebhooksReadyToProcess(Date profileModifiedBefore, int retryDelayMinutes);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/WorkDao.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/WorkDao.java
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 public interface WorkDao extends GenericDao<WorkEntity, Long> {    
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     MinimizedWorkEntity getMinimizedWorkEntity(Long id);
 
     /**
@@ -81,7 +81,7 @@ public interface WorkDao extends GenericDao<WorkEntity, Long> {
      * Returns a list of work ids where the ext id relationship is null         
      * @return a list of work ids    
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getWorksWithNullRelationship();
     
     /**
@@ -93,7 +93,7 @@ public interface WorkDao extends GenericDao<WorkEntity, Long> {
      *         
      * @return a list of work ids    
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getWorksByWorkTypeAndExtIdType(String workType, String extIdType);
     
     /**
@@ -103,16 +103,16 @@ public interface WorkDao extends GenericDao<WorkEntity, Long> {
      * 
      * @return the WorkEntity associated with the parameter id
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     WorkEntity getWork(String orcid, Long id);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<WorkLastModifiedEntity> getWorkLastModifiedList(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<WorkLastModifiedEntity> getPublicWorkLastModifiedList(String orcid);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<WorkLastModifiedEntity> getWorkLastModifiedList(String orcid, List<Long> ids);
 
     void detach(WorkBaseEntity workBaseEntity);
@@ -120,53 +120,53 @@ public interface WorkDao extends GenericDao<WorkEntity, Long> {
     @Transactional(propagation = Propagation.REQUIRED)
     boolean increaseDisplayIndexOnAllElements(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<MinimizedExtendedWorkEntity> getMinimizedExtendedWorkEntities(List<Long> ids);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<WorkEntity> getWorkEntities(String orcid, List<Long> ids);        
 
     @Deprecated
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<WorkEntity> getWorksByOrcidId(String orcid);
     
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean hasPublicWorks(String orcid);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     boolean isPublic(String orcid, List<Long> workIds);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClientIds);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctClientSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClientIds);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void correctUserSource(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void updateUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max);
 
     @Transactional(propagation = Propagation.REQUIRED)
     void revertUserOBODetails(List<BigInteger> ids);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsForUserOBORecords(int max);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<BigInteger> getIdsOfWorksReferencingClientProfiles(int i, List<String> clientProfileOrcidIds);
 
     /**
@@ -176,10 +176,10 @@ public interface WorkDao extends GenericDao<WorkEntity, Long> {
      *
      * @return a list of works associated with the provided orcid
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<Object[]> getWorksByOrcid(String orcid, boolean featuredOnly);
 
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     List<Object[]> getWorksStartingFromWorkId(Long WorkId, int numberOfWorks);
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/AddressDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/AddressDaoImpl.java
@@ -27,7 +27,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public AddressEntity getAddress(String orcid, Long putCode) {
         Query query = entityManager.createQuery("FROM AddressEntity WHERE orcid = :orcid and id = :id");
         query.setParameter("orcid", orcid);
@@ -37,7 +37,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> findAddressesToMigrate() {
         String queryString = "SELECT p.orcid, p.iso2_country, p.profile_address_visibility FROM profile p WHERE p.iso2_country IS NOT NULL AND NOT EXISTS (SELECT a.orcid FROM address a WHERE a.orcid = p.orcid) LIMIT 10000;";                
         Query query = entityManager.createNativeQuery(queryString);                         
@@ -46,7 +46,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "dao-address", key = "#orcid.concat('-').concat(#lastModified)")
     public List<AddressEntity> getAddresses(String orcid, long lastModified) {
         Query query = entityManager.createQuery("FROM AddressEntity WHERE orcid = :orcid order by displayIndex desc, dateCreated asc");
@@ -55,7 +55,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "public-address", key = "#orcid.concat('-').concat(#lastModified)")
     public List<AddressEntity> getPublicAddresses(String orcid, long lastModified) {
         return getAddresses(orcid, PUBLIC_VISIBILITY);
@@ -63,7 +63,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
    
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<AddressEntity> getAddresses(String orcid, String visibility) {
         Query query = entityManager.createQuery("FROM AddressEntity WHERE orcid = :orcid and visibility = :visibility order by displayIndex desc, dateCreated asc");
         query.setParameter("orcid", orcid);
@@ -92,7 +92,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM address WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
         query.setParameter("nonPublicClients", nonPublicClients);
@@ -110,7 +110,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM address WHERE client_source_id = source_id AND client_source_id IN :publicClients");
         query.setParameter("publicClients", publicClients);
@@ -128,7 +128,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM address WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -146,7 +146,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM address WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NOT NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -164,7 +164,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM address WHERE assertion_origin_source_id IS NOT NULL");
         query.setMaxResults(max);
@@ -173,7 +173,7 @@ public class AddressDaoImpl extends GenericDaoImpl<AddressEntity, Long> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfAddressesReferencingClientProfiles(int max, List<String> ids) {
         Query query = entityManager.createNativeQuery("SELECT id FROM address WHERE source_id IN :ids");
         query.setParameter("ids", ids);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/BackupCodeDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/BackupCodeDaoImpl.java
@@ -17,7 +17,7 @@ public class BackupCodeDaoImpl extends GenericDaoImpl<BackupCodeEntity, Long> im
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BackupCodeEntity> getUnusedBackupCodes(String orcid) {
         Query query = entityManager.createQuery("FROM BackupCodeEntity WHERE orcid = :orcid AND usedDate IS NULL");
         query.setParameter("orcid", orcid);
@@ -43,7 +43,7 @@ public class BackupCodeDaoImpl extends GenericDaoImpl<BackupCodeEntity, Long> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date getBackupCodesCreationDate(String orcid) {
         Query query = entityManager.createQuery("SELECT MAX(b.dateCreated) FROM BackupCodeEntity b WHERE b.orcid = :orcid");
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/BiographyDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/BiographyDaoImpl.java
@@ -20,7 +20,7 @@ public class BiographyDaoImpl extends GenericDaoImpl<BiographyEntity, Long> impl
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "biography", key = "#orcid.concat('-').concat(#lastModified)")
     public BiographyEntity getBiography(String orcid, long lastModified) {
         Query query = entityManager.createQuery("FROM BiographyEntity WHERE orcid = :orcid");
@@ -52,7 +52,7 @@ public class BiographyDaoImpl extends GenericDaoImpl<BiographyEntity, Long> impl
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean exists(String orcid) {
         Query query = entityManager.createNativeQuery("select count(*) from biography where orcid=:orcid");
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientDetailsDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientDetailsDaoImpl.java
@@ -34,7 +34,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "client-details", key = "#clientId.concat('-').concat(#lastModified)")
     public ClientDetailsEntity findByClientId(String clientId, long lastModified) {
         TypedQuery<ClientDetailsEntity> query = entityManager.createQuery("from ClientDetailsEntity where id = :clientId", ClientDetailsEntity.class);
@@ -48,7 +48,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date getLastModified(String clientId) {
         TypedQuery<Date> query = entityManager.createQuery("select lastModified from ClientDetailsEntity where id = :clientId", Date.class);
         query.setParameter("clientId", clientId);
@@ -56,7 +56,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Map<String, Date> getLastModifiedByClientIds(List<String> clientIds) {
         if (clientIds == null || clientIds.isEmpty()) {
             return new HashMap<>();
@@ -71,7 +71,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ClientDetailsEntity> findByClientIds(List<String> clientIds) {
         if (clientIds == null || clientIds.isEmpty()) {
             return java.util.Collections.emptyList();
@@ -82,7 +82,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date getLastModifiedByIdP(String idp) {
         TypedQuery<Date> query = entityManager.createQuery("select lastModified from ClientDetailsEntity where authenticationProviderId = :idp", Date.class);
         query.setParameter("idp", idp);
@@ -135,7 +135,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ClientSecretEntity> getClientSecretsByClientId(String clientId) {
         TypedQuery<ClientSecretEntity> query = entityManager.createQuery("From ClientSecretEntity WHERE clientId=:clientId", ClientSecretEntity.class);
         query.setParameter("clientId", clientId);
@@ -143,7 +143,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean exists(String clientId) {
         TypedQuery<Long> query = entityManager.createQuery("select count(*) from ClientDetailsEntity where id=:clientId", Long.class);
         query.setParameter("clientId", clientId);
@@ -152,7 +152,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean belongsTo(String clientId, String groupId) {
         TypedQuery<ClientDetailsEntity> query = entityManager.createQuery("from ClientDetailsEntity where id = :clientId and groupProfileId = :groupId",
                 ClientDetailsEntity.class);
@@ -177,7 +177,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @SuppressWarnings("unchecked")
     public List<ClientDetailsEntity> findByGroupId(String groupId) {
         Query query = entityManager.createQuery("from ClientDetailsEntity where groupProfileId = :groupId");
@@ -200,7 +200,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
      * @return the public client that belongs to the given user
      */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ClientDetailsEntity getPublicClient(String ownerId) {
         TypedQuery<ClientDetailsEntity> query = entityManager.createQuery("from ClientDetailsEntity where groupProfileId = :ownerId and clientType = :clientType",
                 ClientDetailsEntity.class);
@@ -222,7 +222,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
      * @return the name of the member owner of the given client
      */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String getMemberName(String clientId) {
         TypedQuery<String> query = entityManager
                 .createQuery("select r.creditName from RecordNameEntity r where r.orcid = (select c.groupProfileId from ClientDetailsEntity c where c.id=:clientId)", String.class);
@@ -231,7 +231,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean existsAndIsNotPublicClient(String clientId) {
         TypedQuery<Long> query = entityManager
                 .createQuery("select count(c) from ClientDetailsEntity c where c.id=:clientId and c.clientType != 'PUBLIC_CLIENT'", Long.class);
@@ -241,7 +241,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date getLastModifiedIfNotPublicClient(String clientId) {
         Query query = entityManager.createQuery("SELECT c.lastModified FROM ClientDetailsEntity c WHERE c.id = :id AND c.clientType != :type");
         query.setParameter("id", clientId);
@@ -251,7 +251,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ClientDetailsEntity findByIdP(String idp) {
         TypedQuery<ClientDetailsEntity> query = entityManager.createQuery("from ClientDetailsEntity where authenticationProviderId = :idp", ClientDetailsEntity.class);
         query.setParameter("idp", idp);
@@ -259,7 +259,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> findLegacyClientIds() {
         TypedQuery<String> query = entityManager.createQuery("select c.id from ClientDetailsEntity c where c.id not like 'APP-%'", String.class);
         return query.getResultList();
@@ -333,7 +333,7 @@ public class ClientDetailsDaoImpl extends GenericDaoImpl<ClientDetailsEntity, St
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @SuppressWarnings("unchecked")
     public List<ClientDetailsEntity> findMVPEnabled() {
         Query query = entityManager.createQuery("from ClientDetailsEntity where userNotificationEnabled = :userNotificationEnabled and client_type = :premiumUpdater" );

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientRedirectDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientRedirectDaoImpl.java
@@ -21,7 +21,7 @@ public class ClientRedirectDaoImpl extends GenericDaoImpl<ClientRedirectUriEntit
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ClientRedirectUriEntity> findClientDetailsWithRedirectScope(String redirectUriType) {
         Query query = entityManager.createQuery("from ClientRedirectUriEntity as crue where crue.predefinedClientScope is not null and crue.redirectUriType = :rut");
         query.setParameter("rut", redirectUriType);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientScopeDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientScopeDaoImpl.java
@@ -41,7 +41,7 @@ public class ClientScopeDaoImpl extends GenericDaoImpl<ClientScopeEntity, Client
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getActiveScopes(String clientDetailsId) {
         Query getActiveScopes = entityManager.createNativeQuery("SELECT scope_type FROM client_scope WHERE client_details_id = :clientDetailsId");
         getActiveScopes.setParameter("clientDetailsId", clientDetailsId);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientSecretDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ClientSecretDaoImpl.java
@@ -57,7 +57,7 @@ public class ClientSecretDaoImpl extends GenericDaoImpl<ClientSecretEntity, Clie
      * @return a list of all client secrets associated with a client
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ClientSecretEntity> getClientSecretsByClientId(String clientId) {
         TypedQuery<ClientSecretEntity> query = entityManager.createQuery("From ClientSecretEntity WHERE clientId=:clientId", ClientSecretEntity.class);
         query.setParameter("clientId", clientId);
@@ -95,7 +95,7 @@ public class ClientSecretDaoImpl extends GenericDaoImpl<ClientSecretEntity, Clie
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @SuppressWarnings("unchecked")
     public List<ClientSecretEntity> getNonPrimaryKeys(Integer limit) {
         DateTime dt = DateTime.now().minusDays(1);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/CustomEmailDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/CustomEmailDaoImpl.java
@@ -27,7 +27,7 @@ public class CustomEmailDaoImpl extends GenericDaoImpl<CustomEmailEntity, Custom
      * @return a list containing all custom emails associated with a client
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<CustomEmailEntity> getCustomEmails(String clientDetailsId) {
         TypedQuery<CustomEmailEntity> query = entityManager.createQuery("from CustomEmailEntity WHERE clientDetailsEntity.id=:clientDetailsId", CustomEmailEntity.class);
         query.setParameter("clientDetailsId", clientDetailsId);        
@@ -41,7 +41,7 @@ public class CustomEmailDaoImpl extends GenericDaoImpl<CustomEmailEntity, Custom
      * @return a CustomEmailEntity object if the email is found, null otherwise
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "custom-email", key = "#clientDetailsId.concat('-').concat(#emailType).concat('-').concat(#lastModified)")
     public CustomEmailEntity findByClientIdAndEmailType(String clientDetailsId, EmailType emailType, long lastModified) {
         TypedQuery<CustomEmailEntity> query = entityManager.createQuery("FROM CustomEmailEntity WHERE clientDetailsEntity.id=:clientDetailsId and emailType=:emailType", CustomEmailEntity.class);
@@ -122,7 +122,7 @@ public class CustomEmailDaoImpl extends GenericDaoImpl<CustomEmailEntity, Custom
      * @return true if a custom email with id=clientDetailsId and email type=emailType exists
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean exists(String clientDetailsId, EmailType emailType) {
         TypedQuery<Long> query = entityManager.createQuery("SELECT count(c) FROM CustomEmailEntity c WHERE c.clientDetailsEntity.id=:clientDetailsId and c.emailType=:emailType", Long.class);
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -138,7 +138,7 @@ public class CustomEmailDaoImpl extends GenericDaoImpl<CustomEmailEntity, Custom
      * @return the last modified date of the custom email, null in case the email doesn't exists
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date getLastModified(String clientDetailsId, EmailType emailType) {
         TypedQuery<Date> query = entityManager.createQuery("SELECT c.lastModified FROM CustomEmailEntity c WHERE c.clientDetailsEntity.id=:clientDetailsId and c.emailType=:emailType", Date.class);
         query.setParameter("clientDetailsId", clientDetailsId);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EmailDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EmailDaoImpl.java
@@ -30,7 +30,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean emailExists(String emailHash) {
         Assert.hasText(emailHash, "Cannot check for an empty email hash");
         TypedQuery<Long> query = entityManager.createQuery("select count(*) from EmailEntity where id = :emailHash", Long.class);
@@ -40,7 +40,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String findOrcidIdByEmailHash(String emailHash) {
         TypedQuery<String> query = entityManager.createQuery("select orcid from EmailEntity where id = :emailHash", String.class);
         query.setParameter("emailHash", emailHash);
@@ -48,7 +48,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String findOrcidByVerifiedEmail(String emailHash) {
         TypedQuery<String> query = entityManager.createQuery("select orcid from EmailEntity where id = :emailHash and verified = true", String.class);
         query.setParameter("emailHash", emailHash);
@@ -105,7 +105,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
 
     @Override
     @SuppressWarnings("rawtypes")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List findIdByCaseInsensitiveEmail(List<String> emails) {
         for (int i=0; i < emails.size(); i++) {
             if (emails.get(i) != emails.get(i).toLowerCase().trim()) emails.set(i, emails.get(i).toLowerCase().trim());
@@ -134,7 +134,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isVerified(String orcid, String email) {
         Query query = entityManager.createNativeQuery("select is_verified from email where orcid=:orcid and email=:email and is_primary=true");
         query.setParameter("orcid", orcid);
@@ -153,7 +153,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "emails", key = "#orcid.concat('-').concat(#lastModified)")
     public List<EmailEntity> findByOrcid(String orcid, long lastModified) {
         TypedQuery<EmailEntity> query = entityManager.createQuery("from EmailEntity where orcid = :orcid", EmailEntity.class);
@@ -163,14 +163,14 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "public-emails", key = "#orcid.concat('-').concat(#lastModified)")
     public List<EmailEntity> findPublicEmails(String orcid, long lastModified) {
         return findByOrcid(orcid, PUBLIC_VISIBILITY);
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EmailEntity> findPublicEmailsIncludeUnverified(String orcid) {
         TypedQuery<EmailEntity> query = entityManager.createQuery("from EmailEntity where orcid = :orcid and visibility = 'PUBLIC'", EmailEntity.class);
         query.setParameter("orcid", orcid);
@@ -179,7 +179,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EmailEntity> findByOrcid(String orcid, String visibility) {
         TypedQuery<EmailEntity> query = entityManager.createQuery("from EmailEntity where orcid = :orcid and visibility = :visibility", EmailEntity.class);
         query.setParameter("orcid", orcid);
@@ -211,7 +211,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
      *         client source of the record allows auto deprecating records
      */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isAutoDeprecateEnableForEmailUsingHash(String emailHash) {
         Query query = entityManager.createNativeQuery("SELECT allow_auto_deprecate FROM client_details WHERE client_details_id=(SELECT client_source_id FROM profile WHERE orcid=(SELECT orcid FROM email WHERE email_hash = :emailHash) AND claimed = false)");
         query.setParameter("emailHash", emailHash);
@@ -225,7 +225,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isPrimaryEmail(String email) {
         Query query = entityManager.createNativeQuery("select is_primary from email where email=:email");
         query.setParameter("email", email);
@@ -239,7 +239,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isPrimaryEmail(String orcid, String email) {
         Query query = entityManager.createNativeQuery("select is_primary from email where orcid=:orcid and email=:email");
         query.setParameter("orcid", orcid);
@@ -254,7 +254,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public EmailEntity findPrimaryEmail(String orcid) {
         TypedQuery<EmailEntity> query = entityManager.createQuery("from EmailEntity where orcid = :orcid and primary = true", EmailEntity.class);
         query.setParameter("orcid", orcid);
@@ -285,7 +285,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
 
     @Override
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getEmailsToHash(Integer batchSize) {
         Query query = entityManager.createNativeQuery("select id from email where email_hash is null", String.class);
         query.setMaxResults(batchSize);
@@ -302,7 +302,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public EmailEntity findByEmail(String email) {
         TypedQuery<EmailEntity> query = entityManager.createQuery("from EmailEntity where email = :email", EmailEntity.class);
         query.setParameter("email", email);
@@ -319,7 +319,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List getEmailAndHash(int iteration, int batchSize) {        
         int offset = iteration * batchSize;
         Query query = entityManager.createNativeQuery("select orcid, email, email_hash from email order by email");
@@ -330,7 +330,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager.createNativeQuery("SELECT email_hash FROM email WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
         query.setParameter("nonPublicClients", nonPublicClients);
@@ -348,7 +348,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager.createNativeQuery("SELECT email_hash FROM email WHERE client_source_id = source_id AND client_source_id IN :publicClients");
         query.setParameter("publicClients", publicClients);
@@ -366,7 +366,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EmailEntity> get2019VisibilityEmailRecipients(int offset, int batchSize) {
         Query query = entityManager.createNativeQuery("SELECT * from email WHERE is_verified IS TRUE AND is_primary IS TRUE AND orcid in (SELECT email.orcid FROM email INNER JOIN profile ON email.orcid = profile.orcid INNER JOIN email_frequency ON email.orcid = email_frequency.orcid WHERE email.is_current IS TRUE AND profile.record_locked IS FALSE AND profile.deprecated_date IS NULL AND profile.profile_deactivation_date IS NULL AND profile.activities_visibility_default='PRIVATE' AND email_frequency.send_quarterly_tips IS TRUE)", EmailEntity.class);
         query.setMaxResults(batchSize);
@@ -377,7 +377,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EmailEntity> getMarch2019QuarterlyEmailRecipients(int offset, int batchSize) {
         Query query = entityManager.createNativeQuery("SELECT * from email WHERE is_verified IS TRUE AND is_primary IS TRUE AND orcid in (SELECT email.orcid FROM email INNER JOIN profile ON email.orcid = profile.orcid INNER JOIN email_frequency ON email.orcid = email_frequency.orcid WHERE email.is_current IS TRUE AND profile.record_locked IS FALSE AND profile.deprecated_date IS NULL AND profile.profile_deactivation_date IS NULL AND email_frequency.send_quarterly_tips IS TRUE GROUP BY email.orcid HAVING count(*) = 1)", EmailEntity.class);
         query.setMaxResults(batchSize);
@@ -387,7 +387,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getIdsForUserOBOUpdate(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT email_hash FROM email WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -405,7 +405,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getIdsForUserOBORecords(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT email_hash FROM email WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NOT NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -422,7 +422,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String findNewestVerifiedOrNewestEmail(String orcid) {
         TypedQuery<String> query = entityManager.createQuery("select email from EmailEntity where orcid = :orcid order by verified desc, dateCreated desc", String.class);
         query.setParameter("orcid", orcid);
@@ -431,7 +431,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String findNewestPrimaryEmail(String orcid) {
         TypedQuery<String> query = entityManager.createQuery("select email from EmailEntity where orcid = :orcid and primary = true order by lastModified desc", String.class);
         query.setParameter("orcid", orcid);
@@ -441,7 +441,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getIdsForUserOBORecords(int max) {
         Query query = entityManager.createNativeQuery("SELECT email_hash FROM email WHERE assertion_origin_source_id IS NOT NULL");
         query.setMaxResults(max);
@@ -450,7 +450,7 @@ public class EmailDaoImpl extends GenericDaoImpl<EmailEntity, String> implements
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getIdsOfEmailsReferencingClientProfiles(int max, List<String> ids) {
         Query query = entityManager.createNativeQuery("SELECT email_hash FROM email WHERE source_id IN :ids");
         query.setParameter("ids", ids);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EmailDomainDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EmailDomainDaoImpl.java
@@ -65,7 +65,7 @@ public class EmailDomainDaoImpl extends GenericDaoImpl<EmailDomainEntity, Long> 
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EmailDomainEntity>  findByEmailDomain(String emailDomain) {
         TypedQuery<EmailDomainEntity> query = entityManager.createQuery("from EmailDomainEntity where lower(trim(emailDomain)) = lower(trim(:emailDomain))", EmailDomainEntity.class);
         query.setParameter("emailDomain", emailDomain);
@@ -81,7 +81,7 @@ public class EmailDomainDaoImpl extends GenericDaoImpl<EmailDomainEntity, Long> 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EmailDomainEntity> findByCategory(DomainCategory category) {
         TypedQuery<EmailDomainEntity> query = entityManager.createQuery("from EmailDomainEntity where category = :category", EmailDomainEntity.class);
         query.setParameter("category", category);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EmailFrequencyDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EmailFrequencyDaoImpl.java
@@ -17,7 +17,7 @@ public class EmailFrequencyDaoImpl extends GenericDaoImpl<EmailFrequencyEntity, 
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public EmailFrequencyEntity find(String id) {
         Query query = entityManager.createQuery("FROM EmailFrequencyEntity WHERE id = :id");
         query.setParameter("id", id);
@@ -25,7 +25,7 @@ public class EmailFrequencyDaoImpl extends GenericDaoImpl<EmailFrequencyEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public EmailFrequencyEntity findByOrcid(String orcid) {
         Query query = entityManager.createQuery("FROM EmailFrequencyEntity WHERE orcid = :orcid");
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EmailScheduleDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EmailScheduleDaoImpl.java
@@ -18,7 +18,7 @@ public class EmailScheduleDaoImpl extends GenericDaoImpl<EmailScheduleEntity, Lo
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Long getValidScheduleId() {
         Query query = entityManager.createNativeQuery("SELECT id FROM email_schedule WHERE ((now() >= schedule_start AND schedule_end IS NULL) or (now() >= schedule_start AND now() < schedule_end)) AND (latest_sent IS NULL OR EXTRACT(EPOCH FROM latest_sent) * 1000 + schedule_interval <= EXTRACT(EPOCH FROM now()) * 1000) AND paused IS FALSE");
         List<BigInteger> results = query.getResultList();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EventDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EventDaoImpl.java
@@ -31,7 +31,7 @@ public class EventDaoImpl implements EventDao {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public EventEntity find(long id) {
         return entityManager.find(EventEntity.class, id);
     }
@@ -43,7 +43,7 @@ public class EventDaoImpl implements EventDao {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EventEntity> findAll() {
         TypedQuery<EventEntity> query = entityManager.createQuery("from EventEntity", EventEntity.class);
         return query.getResultList();
@@ -70,7 +70,7 @@ public class EventDaoImpl implements EventDao {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EventEntity> findByEventType(EventType eventType) {
         TypedQuery<EventEntity> query = entityManager.createQuery("from EventEntity where eventType = :eventType", EventEntity.class);
         query.setParameter("eventType", eventType.getValue());

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EventStatsDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/EventStatsDaoImpl.java
@@ -38,7 +38,7 @@ public class EventStatsDaoImpl implements EventStatsDao {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<EventStatsEntity> findAll() {
         TypedQuery<EventStatsEntity> query = entityManager.createQuery("from EventStatsEntity", EventStatsEntity.class);
         return query.getResultList();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ExternalIdentifierDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ExternalIdentifierDaoImpl.java
@@ -41,7 +41,7 @@ public class ExternalIdentifierDaoImpl extends GenericDaoImpl<ExternalIdentifier
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "dao-external-identifiers", key = "#orcid.concat('-').concat(#lastModified)")
     public List<ExternalIdentifierEntity> getExternalIdentifiers(String orcid, long lastModified) {
         Query query = entityManager.createQuery("FROM ExternalIdentifierEntity WHERE orcid = :orcid order by displayIndex desc, dateCreated asc");
@@ -50,7 +50,7 @@ public class ExternalIdentifierDaoImpl extends GenericDaoImpl<ExternalIdentifier
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "public-external-identifiers", key = "#orcid.concat('-').concat(#lastModified)")
     public List<ExternalIdentifierEntity> getPublicExternalIdentifiers(String orcid, long lastModified) {
         return getExternalIdentifiers(orcid, PUBLIC_VISIBILITY);
@@ -67,7 +67,7 @@ public class ExternalIdentifierDaoImpl extends GenericDaoImpl<ExternalIdentifier
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ExternalIdentifierEntity> getExternalIdentifiers(String orcid, String visibility) {
         Query query = entityManager.createQuery("FROM ExternalIdentifierEntity WHERE orcid = :orcid and visibility = :visibility order by displayIndex desc, dateCreated asc");
         query.setParameter("orcid", orcid);
@@ -76,7 +76,7 @@ public class ExternalIdentifierDaoImpl extends GenericDaoImpl<ExternalIdentifier
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ExternalIdentifierEntity getExternalIdentifierEntity(String orcid, Long id) {
         Query query = entityManager.createQuery("FROM ExternalIdentifierEntity WHERE orcid = :orcid and id = :id");
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/FindMyStuffHistoryDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/FindMyStuffHistoryDaoImpl.java
@@ -18,7 +18,7 @@ public class FindMyStuffHistoryDaoImpl extends GenericDaoImpl<FindMyStuffHistory
     } 
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<FindMyStuffHistoryEntity> findAll(String orcid) {
         TypedQuery<FindMyStuffHistoryEntity> query = entityManager.createQuery("from FindMyStuffHistoryEntity where orcid = :orcid", FindMyStuffHistoryEntity.class);
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/GenericDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/GenericDaoImpl.java
@@ -34,14 +34,14 @@ public class GenericDaoImpl<E extends OrcidEntity<I>, I extends Serializable> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public E find(I id) {
         return entityManager.find(clazz, id);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<E> findLastModifiedBefore(Date latestDate, int maxResults) {
         Query query = entityManager.createQuery("from " + clazz.getSimpleName() + " where lastModified <= :latestDate");
         query.setParameter("latestDate", latestDate);
@@ -51,7 +51,7 @@ public class GenericDaoImpl<E extends OrcidEntity<I>, I extends Serializable> im
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<E> getAll() {
         return entityManager.createQuery("from " + clazz.getSimpleName()).getResultList();
     }
@@ -113,7 +113,7 @@ public class GenericDaoImpl<E extends OrcidEntity<I>, I extends Serializable> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Long countAll() {
         return (Long) entityManager.createQuery("select count(e) from " + clazz.getSimpleName() + " e").getSingleResult();
     }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/GivenPermissionToDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/GivenPermissionToDaoImpl.java
@@ -25,7 +25,7 @@ public class GivenPermissionToDaoImpl extends GenericDaoImpl<GivenPermissionToEn
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public GivenPermissionToEntity findByGiverAndReceiverOrcid(String giverOrcid, String receiverOrcid) {
         TypedQuery<GivenPermissionToEntity> query = entityManager.createQuery("from GivenPermissionToEntity where giver = :giverOrcid and receiver = :receiverOrcid",
                 GivenPermissionToEntity.class);
@@ -46,7 +46,7 @@ public class GivenPermissionToDaoImpl extends GenericDaoImpl<GivenPermissionToEn
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<GivenPermissionToEntity> findByGiver(String giverOrcid) {
         TypedQuery<GivenPermissionToEntity> query = entityManager.createQuery("from GivenPermissionToEntity where giver = :giverOrcid",
                 GivenPermissionToEntity.class);
@@ -55,7 +55,7 @@ public class GivenPermissionToDaoImpl extends GenericDaoImpl<GivenPermissionToEn
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<GivenPermissionByEntity> findByReceiver(String receiverOrcid) {
         TypedQuery<GivenPermissionByEntity> query = entityManager.createQuery("from GivenPermissionByEntity where receiver = :receiverOrcid",
                 GivenPermissionByEntity.class);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/GroupIdRecordDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/GroupIdRecordDaoImpl.java
@@ -21,7 +21,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<GroupIdRecordEntity> getGroupIdRecords(int pageSize, int page) {
         TypedQuery<GroupIdRecordEntity> query = entityManager.createQuery("from GroupIdRecordEntity order by dateCreated", GroupIdRecordEntity.class);
         query.setFirstResult(pageSize * (page - 1));
@@ -30,7 +30,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean exists(String groupId) {
         TypedQuery<Long> query = entityManager.createQuery("select count(g) from GroupIdRecordEntity g where trim(lower(g.groupId)) = trim(lower(:groupId))", Long.class);
         query.setParameter("groupId", groupId);
@@ -39,7 +39,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public GroupIdRecordEntity findByGroupId(String groupId) {
         TypedQuery<GroupIdRecordEntity> query = entityManager.createQuery("from GroupIdRecordEntity where trim(lower(groupId)) = trim(lower(:groupId))",
                 GroupIdRecordEntity.class);
@@ -49,7 +49,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public GroupIdRecordEntity findByName(String name) {
         TypedQuery<GroupIdRecordEntity> query = entityManager.createQuery("from GroupIdRecordEntity where trim(lower(groupName)) = trim(lower(:groupName))",
                 GroupIdRecordEntity.class);
@@ -59,7 +59,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean haveAnyPeerReview(String groupId) {
         TypedQuery<Long> query = entityManager.createQuery("select count(p) from PeerReviewEntity p where trim(lower(p.groupId)) = trim(lower(:groupId))", Long.class);
         query.setParameter("groupId", groupId);
@@ -68,7 +68,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean duplicateExists(Long putCode, String groupId) {
         StringBuilder queryString = new StringBuilder("select count(g) from GroupIdRecordEntity g where trim(lower(g.groupId)) = trim(lower(:groupId))");
         if (putCode != null) {
@@ -85,7 +85,7 @@ public class GroupIdRecordDaoImpl extends GenericDaoImpl<GroupIdRecordEntity, Lo
     }   
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<GroupIdRecordEntity> getIssnRecordsSortedBySyncDate(int batchSize, Date syncTime) {
         Query query = entityManager.createNativeQuery("SELECT * FROM group_id_record g WHERE (g.issn_loader_fail_count is null OR g.issn_loader_fail_count < :max) AND g.group_id LIKE 'issn:%' AND (g.sync_date is null OR g.sync_date < :syncTime) ORDER BY g.sync_date NULLS FIRST", GroupIdRecordEntity.class);
         query.setParameter("max", maxRetries);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/IdentifierTypeDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/IdentifierTypeDaoImpl.java
@@ -44,7 +44,7 @@ public class IdentifierTypeDaoImpl extends GenericDaoImpl<IdentifierTypeEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public IdentifierTypeEntity getEntityByName(String idName) {
         TypedQuery<IdentifierTypeEntity> query = entityManager.createQuery("FROM IdentifierTypeEntity WHERE name = :idName", IdentifierTypeEntity.class);
         query.setParameter("idName", idName);
@@ -52,7 +52,7 @@ public class IdentifierTypeDaoImpl extends GenericDaoImpl<IdentifierTypeEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<IdentifierTypeEntity> getEntities() {
         TypedQuery<IdentifierTypeEntity> query = entityManager.createQuery("FROM IdentifierTypeEntity order by name", IdentifierTypeEntity.class);
         return query.getResultList();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/IdentityProviderDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/IdentityProviderDaoImpl.java
@@ -23,7 +23,7 @@ public class IdentityProviderDaoImpl extends GenericDaoImpl<IdentityProviderEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public IdentityProviderEntity findByProviderid(String providerid) {
         TypedQuery<IdentityProviderEntity> query = entityManager.createQuery("from IdentityProviderEntity i where i.providerid = :providerid", IdentityProviderEntity.class);
         query.setParameter("providerid", providerid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/InvalidRecordDataChangeDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/InvalidRecordDataChangeDaoImpl.java
@@ -23,7 +23,7 @@ public class InvalidRecordDataChangeDaoImpl implements InvalidRecordDataChangeDa
     
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<InvalidRecordDataChangeEntity> getByDateCreated(Long lastId, Long pageSize, boolean descendantOrder) {
         String queryStr = "SELECT * FROM invalid_record_data_changes WHERE id {GTorLT} {LAST_SEQUENCE} ORDER BY id {ORDER} LIMIT :pageSize";
         
@@ -43,7 +43,7 @@ public class InvalidRecordDataChangeDaoImpl implements InvalidRecordDataChangeDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean haveNext(Long sequence, boolean descendantOrder) {
         String queryStr = "SELECT COUNT(*) FROM InvalidRecordDataChangeEntity WHERE id {GTorLT} :sequence";        
         TypedQuery<Long> query = entityManager.createQuery(queryStr.replace("{GTorLT}", descendantOrder ? "<" : ">"), Long.class);
@@ -52,7 +52,7 @@ public class InvalidRecordDataChangeDaoImpl implements InvalidRecordDataChangeDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean havePrevious(Long sequence, boolean descendantOrder) {
         String queryStr = "SELECT COUNT(*) FROM InvalidRecordDataChangeEntity WHERE id {GTorLT} :sequence";        
         TypedQuery<Long> query = entityManager.createQuery(queryStr.replace("{GTorLT}", descendantOrder ? ">" : "<"), Long.class);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/MemberChosenOrgDisambiguatedDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/MemberChosenOrgDisambiguatedDaoImpl.java
@@ -17,7 +17,7 @@ public class MemberChosenOrgDisambiguatedDaoImpl implements MemberChosenOrgDisam
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<MemberChosenOrgDisambiguatedEntity> getAll() {
         return entityManager.createQuery("from MemberChosenOrgDisambiguatedEntity").getResultList();
     }

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/MemberOBOWhitelistedClientDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/MemberOBOWhitelistedClientDaoImpl.java
@@ -16,7 +16,7 @@ public class MemberOBOWhitelistedClientDaoImpl extends GenericDaoImpl<MemberOBOW
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<MemberOBOWhitelistedClientEntity> getWhitelistForClient(String clientDetailsId) {
         TypedQuery<MemberOBOWhitelistedClientEntity> query = entityManager.createQuery("from MemberOBOWhitelistedClientEntity where clientDetailsEntity.id = :clientDetailsId", MemberOBOWhitelistedClientEntity.class);
         query.setParameter("clientDetailsId", clientDetailsId);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/MiscDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/MiscDaoImpl.java
@@ -24,7 +24,7 @@ public class MiscDaoImpl implements MiscDao {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date retrieveDatabaseDatetime() {
         Query query = entityManager.createNativeQuery("SELECT now()");
         Object result = query.getSingleResult();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/NotificationDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/NotificationDaoImpl.java
@@ -40,7 +40,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findByOrcid(String orcid, boolean includeArchived, int firstResult, int maxResults) {
         StringBuilder builder = new StringBuilder("from NotificationEntity where orcid = :orcid");
         if (!includeArchived) {
@@ -55,14 +55,14 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public NotificationEntity findLatestByOrcid(String orcid) {
         List<NotificationEntity> results = findByOrcid(orcid, false, 0, 1);
         return results.isEmpty() ? null : results.get(0);
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findUnsentByOrcid(String orcid) {
         TypedQuery<NotificationEntity> query = entityManager.createQuery("from NotificationEntity where sentDate is null and orcid = :orcid", NotificationEntity.class);
         query.setParameter("orcid", orcid);
@@ -71,7 +71,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findNotificationAlertsByOrcid(String orcid) {
         TypedQuery<NotificationEntity> query = entityManager.createQuery(
                 "select n from NotificationEntity n, ClientRedirectUriEntity r where n.notificationType = 'INSTITUTIONAL_CONNECTION' and n.readDate is null and n.archivedDate is null and n.orcid = :orcid and n.clientSourceId = r.clientId and r.redirectUriType = 'institutional-sign-in' order by n.dateCreated desc",
@@ -82,7 +82,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public int getUnreadCount(String orcid) {
         TypedQuery<Long> query = entityManager.createQuery("select count(n) from NotificationEntity n where n.readDate is null and n.archivedDate is null and n.orcid = :orcid",
                 Long.class);
@@ -92,7 +92,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
 
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public int getTotalCount(String orcid, boolean archived) {
         StringBuffer sb = new StringBuffer();
         sb.append("select count(n) from NotificationEntity n where n.orcid = :orcid");
@@ -106,7 +106,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public NotificationEntity findByOricdAndId(String orcid, Long id) {
         TypedQuery<NotificationEntity> query = entityManager.createQuery("from NotificationEntity where orcid = :orcid and id = :id", NotificationEntity.class);
         query.setParameter("orcid", orcid);
@@ -205,7 +205,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findPermissionsByOrcidAndClient(String orcid, String client, int firstResult, int maxResults) {
         TypedQuery<NotificationEntity> query = entityManager.createQuery(
                 "from NotificationEntity where orcid = :orcid and clientSourceId = :client and notificationType = :notificationType", NotificationEntity.class);
@@ -217,7 +217,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> findRecordsWithUnsentNotifications() {
         Query query = entityManager.createNamedQuery(NotificationEntity.FIND_ORCIDS_WITH_UNSENT_NOTIFICATIONS_ON_EMAIL_FREQUENCIES_TABLE);
         query.setParameter("never", Float.MAX_VALUE);  
@@ -235,7 +235,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
                
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findNotificationsToSendLegacy(Date effectiveDate, String orcid, Float emailFrequency, Date recordActiveDate) {
         TypedQuery<NotificationEntity> query = entityManager.createNamedQuery(NotificationEntity.FIND_NOTIFICATIONS_TO_SEND_BY_ORCID, NotificationEntity.class);
         query.setParameter("orcid", orcid);
@@ -247,7 +247,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findNotificationsToSend(Date effectiveDate, String orcid, Date recordActiveDate) {
         String unsentNotificationsQuery = notificationQueries.getProperty("notifications.unsent");
         Query query = entityManager.createNativeQuery(unsentNotificationsQuery, NotificationEntity.class);
@@ -293,7 +293,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findUnsentServiceAnnouncements(int batchSize) {
         Query query = entityManager.createNativeQuery("select n.* from notification n where n.sent_date is NULL AND n.sendable != false AND n.notification_type = 'SERVICE_ANNOUNCEMENT'", NotificationEntity.class);
         query.setMaxResults(batchSize);
@@ -302,7 +302,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findUnsentTips(int batchSize) {
         Query query = entityManager.createNativeQuery("select n.* from notification n join email_frequency ef on n.orcid = ef.orcid AND ef.send_quarterly_tips IS true where n.notification_type = 'TIP' AND n.sent_date is NULL AND n.sendable != false", NotificationEntity.class);
         query.setMaxResults(batchSize);
@@ -361,7 +361,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> findNotificationsToDeleteByOffset(Integer offset, Integer recordsPerBatch) {
         Query selectQuery = entityManager.createNativeQuery("SELECT orcid FROM notification group by orcid having count(*) > :offset order by count(*) desc limit :limit");
         selectQuery.setParameter("offset", offset);
@@ -386,7 +386,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM notification WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
         query.setParameter("nonPublicClients", nonPublicClients);
@@ -404,7 +404,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM notification WHERE client_source_id = source_id AND client_source_id IN :publicClients");
         query.setParameter("publicClients", publicClients);
@@ -422,7 +422,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfNotificationsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds) {
         Query query = entityManager.createNativeQuery("SELECT id FROM notification WHERE source_id IN :ids");
         query.setParameter("ids", clientProfileOrcidIds);
@@ -432,7 +432,7 @@ public class NotificationDaoImpl extends GenericDaoImpl<NotificationEntity, Long
     
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<NotificationEntity> findNotificationsByOrcidAndClientAndFamilyNoClientToken(String orcid, String clientId, String notificationFamily){
         Query query = entityManager.createNativeQuery("SELECT * FROM notification WHERE client_source_id = :clientId AND orcid = :orcid "
                 + "AND notification_family = :notificationFamily AND NOT EXISTS (SELECT 1  FROM oauth2_token_detail WHERE "

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrcidOauth2AuthoriziationCodeDetailDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrcidOauth2AuthoriziationCodeDetailDaoImpl.java
@@ -46,7 +46,7 @@ public class OrcidOauth2AuthoriziationCodeDetailDaoImpl extends GenericDaoImpl<O
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isPersistentToken(String code) {
         TypedQuery<OrcidOauth2AuthoriziationCodeDetail> query = entityManager.createQuery("from OrcidOauth2AuthoriziationCodeDetail where id=:code",
                 OrcidOauth2AuthoriziationCodeDetail.class);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrcidOauth2TokenDetailDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrcidOauth2TokenDetailDaoImpl.java
@@ -27,7 +27,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrcidOauth2TokenDetail findByTokenValue(String tokenValue) {
         Assert.hasText(tokenValue, "Attempt to retrieve a OrcidOauth2TokenDetail with a null or empty token value");
         TypedQuery<OrcidOauth2TokenDetail> query = entityManager.createQuery("from OrcidOauth2TokenDetail where tokenValue = :token", OrcidOauth2TokenDetail.class);
@@ -36,7 +36,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrcidOauth2TokenDetail findNonDisabledByTokenValue(String tokenValue) {
         Assert.hasText(tokenValue, "Attempt to retrieve a OrcidOauth2TokenDetail with a null or empty token value");
         TypedQuery<OrcidOauth2TokenDetail> query = entityManager.createQuery("from "
@@ -58,7 +58,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrcidOauth2TokenDetail findByRefreshTokenValue(String refreshTokenValue) {
         TypedQuery<OrcidOauth2TokenDetail> query = entityManager.createQuery("from " + "OrcidOauth2TokenDetail where refreshTokenValue = :refreshTokenValue",
                 OrcidOauth2TokenDetail.class);
@@ -67,7 +67,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrcidOauth2TokenDetail> findByAuthenticationKey(String authenticationKey) {
         TypedQuery<OrcidOauth2TokenDetail> query = entityManager.createQuery("from " + "OrcidOauth2TokenDetail where authenticationKey = :authenticationKey",
                 OrcidOauth2TokenDetail.class);
@@ -76,7 +76,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrcidOauth2TokenDetail> findByUserName(String userName) {
         TypedQuery<OrcidOauth2TokenDetail> query = entityManager.createQuery("from OrcidOauth2TokenDetail where orcid = :userName and tokenExpiration > :now and (tokenDisabled IS NULL OR tokenDisabled = FALSE)",
                 OrcidOauth2TokenDetail.class);
@@ -86,7 +86,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrcidOauth2TokenDetail> findByClientId(String clientId) {
         TypedQuery<OrcidOauth2TokenDetail> query = entityManager.createQuery("from " + "OrcidOauth2TokenDetail where clientDetailsId = :clientId",
                 OrcidOauth2TokenDetail.class);
@@ -95,7 +95,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrcidOauth2TokenDetail> findByClientIdAndUserName(String clientId, String userName) {
         TypedQuery<OrcidOauth2TokenDetail> query = entityManager.createQuery("from OrcidOauth2TokenDetail where clientDetailsId = :clientId and orcid = :userName",
                 OrcidOauth2TokenDetail.class);
@@ -149,7 +149,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
      * @return the list of available scopes over a profile
      * */
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> findAvailableScopesByUserAndClientId(String clientId, String userName) {
         Query query = entityManager
                 .createNativeQuery("select distinct(scope_type) from oauth2_token_detail where user_orcid=:userName and client_details_id=:clientId and (token_disabled = FALSE or token_disabled is null)");
@@ -159,7 +159,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean hasToken(String userName) {
     	Query query = entityManager
                 .createNativeQuery("select true from oauth2_token_detail where user_orcid=:userName limit 1");
@@ -173,7 +173,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean hasTokenForClient(String userName, String clientId) {
         Query query = entityManager
                 .createNativeQuery("select true from oauth2_token_detail where user_orcid=:userName and client_details_id=:clientId limit 1");
@@ -205,7 +205,7 @@ public class OrcidOauth2TokenDetailDaoImpl extends GenericDaoImpl<OrcidOauth2Tok
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> findAccessTokenByCodeAndClient(String authorizationCode, String clientId) {
         Query query = entityManager.createQuery("select tokenValue from OrcidOauth2TokenDetail where clientDetailsId = :clientId and authorizationCode = :authorizationCode");
         query.setParameter("authorizationCode", authorizationCode);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrcidPropsDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrcidPropsDaoImpl.java
@@ -67,7 +67,7 @@ public class OrcidPropsDaoImpl extends GenericDaoImpl<OrcidPropsEntity, String> 
      *             if there are more than one row with the same key name
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean exists(String key) throws NonUniqueResultException {
         Assert.hasText(key, "Cannot look for empty keys");
         Query query = entityManager.createQuery("FROM OrcidPropsEntity WHERE key=:key");
@@ -83,7 +83,7 @@ public class OrcidPropsDaoImpl extends GenericDaoImpl<OrcidPropsEntity, String> 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String getValue(String key) {
         Assert.hasText(key, "Cannot look for empty keys");
         Query query = entityManager.createQuery("SELECT o.value FROM OrcidPropsEntity o WHERE o.key=:key");

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgAffiliationRelationDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgAffiliationRelationDaoImpl.java
@@ -274,49 +274,49 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "distinctions-summaries", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<OrgAffiliationRelationEntity> getDistinctionSummaries(String userOrcid, long lastModified) {
         return getByUserAndType(userOrcid, AFFILIATION_TYPE_DISTINCTION);
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "educations-summaries", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<OrgAffiliationRelationEntity> getEducationSummaries(String userOrcid, long lastModified) {
         return getByUserAndType(userOrcid, AFFILIATION_TYPE_EDUCATION);
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "employments-summaries", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<OrgAffiliationRelationEntity> getEmploymentSummaries(String userOrcid, long lastModified) {
         return getByUserAndType(userOrcid, AFFILIATION_TYPE_EMPLOYMENT);
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "invited-positions-summaries", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<OrgAffiliationRelationEntity> getInvitedPositionSummaries(String userOrcid, long lastModified) {
         return getByUserAndType(userOrcid, AFFILIATION_TYPE_INVITED_POSITION);
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "memberships-summaries", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<OrgAffiliationRelationEntity> getMembershipSummaries(String userOrcid, long lastModified) {
         return getByUserAndType(userOrcid, AFFILIATION_TYPE_MEMBERSHIP);
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "qualifications-summaries", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<OrgAffiliationRelationEntity> getQualificationSummaries(String userOrcid, long lastModified) {
         return getByUserAndType(userOrcid, AFFILIATION_TYPE_QUALIFICATION);
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "services-summaries", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<OrgAffiliationRelationEntity> getServiceSummaries(String userOrcid, long lastModified) {
         return getByUserAndType(userOrcid, AFFILIATION_TYPE_SERVICE);
@@ -333,7 +333,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
      *         matches the given type
      */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgAffiliationRelationEntity> getByUserAndType(String userOrcid, String type) {
         TypedQuery<OrgAffiliationRelationEntity> query = entityManager
                 .createQuery("from OrgAffiliationRelationEntity where orcid=:userOrcid and affiliationType=:affiliationType", OrgAffiliationRelationEntity.class);
@@ -350,7 +350,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
      * @return the list of affiliations that belongs to the user
      */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgAffiliationRelationEntity> getByUser(String orcid) {
         TypedQuery<OrgAffiliationRelationEntity> query = entityManager.createQuery("from OrgAffiliationRelationEntity where orcid=:orcid order by dateCreated asc",
                 OrgAffiliationRelationEntity.class);
@@ -388,7 +388,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Boolean hasPublicAffiliations(String orcid) {
         Query query = entityManager.createNativeQuery("SELECT count(*) FROM org_affiliation_relation WHERE orcid=:orcid AND visibility='PUBLIC'");
         query.setParameter("orcid", orcid);
@@ -398,7 +398,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager
                 .createNativeQuery("SELECT id FROM org_affiliation_relation WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
@@ -417,7 +417,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager
                 .createNativeQuery("SELECT id FROM org_affiliation_relation WHERE client_source_id = source_id AND client_source_id IN :publicClients");
@@ -436,7 +436,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max) {
         Query query = entityManager
                 .createNativeQuery("SELECT id FROM org_affiliation_relation WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NULL");
@@ -455,7 +455,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgAffiliationRelationEntity> getOrgAffiliationRelationsReferencingOrgs(List<Long> orgIds) {
         Query query = entityManager.createQuery("from OrgAffiliationRelationEntity where org.id in (:orgIds)");
         query.setParameter("orgIds", orgIds);
@@ -464,7 +464,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max) {
         Query query = entityManager
                 .createNativeQuery("SELECT id FROM org_affiliation_relation WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NOT NULL");
@@ -504,7 +504,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM org_affiliation_relation WHERE assertion_origin_source_id IS NOT NULL");
         query.setMaxResults(max);
@@ -513,7 +513,7 @@ public class OrgAffiliationRelationDaoImpl extends GenericDaoImpl<OrgAffiliation
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfOrgAffiliationRelationsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds) {
         Query query = entityManager.createNativeQuery("SELECT id FROM org_affiliation_relation WHERE source_id IN :ids");
         query.setParameter("ids", clientProfileOrcidIds);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDaoImpl.java
@@ -25,7 +25,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<AmbiguousOrgEntity> getAmbiguousOrgs(int firstResult, int maxResults) {
         // Order by ID so we can page through in a predictable way
         TypedQuery<AmbiguousOrgEntity> query = entityManager.createQuery("from AmbiguousOrgEntity order by id", AmbiguousOrgEntity.class);
@@ -35,7 +35,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgEntity> getOrgs(String searchTerm, int firstResult, int maxResults) {
         TypedQuery<OrgEntity> query = entityManager.createQuery("from OrgEntity where lower(name) like lower(:searchTerm) || '%' order by name", OrgEntity.class);
         query.setParameter("searchTerm", searchTerm);
@@ -45,7 +45,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgEntity> getOrgsByName(String searchTerm) {
         TypedQuery<OrgEntity> query = entityManager.createQuery("from OrgEntity where lower(name) like lower(:searchTerm) order by name", OrgEntity.class);
         query.setParameter("searchTerm", searchTerm);
@@ -53,7 +53,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrgEntity findByNameCityRegionAndCountry(String name, String city, String region, String country) {
         TypedQuery<OrgEntity> query = entityManager.createQuery("from OrgEntity where name = :name and city = :city and region = :region and country = :country",
                 OrgEntity.class);
@@ -66,7 +66,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrgEntity findByNameCityRegionCountryAndType(String name, String city, String region, String country, String sourceType) {
         TypedQuery<OrgEntity> query = entityManager.createQuery(
                 "from OrgEntity where name = :name and city = :city and region = :region and country = :country and orgDisambiguated.sourceType = :orgType",
@@ -95,7 +95,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrgEntity findByAddressAndDisambiguatedOrg(String name, String city, String region, String country, OrgDisambiguatedEntity orgDisambiguated) {
         TypedQuery<OrgEntity> query = entityManager.createQuery(
                 "from OrgEntity where COALESCE(name, '') = :name and COALESCE(city, '') = :city and COALESCE(region, '') = :region and country = :country and (orgDisambiguated.id = :orgDisambiguatedId or (orgDisambiguated is null and :orgDisambiguatedId is null))",
@@ -113,7 +113,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM org WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
         query.setParameter("nonPublicClients", nonPublicClients);
@@ -131,7 +131,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM org WHERE client_source_id = source_id AND client_source_id IN :publicClients");
         query.setParameter("publicClients", publicClients);
@@ -149,7 +149,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> findConstraintViolatingDuplicateOrgDetails() {
         Query query = entityManager.createNativeQuery(
                 "SELECT name, CASE WHEN city IS NULL OR city = '' THEN 'nocity' ELSE city END AS citygroup, CASE WHEN region IS NULL OR region = '' THEN 'noregion' ELSE region END AS regiongroup, CASE WHEN country IS NULL OR country = '' THEN 'nocountry' ELSE country END AS countrygroup, org_disambiguated_id FROM org WHERE org_disambiguated_id IS NOT NULL GROUP BY name, citygroup, regiongroup, countrygroup, org_disambiguated_id HAVING COUNT(*) > 1");
@@ -158,7 +158,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getOrgIdsForDuplicateOrgDetails(String name, String city, String region, String country, Long orgDisambiguatedId) {
         Query query = entityManager.createNativeQuery(
                 "SELECT id FROM org WHERE COALESCE(name, '') = :name AND COALESCE(city, '') = :city AND COALESCE(region, '') = :region AND COALESCE(country, '') = :country AND COALESCE(org_disambiguated_id, 0) = :orgDisambiguatedId");
@@ -223,7 +223,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfOrgsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds) {
         Query query = entityManager.createNativeQuery("SELECT id FROM org WHERE source_id IN :ids");
         query.setParameter("ids", clientProfileOrcidIds);
@@ -232,7 +232,7 @@ public class OrgDaoImpl extends GenericDaoImpl<OrgEntity, Long> implements OrgDa
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgEntity> findByOrgDisambiguatedId(Long orgDisambiguatedId) {
         TypedQuery<OrgEntity> query = entityManager.createQuery("from OrgEntity where orgDisambiguated.id = :orgDisambiguatedId", OrgEntity.class);
         query.setParameter("orgDisambiguatedId", orgDisambiguatedId);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedDaoImpl.java
@@ -32,7 +32,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrgDisambiguatedEntity findBySourceIdAndSourceType(String sourceId, String sourceType) {
         TypedQuery<OrgDisambiguatedEntity> query = entityManager.createQuery("from OrgDisambiguatedEntity where sourceId = :sourceId and sourceType = :sourceType",
                 OrgDisambiguatedEntity.class);
@@ -43,7 +43,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgDisambiguatedEntity> findBySourceType(String sourceType, int firstResult, int maxResults){
         TypedQuery<OrgDisambiguatedEntity> query = entityManager.createQuery("from OrgDisambiguatedEntity where sourceType = :sourceType",
                 OrgDisambiguatedEntity.class);
@@ -54,7 +54,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgDisambiguatedEntity> getChunk(int firstResult, int maxResults) {
         // Order by id so that we can page through in a predictable way
         TypedQuery<OrgDisambiguatedEntity> query = entityManager.createQuery("from OrgDisambiguatedEntity order by id", OrgDisambiguatedEntity.class);
@@ -64,7 +64,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrgDisambiguatedEntity findByNameCityRegionCountryAndSourceType(String name, String city, String region, String country, String sourceType) {
         TypedQuery<OrgDisambiguatedEntity> query = entityManager.createQuery(
                 "from OrgDisambiguatedEntity where name = :name and city = :city and (region = :region or (region is null and :region is null)) and country = :country and sourceType = :sourceType",
@@ -79,7 +79,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgDisambiguatedEntity> findByName(String name) {
         TypedQuery<OrgDisambiguatedEntity> query = entityManager.createQuery("from OrgDisambiguatedEntity where lower(name) = lower(:name)",
                 OrgDisambiguatedEntity.class);
@@ -90,7 +90,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable("orgs")
     public List<OrgDisambiguatedEntity> getOrgs(String searchTerm, int firstResult, int maxResults) {
         String qStr = "select od.*, COUNT(*) as countAll from org_disambiguated od left join org_affiliation_relation oa on od.id = oa.org_id"
@@ -107,7 +107,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgDisambiguatedEntity> findOrgsToGroup(int firstResult, int maxResult) {
         Query query = entityManager.createNativeQuery(GROUPING_ORGS_QUERY, OrgDisambiguatedEntity.class);
         query.setFirstResult(firstResult);
@@ -116,7 +116,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Long> findOrgsPendingIndexing(int maxResult) {
         TypedQuery<Long> query = entityManager.createQuery("select o.id from OrgDisambiguatedEntity o where indexingStatus not in ('DONE', 'IGNORE') order by dateCreated",
                 Long.class);
@@ -143,7 +143,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Pair<Long, Integer>> findDisambuguatedOrgsWithIncorrectPopularity(int maxResults) {
         Query query = entityManager.createNativeQuery("SELECT od1.id, actual.popularity FROM org_disambiguated od1 JOIN"
                 + " (SELECT od2.id id, COUNT(*) popularity FROM org_disambiguated od2 JOIN org o ON o.org_disambiguated_id = od2.id JOIN org_affiliation_relation oar ON oar.org_id = o.id GROUP BY od2.id)"
@@ -186,7 +186,7 @@ public class OrgDisambiguatedDaoImpl extends GenericDaoImpl<OrgDisambiguatedEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgDisambiguatedEntity> findDuplicates() {
         TypedQuery<OrgDisambiguatedEntity> query = entityManager.createNamedQuery(OrgDisambiguatedEntity.FIND_DUPLICATES, OrgDisambiguatedEntity.class);
         return query.getResultList();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedExternalIdentifierDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgDisambiguatedExternalIdentifierDaoImpl.java
@@ -30,7 +30,7 @@ public class OrgDisambiguatedExternalIdentifierDaoImpl extends GenericDaoImpl<Or
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OrgDisambiguatedExternalIdentifierEntity findByDetails(Long orgDisambiguatedId, String identifier, String identifierType) {
         try {
             TypedQuery<OrgDisambiguatedExternalIdentifierEntity> query = entityManager.createQuery("FROM OrgDisambiguatedExternalIdentifierEntity WHERE orgDisambiguated.id = :orgDisambiguatedId AND identifier = :identifier AND identifierType = :identifierType",
@@ -46,7 +46,7 @@ public class OrgDisambiguatedExternalIdentifierDaoImpl extends GenericDaoImpl<Or
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgDisambiguatedExternalIdentifierEntity> findISNIsOfIncorrectLength(int batchSize) {
             TypedQuery<OrgDisambiguatedExternalIdentifierEntity> query = entityManager.createQuery("FROM OrgDisambiguatedExternalIdentifierEntity e WHERE LENGTH(e.identifier) != 16 AND e.identifierType = 'ISNI')",
                     OrgDisambiguatedExternalIdentifierEntity.class);
@@ -56,7 +56,7 @@ public class OrgDisambiguatedExternalIdentifierDaoImpl extends GenericDaoImpl<Or
     
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean exists(Long orgDisambiguatedId, String identifier, String identifierType) {
         try {
             TypedQuery<Long> query = entityManager.createQuery("SELECT count(e) FROM OrgDisambiguatedExternalIdentifierEntity e WHERE e.orgDisambiguated.id = :orgDisambiguatedId AND e.identifier = :identifier AND e.identifierType = :identifierType",
@@ -73,7 +73,7 @@ public class OrgDisambiguatedExternalIdentifierDaoImpl extends GenericDaoImpl<Or
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrgDisambiguatedExternalIdentifierEntity> findByIdentifierIdAndType(String identifier, String identifierType) {
         TypedQuery<OrgDisambiguatedExternalIdentifierEntity> query = entityManager.createQuery("FROM OrgDisambiguatedExternalIdentifierEntity WHERE identifier = :identifier AND identifierType = :identifierType",
                 OrgDisambiguatedExternalIdentifierEntity.class);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgImportLogDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OrgImportLogDaoImpl.java
@@ -17,7 +17,7 @@ public class OrgImportLogDaoImpl extends GenericDaoImpl<OrgImportLogEntity, Long
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getImportSourceOrder() {
         Query query = entityManager.createNativeQuery("SELECT source FROM (SELECT MAX(start_time) AS start, source_type AS source from org_import_log GROUP BY source_type) AS dr ORDER BY start ASC;");
         return (List<String>) query.getResultList();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OtherNameDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/OtherNameDaoImpl.java
@@ -29,7 +29,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
      * */
     @Override
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "dao-other-names", key = "#orcid.concat('-').concat(#lastModified)")
     public List<OtherNameEntity> getOtherNames(String orcid, long lastModified) {
         Query query = entityManager.createQuery("FROM OtherNameEntity WHERE orcid=:orcid order by displayIndex desc, dateCreated asc");
@@ -38,7 +38,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "public-other-names", key = "#orcid.concat('-').concat(#lastModified)")
     public List<OtherNameEntity> getPublicOtherNames(String orcid, long lastModified) {
         return getOtherNames(orcid, PUBLIC_VISIBILITY);
@@ -46,7 +46,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
 
     @Override
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OtherNameEntity> getOtherNames(String orcid, String visibility) {
         Query query = entityManager.createQuery("FROM OtherNameEntity WHERE orcid=:orcid AND visibility=:visibility order by displayIndex desc, dateCreated asc");
         query.setParameter("orcid", orcid);
@@ -101,7 +101,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public OtherNameEntity getOtherName(String orcid, Long putCode) {
         Query query = entityManager.createQuery("FROM OtherNameEntity WHERE orcid=:orcid and id=:id");
         query.setParameter("orcid", orcid);
@@ -120,7 +120,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager.createNativeQuery("SELECT other_name_id FROM other_name WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
         query.setParameter("nonPublicClients", nonPublicClients);
@@ -138,7 +138,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager.createNativeQuery("SELECT other_name_id FROM other_name WHERE client_source_id = source_id AND client_source_id IN :publicClients");
         query.setParameter("publicClients", publicClients);
@@ -156,7 +156,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT other_name_id FROM other_name WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -174,7 +174,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT other_name_id FROM other_name WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NOT NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -192,7 +192,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max) {
         Query query = entityManager.createNativeQuery("SELECT other_name_id FROM other_name WHERE assertion_origin_source_id IS NOT NULL");
         query.setMaxResults(max);
@@ -201,7 +201,7 @@ public class OtherNameDaoImpl extends GenericDaoImpl<OtherNameEntity, Long> impl
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfOtherNamesReferencingClientProfiles(int max, List<String> clientProfileOrcidIds) {
         Query query = entityManager.createNativeQuery("SELECT other_name_id FROM other_name WHERE source_id IN :ids");
         query.setParameter("ids", clientProfileOrcidIds);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/PeerReviewDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/PeerReviewDaoImpl.java
@@ -22,7 +22,7 @@ public class PeerReviewDaoImpl extends GenericDaoImpl<PeerReviewEntity, Long> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public PeerReviewEntity getPeerReview(String userOrcid, Long peerReviewId) {
         Query query = entityManager.createQuery("from PeerReviewEntity where orcid=:userOrcid and id=:peerReviewId");
         query.setParameter("userOrcid", userOrcid);
@@ -41,7 +41,7 @@ public class PeerReviewDaoImpl extends GenericDaoImpl<PeerReviewEntity, Long> im
     }    
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "peer-reviews", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<PeerReviewEntity> getByUser(String userOrcid, long lastModified) {
         TypedQuery<PeerReviewEntity> query = entityManager.createQuery("from PeerReviewEntity where orcid=:userOrcid order by completionDate.year desc, completionDate.month desc, completionDate.day desc", PeerReviewEntity.class);
@@ -50,7 +50,7 @@ public class PeerReviewDaoImpl extends GenericDaoImpl<PeerReviewEntity, Long> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> getPeerReviewsByOrcid(String orcid, boolean justPublic) {
         String sqlString = null;
         if (justPublic) {
@@ -65,7 +65,7 @@ public class PeerReviewDaoImpl extends GenericDaoImpl<PeerReviewEntity, Long> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<PeerReviewEntity> getPeerReviewsByOrcidAndGroupId(String orcid, String groupId, boolean justPublic) {
         String sqlString = null;
         if(justPublic) {
@@ -122,7 +122,7 @@ public class PeerReviewDaoImpl extends GenericDaoImpl<PeerReviewEntity, Long> im
      * @return a list of peer review ids with old ext ids          
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @SuppressWarnings("unchecked") 
     public List<BigInteger> getPeerReviewWithOldExtIds(long limit) {
         Query query = entityManager.createNativeQuery("SELECT distinct(id) FROM (SELECT id, json_array_elements(json_extract_path(external_identifiers_json, 'workExternalIdentifier')) AS j FROM peer_review WHERE external_identifiers_json is not null limit :limit) AS a WHERE (j->'relationship') is null");
@@ -148,7 +148,7 @@ public class PeerReviewDaoImpl extends GenericDaoImpl<PeerReviewEntity, Long> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Boolean hasPublicPeerReviews(String orcid) {
         Query query = entityManager.createNativeQuery("select count(*) from peer_review where orcid=:orcid and visibility='PUBLIC'");
         query.setParameter("orcid", orcid);
@@ -158,7 +158,7 @@ public class PeerReviewDaoImpl extends GenericDaoImpl<PeerReviewEntity, Long> im
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<PeerReviewEntity> getPeerReviewsReferencingOrgs(List<Long> orgIds) {
         Query query = entityManager.createQuery("from PeerReviewEntity where org.id in (:orgIds)");
         query.setParameter("orgIds", orgIds);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileDaoImpl.java
@@ -72,7 +72,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
      */
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Map<String, Date> findOrcidsByIndexingStatus(IndexingStatus indexingStatus, int maxResults, Integer delay) {
         return findOrcidsByIndexingStatus(indexingStatus, maxResults, Collections.EMPTY_LIST, delay);
     }
@@ -95,7 +95,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
      */
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Map<String, Date> findOrcidsByIndexingStatus(IndexingStatus indexingStatus, int maxResults, Collection<String> orcidsToExclude, Integer delay) {
         StringBuilder builder = new StringBuilder("SELECT p.orcid, p.last_modified FROM profile p WHERE p.indexing_status = :indexingStatus");
 
@@ -139,7 +139,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> findUnclaimedNotIndexedAfterWaitPeriod(int waitPeriodDays, int maxDaysBack, int maxResults, Collection<String> orcidsToExclude) {
 
         StringBuilder builder = new StringBuilder("SELECT orcid FROM profile p");
@@ -173,7 +173,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Triple<String, String, Boolean>> findEmailsUnverfiedDays(int daysUnverified, EmailEventType eventSent) {
         int rangeStart = daysUnverified;
         int rangeEnd = daysUnverified - 1;
@@ -194,7 +194,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> findUnclaimedNeedingReminder(int remindAfterDays, int maxResults, Collection<String> orcidsToExclude) {
         StringBuilder builder = new StringBuilder(
                 "SELECT p.orcid FROM profile p LEFT JOIN profile_event e ON e.orcid = p.orcid AND e.profile_event_type = :profileEventType");
@@ -223,7 +223,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> findByMissingEventTypes(int maxResults, List<ProfileEventType> pets, Collection<String> orcidsToExclude, boolean not) {
         return findByMissingEventTypes(maxResults, pets, orcidsToExclude, not, false);
     }
@@ -251,7 +251,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
      */
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> findByMissingEventTypes(int maxResults, List<ProfileEventType> pets, Collection<String> orcidsToExclude, boolean not,
             boolean checkQuarterlyTipsEnabled) {
         /*
@@ -310,7 +310,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> findOrcidsNeedingEmailMigration(int maxResults) {
         TypedQuery<String> query = entityManager.createQuery("select p.id from ProfileEntity p where email is not null and orcidType != 'CLIENT'", String.class);
         query.setMaxResults(maxResults);
@@ -318,7 +318,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileEntity> findProfilesThatMissedIndexing(int maxResults) {
         TypedQuery<ProfileEntity> query = entityManager.createQuery(
                 "from ProfileEntity where (lastModified > lastIndexedDate or lastIndexedDate is null) and indexingStatus not in ('PENDING', 'IGNORE') order by lastModified",
@@ -328,7 +328,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean orcidExists(String orcid) {
         TypedQuery<Long> query = entityManager.createQuery("select count(pe.id) from ProfileEntity pe where pe.id=:orcid", Long.class);
         query.setParameter("orcid", orcid);
@@ -337,7 +337,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean hasBeenGivenPermissionTo(String giverOrcid, String receiverOrcid) {
         TypedQuery<Long> query = entityManager
                 .createQuery("select count(gpt.id) from GivenPermissionToEntity gpt where gpt.giver = :giverOrcid and gpt.receiver = :receiverOrcid", Long.class);
@@ -348,7 +348,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean existsAndNotClaimedAndBelongsTo(String messageOrcid, String clientId) {
         TypedQuery<Long> query = entityManager.createQuery(
                 "select count(p.id) from ProfileEntity p where p.claimed = FALSE and (p.source.sourceClient.id = :clientId or p.source.sourceProfile.id = :clientId) and p.id = :messageOrcid",
@@ -360,7 +360,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public IndexingStatus retrieveIndexingStatus(String orcid) {
         TypedQuery<IndexingStatus> query = entityManager.createQuery("select indexingStatus from ProfileEntity where id = :orcid", IndexingStatus.class);
         query.setParameter("orcid", orcid);
@@ -389,7 +389,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Long getConfirmedProfileCount() {
         TypedQuery<Long> query = entityManager.createQuery("select count(pe) from ProfileEntity pe where pe.completedDate is not null", Long.class);
         return query.getSingleResult();
@@ -413,7 +413,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String retrieveOrcidType(String orcid) {
         TypedQuery<String> query = entityManager.createQuery("select orcidType from ProfileEntity where id = :orcid", String.class);
         query.setParameter("orcid", orcid);
@@ -422,7 +422,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> findInfoForDecryptionAnalysis() {
         Query query = entityManager.createQuery("select id, encryptedSecurityAnswer from ProfileEntity");
         @SuppressWarnings("unchecked")
@@ -431,7 +431,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String retrieveLocale(String orcid) {
         TypedQuery<String> query = entityManager.createQuery("select locale from ProfileEntity where id = :orcid", String.class);
         query.setParameter("orcid", orcid);
@@ -478,13 +478,13 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isProfileDeprecated(String orcid) {
         return retrievePrimaryAccountOrcid(orcid) != null;
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String retrievePrimaryAccountOrcid(String deprecatedOrcid) {
         Query query = entityManager.createNativeQuery("select primary_record from profile where orcid = :orcid");
         query.setParameter("orcid", deprecatedOrcid);
@@ -527,7 +527,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean getClaimedStatus(String orcid) {
         Query query = entityManager.createNativeQuery("select claimed from profile where orcid=:orcid");
         query.setParameter("orcid", orcid);
@@ -542,7 +542,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
      * @return the client type, null if it is not a client
      */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String getClientType(String orcid) {
         TypedQuery<String> query = entityManager.createQuery("select clientType from ClientDetailsEntity where id = :orcid", String.class);
         query.setParameter("orcid", orcid);
@@ -558,7 +558,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
      * @return the group type, null if it is not a group
      */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public String getGroupType(String orcid) {
         TypedQuery<String> query = entityManager.createQuery("select groupType from ProfileEntity where id = :orcid", String.class);
         query.setParameter("orcid", orcid);
@@ -622,7 +622,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isLocked(String orcid) {
         TypedQuery<Boolean> query = entityManager.createQuery("select recordLocked from ProfileEntity where id = :orcid", Boolean.class);
         query.setParameter("orcid", orcid);
@@ -636,7 +636,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isDeactivated(String orcid) {
         TypedQuery<Date> query = entityManager.createQuery("select deactivationDate from ProfileEntity where id = :orcid", Date.class);
         query.setParameter("orcid", orcid);
@@ -645,7 +645,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isReviewed(String orcid) {
         TypedQuery<Boolean> query = entityManager.createQuery("select reviewed from ProfileEntity where id = :orcid", Boolean.class);
         query.setParameter("orcid", orcid);
@@ -682,7 +682,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean getClaimedStatusByEmailHash(String emailHash) {
         Query query = entityManager.createNativeQuery("SELECT claimed FROM profile WHERE orcid=(SELECT orcid FROM email WHERE email_hash = :emailHash)");
         query.setParameter("emailHash", emailHash);
@@ -702,7 +702,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getProfilesWithNoHashedOrcid(int limit) {
         Query query = entityManager.createNativeQuery("select orcid from profile where hashed_orcid is null");
         query.setMaxResults(limit);
@@ -719,7 +719,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date getLastLogin(String orcid) {
         TypedQuery<Date> query = entityManager.createQuery("select lastLogin from ProfileEntity where id = :orcid", Date.class);
         query.setParameter("orcid", orcid);
@@ -768,7 +768,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<OrcidGrantedAuthority> getGrantedAuthoritiesForProfile(String orcid) {
         Query query = entityManager.createQuery("from OrcidGrantedAuthority where orcid = :orcid");
         query.setParameter("orcid", orcid);
@@ -777,7 +777,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileEventEntity> getProfileEvents(String orcid, List<ProfileEventType> eventTypes) {
         Query query = entityManager.createQuery("from ProfileEventEntity where orcid = :orcid and type IN :types");
         query.setParameter("orcid", orcid);
@@ -786,7 +786,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ProfileEntity getLockedReason(String orcid) {
         TypedQuery<ProfileEntity> query = entityManager.createQuery("FROM ProfileEntity where orcid = :orcid", ProfileEntity.class);
         query.setParameter("orcid", orcid);
@@ -794,7 +794,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileEntity> findByOrcidType(String orcidType) {
         TypedQuery<ProfileEntity> query = entityManager.createQuery("FROM ProfileEntity where orcidType = :orcidType", ProfileEntity.class);
         query.setParameter("orcidType", orcidType);
@@ -811,7 +811,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getAllOrcidIdsForInvalidRecords() {
         Query query = entityManager
                 .createNativeQuery("SELECT orcid FROM profile WHERE profile_deactivation_date IS NOT NULL OR deprecated_date IS NOT NULL OR record_locked IS TRUE");
@@ -836,7 +836,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> registeredBetween(Date startDate, Date endDate) {
         Query query = entityManager.createNativeQuery("SELECT orcid FROM profile WHERE date_created between :startDate and :endDate");
         query.setParameter("startDate", startDate);
@@ -852,7 +852,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isOrcidValidAsDelegate(String orcid) {
         TypedQuery<Long> query = entityManager.createQuery(
                 "SELECT count(p) FROM ProfileEntity p WHERE p.id=:orcid AND p.deactivationDate is NULL AND p.deprecatedDate is NULL AND p.primaryRecord is NULL AND (p.recordLocked is NULL OR p.recordLocked is FALSE)",
@@ -866,7 +866,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> getSigninLock(String orcid) {
         Query query = entityManager.createNativeQuery("SELECT signin_lock_start, signin_lock_last_attempt, signin_lock_count from profile WHERE orcid= :orcid");
         query.setParameter("orcid", orcid);
@@ -909,7 +909,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean haveMemberPushedWorksOrAffiliationsToRecord(String orcid, String clientId) {
         try {
             String queryString = "select p.orcid from profile p where p.orcid = :orcid and ( exists (select 1 from work w where w.orcid = p.orcid and w.client_source_id = :clientId) or exists (select 1 from org_affiliation_relation o where o.orcid = p.orcid and o.client_source_id = :clientId));";
@@ -927,7 +927,7 @@ public class ProfileDaoImpl extends GenericDaoImpl<ProfileEntity, String> implem
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Pair<String, String>> findEmailsToSendAddWorksEmail(int profileCreatedNumberOfDaysAgo) {
         StringBuilder qs = new StringBuilder("SELECT e.email, p.orcid FROM email e ");
         qs.append("LEFT JOIN email_frequency ef ON e.orcid = ef.orcid ");

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileEmailDomainDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileEmailDomainDaoImpl.java
@@ -70,7 +70,7 @@ public class ProfileEmailDomainDaoImpl extends GenericDaoImpl<ProfileEmailDomain
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileEmailDomainEntity> findByOrcid(String orcid) {
         TypedQuery<ProfileEmailDomainEntity> query = entityManager.createQuery("from ProfileEmailDomainEntity where orcid = :orcid", ProfileEmailDomainEntity.class);
         query.setParameter("orcid", orcid);
@@ -79,7 +79,7 @@ public class ProfileEmailDomainDaoImpl extends GenericDaoImpl<ProfileEmailDomain
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileEmailDomainEntity> findPublicEmailDomains(String orcid) {
         TypedQuery<ProfileEmailDomainEntity> query = entityManager.createQuery("from ProfileEmailDomainEntity where orcid = :orcid and visibility = 'PUBLIC'",
                 ProfileEmailDomainEntity.class);
@@ -89,7 +89,7 @@ public class ProfileEmailDomainDaoImpl extends GenericDaoImpl<ProfileEmailDomain
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ProfileEmailDomainEntity findByEmailDomain(String orcid, String emailDomain) {
         TypedQuery<ProfileEmailDomainEntity> query = entityManager.createQuery("from ProfileEmailDomainEntity where orcid = :orcid and emailDomain = :emailDomain",
                 ProfileEmailDomainEntity.class);
@@ -119,7 +119,7 @@ public class ProfileEmailDomainDaoImpl extends GenericDaoImpl<ProfileEmailDomain
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileEmailDomainEntity> findByEmailDomain(String emailDomain) {
         TypedQuery<ProfileEmailDomainEntity> query = entityManager.createQuery("from ProfileEmailDomainEntity where emailDomain = :emailDomain",
                 ProfileEmailDomainEntity.class);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileEventDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileEventDaoImpl.java
@@ -18,7 +18,7 @@ public class ProfileEventDaoImpl extends GenericDaoImpl<ProfileEventEntity, Long
     public ProfileEventDaoImpl() { super(ProfileEventEntity.class); }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isAttemptSend(String orcid, ProfileEventType eventType) {
         Query query = entityManager.createNativeQuery("select count(*) from profile_event where orcid=:orcid and profile_event_type=:eventType");
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileFundingDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileFundingDaoImpl.java
@@ -30,7 +30,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
      * @return a profile funding entity that have the give id and belongs to the given user 
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ProfileFundingEntity getProfileFunding(String userOrcid, Long profileFundingId) {
         Query query = entityManager.createQuery("from ProfileFundingEntity where orcid=:userOrcid and id=:profileFundingId");
         query.setParameter("userOrcid", userOrcid);
@@ -137,7 +137,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
      * @return the ProfileFundingEntity object
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ProfileFundingEntity getProfileFundingEntity(String orgId, String clientOrcid) {
         Query query = entityManager.createQuery("from ProfileFundingEntity where orcid=:clientOrcid and org.id=:orgId");
         query.setParameter("clientOrcid", clientOrcid);
@@ -154,7 +154,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
      * @return the ProfileFundingEntity object
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ProfileFundingEntity getProfileFundingEntity(Long profileFundingId) {
         Query query = entityManager.createQuery("from ProfileFundingEntity where id=:id");
         query.setParameter("id", profileFundingId);
@@ -166,7 +166,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
      * 
      * @return a list of all profile fundings where the amount is not null
      * */
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileFundingEntity> getProfileFundingWithAmount() {
         TypedQuery<ProfileFundingEntity> query = entityManager.createQuery("from ProfileFundingEntity where amount is not null and numeric_amount is null", ProfileFundingEntity.class);
         return query.getResultList();
@@ -218,7 +218,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @SuppressWarnings("unchecked")    
     public List<BigInteger> findFundingNeedingExternalIdentifiersMigration(int chunkSize) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_funding WHERE id IN (SELECT profile_funding_id FROM funding_external_identifier) AND external_identifiers_json IS NULL LIMIT :chunkSize");
@@ -249,7 +249,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "fundings", key = "#userOrcid.concat('-').concat(#lastModified)")
     public List<ProfileFundingEntity> getByUser(String userOrcid, long lastModified) {
         TypedQuery<ProfileFundingEntity> query = entityManager.createQuery("from ProfileFundingEntity where orcid=:userOrcid order by displayIndex desc, dateCreated asc", ProfileFundingEntity.class);
@@ -264,7 +264,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
      * @return a list of funding ids with old ext ids          
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @SuppressWarnings("unchecked")   
     public List<BigInteger> getFundingWithOldExtIds(long limit) {
         Query query = entityManager.createNativeQuery("SELECT distinct(id) FROM (SELECT id, json_array_elements(json_extract_path(external_identifiers_json, 'fundingExternalIdentifier')) AS j FROM profile_funding WHERE external_identifiers_json is not null limit :limit) AS a WHERE (j->'relationship') is null;");
@@ -290,7 +290,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Boolean hasPublicFunding(String orcid) {
         Query query = entityManager.createNativeQuery("SELECT count(*) FROM profile_funding WHERE orcid=:orcid AND visibility='PUBLIC'");
         query.setParameter("orcid", orcid);
@@ -300,7 +300,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_funding WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
         query.setParameter("nonPublicClients", nonPublicClients);
@@ -318,7 +318,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_funding WHERE client_source_id = source_id AND client_source_id IN :publicClients");
         query.setParameter("publicClients", publicClients);
@@ -337,7 +337,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_funding WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -355,7 +355,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileFundingEntity> getFundingsReferencingOrgs(List<Long> orgIds) {
         Query query = entityManager.createQuery("from ProfileFundingEntity where org.id in (:orgIds)");
         query.setParameter("orgIds", orgIds);
@@ -364,7 +364,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_funding WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NOT NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -382,7 +382,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_funding WHERE assertion_origin_source_id IS NOT NULL");
         query.setMaxResults(max);
@@ -391,7 +391,7 @@ public class ProfileFundingDaoImpl extends GenericDaoImpl<ProfileFundingEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfFundingsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_funding WHERE source_id IN :ids");
         query.setParameter("ids", clientProfileOrcidIds);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileHistoryEventDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileHistoryEventDaoImpl.java
@@ -17,7 +17,7 @@ public class ProfileHistoryEventDaoImpl extends GenericDaoImpl<ProfileHistoryEve
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileHistoryEventEntity> findByProfile(String orcid) {
         Query query = entityManager.createQuery("FROM ProfileHistoryEventEntity WHERE orcid = :orcid ORDER BY dateCreated DESC");
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileInterstitialFlagDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileInterstitialFlagDaoImpl.java
@@ -26,7 +26,7 @@ public class ProfileInterstitialFlagDaoImpl extends GenericDaoImpl<ProfileInters
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean hasInterstitialFlag(String orcid, String interstitialName) {
         Query query = entityManager.createNativeQuery("select count(*) from profile_interstitial_flag where orcid = :orcid and interstitial_name = :interstitialName");
         query.setParameter("orcid", orcid);
@@ -36,7 +36,7 @@ public class ProfileInterstitialFlagDaoImpl extends GenericDaoImpl<ProfileInters
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileInterstitialFlagEntity> findByOrcid(String orcid) {
         TypedQuery<ProfileInterstitialFlagEntity> query = entityManager.createQuery("from ProfileInterstitialFlagEntity where orcid = :orcid", ProfileInterstitialFlagEntity.class);
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileKeywordDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileKeywordDaoImpl.java
@@ -29,7 +29,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
      * */
     @Override
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "dao-keywords", key = "#orcid.concat('-').concat(#lastModified)")
     public List<ProfileKeywordEntity> getProfileKeywords(String orcid, long lastModified) {
         Query query = entityManager.createQuery("FROM ProfileKeywordEntity WHERE orcid = :orcid order by displayIndex desc, dateCreated asc");
@@ -38,7 +38,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "public-keywords", key = "#orcid.concat('-').concat(#lastModified)")
     public List<ProfileKeywordEntity> getPublicProfileKeywords(String orcid, long lastModified) {
         return getProfileKeywords(orcid, PUBLIC_VISIBILITY);
@@ -46,7 +46,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
     
     @Override
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ProfileKeywordEntity> getProfileKeywords(String orcid, String visibility) {
         Query query = entityManager.createQuery("FROM ProfileKeywordEntity WHERE orcid=:orcid AND visibility=:visibility order by displayIndex desc, dateCreated asc");
         query.setParameter("orcid", orcid);
@@ -91,7 +91,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ProfileKeywordEntity getProfileKeyword(String orcid, Long putCode) {
         Query query = entityManager.createQuery("FROM ProfileKeywordEntity WHERE orcid=:orcid and id=:id");
         query.setParameter("orcid", orcid);
@@ -119,7 +119,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_keyword WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
         query.setParameter("nonPublicClients", nonPublicClients);
@@ -137,7 +137,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_keyword WHERE client_source_id = source_id AND client_source_id IN :publicClients");
         query.setParameter("publicClients", publicClients);
@@ -155,7 +155,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_keyword WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -173,7 +173,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_keyword WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NOT NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -191,7 +191,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_keyword WHERE assertion_origin_source_id IS NOT NULL");
         query.setMaxResults(max);
@@ -200,7 +200,7 @@ public class ProfileKeywordDaoImpl extends GenericDaoImpl<ProfileKeywordEntity, 
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfKeywordsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds) {
         Query query = entityManager.createNativeQuery("SELECT id FROM profile_keyword WHERE source_id IN :ids");
         query.setParameter("ids", clientProfileOrcidIds);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileLastModifiedDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ProfileLastModifiedDaoImpl.java
@@ -66,7 +66,7 @@ public class ProfileLastModifiedDaoImpl implements ProfileLastModifiedDao {
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     /**
      * Fetches the last modified from the database Do not call unless it also
      * manages the request level cache

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/PublicApiDailyRateLimitDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/PublicApiDailyRateLimitDaoImpl.java
@@ -22,7 +22,7 @@ public class PublicApiDailyRateLimitDaoImpl extends GenericDaoImpl<PublicApiDail
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public PublicApiDailyRateLimitEntity findByClientIdAndRequestDate(String clientId, LocalDate requestDate) {
         Query nativeQuery = entityManager.createNativeQuery("SELECT * FROM public_api_daily_rate_limit p where p.client_id=:clientId and p.request_date=:requestDate",
                 PublicApiDailyRateLimitEntity.class);
@@ -39,7 +39,7 @@ public class PublicApiDailyRateLimitDaoImpl extends GenericDaoImpl<PublicApiDail
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public PublicApiDailyRateLimitEntity findByIpAddressAndRequestDate(String ipAddress, LocalDate requestDate) {
         String baseQuery = "SELECT * FROM public_api_daily_rate_limit p where p.ip_address=:ipAddress and p.request_date=:requestDate";
 
@@ -59,7 +59,7 @@ public class PublicApiDailyRateLimitDaoImpl extends GenericDaoImpl<PublicApiDail
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public int countClientRequestsWithLimitExceeded(LocalDate requestDate, int limit) {
         Query nativeQuery = entityManager.createNativeQuery(
                 "SELECT count(*) FROM public_api_daily_rate_limit p WHERE NOT ((p.client_id = '' OR p.client_id IS NULL)) and p.request_date=:requestDate and p.request_count >=:requestCount");
@@ -74,7 +74,7 @@ public class PublicApiDailyRateLimitDaoImpl extends GenericDaoImpl<PublicApiDail
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public int countAnonymousRequestsWithLimitExceeded(LocalDate requestDate, int limit) {
         Query nativeQuery = entityManager.createNativeQuery(
                 "SELECT count(*) FROM public_api_daily_rate_limit p WHERE ((p.client_id = '' OR p.client_id IS NULL)) and p.request_date=:requestDate and p.request_count >=:requestCount");

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/RecordNameDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/RecordNameDaoImpl.java
@@ -26,7 +26,7 @@ public class RecordNameDaoImpl extends GenericDaoImpl<RecordNameEntity, Long> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "record-name", key = "#orcid.concat('-').concat(#lastModified)")
     public RecordNameEntity getRecordName(String orcid, long lastModified) {
         Query query = entityManager.createQuery("FROM RecordNameEntity WHERE orcid = :orcid");
@@ -35,7 +35,7 @@ public class RecordNameDaoImpl extends GenericDaoImpl<RecordNameEntity, Long> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public RecordNameEntity findByCreditName(String creditName) {
         Query query = entityManager.createQuery("FROM RecordNameEntity WHERE creditName = :creditName");
         query.setParameter("creditName", creditName);
@@ -63,7 +63,7 @@ public class RecordNameDaoImpl extends GenericDaoImpl<RecordNameEntity, Long> im
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean exists(String orcid) {
         Query query = entityManager.createNativeQuery("select count(*) from record_name where orcid=:orcid");
         query.setParameter("orcid", orcid);
@@ -72,7 +72,7 @@ public class RecordNameDaoImpl extends GenericDaoImpl<RecordNameEntity, Long> im
     }   
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Date getLastModified(String orcid) {
         TypedQuery<Date> query = entityManager.createQuery("SELECT r.lastModified FROM RecordNameEntity r WHERE r.orcid = :orcid", Date.class);
         query.setParameter("orcid", orcid);
@@ -80,7 +80,7 @@ public class RecordNameDaoImpl extends GenericDaoImpl<RecordNameEntity, Long> im
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<RecordNameEntity> getRecordNames(List<String> orcids) {
         TypedQuery<RecordNameEntity> query = entityManager.createQuery("FROM RecordNameEntity WHERE orcid in :ids", RecordNameEntity.class);
         query.setParameter("ids", orcids);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/RejectedGroupingSuggestionDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/RejectedGroupingSuggestionDaoImpl.java
@@ -16,7 +16,7 @@ public class RejectedGroupingSuggestionDaoImpl extends GenericDaoImpl<RejectedGr
     
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public RejectedGroupingSuggestionEntity findGroupingSuggestionIdAndOrcid(String orcid, String putCodes) {
         Query query = entityManager.createQuery("FROM RejectedGroupingSuggestionEntity WHERE orcid = :orcid AND id = :putCodes", RejectedGroupingSuggestionEntity.class);
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ResearchResourceDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ResearchResourceDaoImpl.java
@@ -21,7 +21,7 @@ public class ResearchResourceDaoImpl extends GenericDaoImpl<ResearchResourceEnti
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ResearchResourceEntity getResearchResource(String userOrcid, Long researchResourceId) {
         Query query = entityManager.createQuery("from ResearchResourceEntity where orcid=:userOrcid and id=:researchResourceId");
         query.setParameter("userOrcid", userOrcid);
@@ -44,7 +44,7 @@ public class ResearchResourceDaoImpl extends GenericDaoImpl<ResearchResourceEnti
     
     //note these are not cacheable entities as they require a session to work.
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ResearchResourceEntity> getByUser(String userOrcid, long lastModified) {
         TypedQuery<ResearchResourceEntity> query = entityManager.createQuery("from ResearchResourceEntity where orcid=:userOrcid", ResearchResourceEntity.class);
         query.setParameter("userOrcid", userOrcid);
@@ -96,7 +96,7 @@ public class ResearchResourceDaoImpl extends GenericDaoImpl<ResearchResourceEnti
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public Boolean hasPublicResearchResources(String orcid) {
         Query query = entityManager.createNativeQuery("SELECT count(*) FROM research_resource WHERE orcid=:orcid AND visibility='PUBLIC'");
         query.setParameter("orcid", orcid);
@@ -106,7 +106,7 @@ public class ResearchResourceDaoImpl extends GenericDaoImpl<ResearchResourceEnti
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getResearchResourcesReferencingOrgs(List<Long> orgIds) {
         Query query = entityManager.createNativeQuery("SELECT distinct rr.id FROM research_resource rr LEFT JOIN research_resource_org rro ON rr.id = rro.research_resource_id LEFT JOIN research_resource_item rri ON rr.id = rri.research_resource_id LEFT JOIN research_resource_item_org rrio ON rri.id = rrio.research_resource_item_id WHERE rro.org_id IN (:orgIds) OR rrio.org_id IN (:orgIds)");
         query.setParameter("orgIds", orgIds);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ResearcherUrlDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ResearcherUrlDaoImpl.java
@@ -30,7 +30,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
      * */
     @Override
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "researcher-urls", key = "#orcid.concat('-').concat(#lastModified)")
     public List<ResearcherUrlEntity> getResearcherUrls(String orcid, long lastModified) {
         Query query = entityManager.createQuery("FROM ResearcherUrlEntity WHERE orcid = :orcid order by displayIndex desc, dateCreated asc");
@@ -39,7 +39,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @Cacheable(value = "public-researcher-urls", key = "#orcid.concat('-').concat(#lastModified)")
     public List<ResearcherUrlEntity> getPublicResearcherUrls(String orcid, long lastModified) {
         return getResearcherUrls(orcid, PUBLIC_VISIBILITY);
@@ -54,7 +54,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
      * */
     @Override
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ResearcherUrlEntity> getResearcherUrls(String orcid, String visibility) {
         Query query = entityManager.createQuery("FROM ResearcherUrlEntity WHERE orcid = :orcid AND visibility = :visibility order by displayIndex desc, dateCreated asc");
         query.setParameter("orcid", orcid);
@@ -83,7 +83,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
      * @return the ResearcherUrlEntity associated with the parameter id
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ResearcherUrlEntity getResearcherUrl(String orcid, Long id) {
         TypedQuery<ResearcherUrlEntity> query = entityManager.createQuery("FROM ResearcherUrlEntity WHERE id = :id AND orcid = :orcid", ResearcherUrlEntity.class);
         query.setParameter("id", id);
@@ -119,7 +119,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM researcher_url WHERE client_source_id = source_id AND client_source_id IN :nonPublicClients");
         query.setParameter("nonPublicClients", nonPublicClients);
@@ -137,7 +137,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClients) {
         Query query = entityManager.createNativeQuery("SELECT id FROM researcher_url WHERE client_source_id = source_id AND client_source_id IN :publicClients");
         query.setParameter("publicClients", publicClients);
@@ -155,7 +155,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM researcher_url WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -173,7 +173,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM researcher_url WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NOT NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -191,7 +191,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max) {
         Query query = entityManager.createNativeQuery("SELECT id FROM researcher_url WHERE assertion_origin_source_id IS NOT NULL");
         query.setMaxResults(max);
@@ -200,7 +200,7 @@ public class ResearcherUrlDaoImpl extends GenericDaoImpl<ResearcherUrlEntity, Lo
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfResearcherUrlsReferencingClientProfiles(int max, List<String> clientProfileOrcidIds) {
         Query query = entityManager.createNativeQuery("SELECT id FROM researcher_url WHERE source_id IN :ids");
         query.setParameter("ids", clientProfileOrcidIds);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/SalesForceConnectionDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/SalesForceConnectionDaoImpl.java
@@ -19,7 +19,7 @@ public class SalesForceConnectionDaoImpl extends GenericDaoImpl<SalesForceConnec
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public SalesForceConnectionEntity findByOrcidAndAccountId(String orcid, String accountId) {
         TypedQuery<SalesForceConnectionEntity> query = entityManager
                 .createQuery("from SalesForceConnectionEntity where orcid = :orcid and salesForceAccountId = :accountId", SalesForceConnectionEntity.class);
@@ -30,7 +30,7 @@ public class SalesForceConnectionDaoImpl extends GenericDaoImpl<SalesForceConnec
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<SalesForceConnectionEntity> findByOrcid(String orcid) {
         TypedQuery<SalesForceConnectionEntity> query = entityManager.createQuery("from SalesForceConnectionEntity where orcid = :orcid",
                 SalesForceConnectionEntity.class);
@@ -39,7 +39,7 @@ public class SalesForceConnectionDaoImpl extends GenericDaoImpl<SalesForceConnec
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<SalesForceConnectionEntity> findByAccountId(String accountId) {
         TypedQuery<SalesForceConnectionEntity> query = entityManager.createQuery("from SalesForceConnectionEntity where salesForceAccountId = :salesForceAccountId",
                 SalesForceConnectionEntity.class);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ShibbolethAccountDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ShibbolethAccountDaoImpl.java
@@ -21,7 +21,7 @@ public class ShibbolethAccountDaoImpl extends GenericDaoImpl<ShibbolethAccountEn
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public ShibbolethAccountEntity findByRemoteUserAndShibIdentityProvider(String remoteUser, String shibIdentityProvider) {
         TypedQuery<ShibbolethAccountEntity> query = entityManager.createQuery(
                 "from ShibbolethAccountEntity where remoteUser = :remoteUser and shibIdentityProvider = :shibIdentityProvider", ShibbolethAccountEntity.class);
@@ -32,7 +32,7 @@ public class ShibbolethAccountDaoImpl extends GenericDaoImpl<ShibbolethAccountEn
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<ShibbolethAccountEntity> findByOrcid(String orcid) {
         TypedQuery<ShibbolethAccountEntity> query = entityManager.createQuery("from ShibbolethAccountEntity where orcid = :orcid", ShibbolethAccountEntity.class);
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/SpamDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/SpamDaoImpl.java
@@ -19,7 +19,7 @@ public class SpamDaoImpl extends GenericDaoImpl<SpamEntity, Long> implements Spa
     }    
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean exists(String orcid) {
         Query query = entityManager.createNativeQuery("select count(*) from spam where orcid=:orcid");
         query.setParameter("orcid", orcid);
@@ -28,7 +28,7 @@ public class SpamDaoImpl extends GenericDaoImpl<SpamEntity, Long> implements Spa
     }   
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public SpamEntity getSpam(String orcid) {
         Query query = entityManager.createQuery("from SpamEntity where orcid=:orcid");
         query.setParameter("orcid", orcid);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/StatisticsDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/StatisticsDaoImpl.java
@@ -21,7 +21,7 @@ public class StatisticsDaoImpl implements StatisticsDao {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public long calculateLiveIds() {
         Query query = entityManager.createNativeQuery("select count(*) from profile where profile_deactivation_date is null and record_locked = false");
         Object result = query.getSingleResult();
@@ -43,7 +43,7 @@ public class StatisticsDaoImpl implements StatisticsDao {
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public long getLatestLiveIds() {
         Query query = entityManager.createNativeQuery("select statistic_value from statistic_values where key_id = (SELECT max(key_id) FROM statistic_values) and statistic_name = 'liveIds'");
         Object result = query.getSingleResult();

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/UserConnectionDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/UserConnectionDaoImpl.java
@@ -30,7 +30,7 @@ public class UserConnectionDaoImpl extends GenericDaoImpl<UserconnectionEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public UserconnectionEntity findByProviderIdAndProviderUserId(String providerUserId, String providerId) {
         TypedQuery<UserconnectionEntity> query = entityManager
             .createQuery("from UserconnectionEntity where id.provideruserid = :providerUserId and id.providerid = :providerId", UserconnectionEntity.class);
@@ -41,7 +41,7 @@ public class UserConnectionDaoImpl extends GenericDaoImpl<UserconnectionEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public UserconnectionEntity findByProviderIdAndProviderUserIdAndIdType(String providerUserId, String providerId, String idType) {
         TypedQuery<UserconnectionEntity> query = entityManager.createQuery(
             "from UserconnectionEntity where id.provideruserid = :providerUserId and id.providerid = :providerId and idType = :idType", UserconnectionEntity.class);
@@ -53,7 +53,7 @@ public class UserConnectionDaoImpl extends GenericDaoImpl<UserconnectionEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<UserconnectionEntity> findByOrcid(String orcid) {
         TypedQuery<UserconnectionEntity> query = entityManager.createQuery("from UserconnectionEntity where orcid = :orcid", UserconnectionEntity.class);
         query.setParameter("orcid", orcid);
@@ -69,7 +69,7 @@ public class UserConnectionDaoImpl extends GenericDaoImpl<UserconnectionEntity, 
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public UserconnectionEntity findByUserConnectionId(String userConnectionId) {
         TypedQuery<UserconnectionEntity> query = entityManager.createQuery(
                 "from UserconnectionEntity where id.userid = :userConnectionId", UserconnectionEntity.class);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ValidatedPublicProfileDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/ValidatedPublicProfileDaoImpl.java
@@ -17,7 +17,7 @@ public class ValidatedPublicProfileDaoImpl extends GenericDaoImpl<ValidatedPubli
     }
 
     @SuppressWarnings("unchecked")
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<String> getNextRecordsToValidate(int batchSize) {
         Query query = entityManager
                 .createNativeQuery("SELECT p.orcid FROM profile p LEFT JOIN validated_public_profile v ON  p.orcid = v.orcid WHERE v IS NULL AND p.enabled IS TRUE AND p.deprecated_date IS NULL AND p.record_locked IS NOT TRUE and p.profile_deactivation_date IS NULL");

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WebhookDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WebhookDaoImpl.java
@@ -27,7 +27,7 @@ public class WebhookDaoImpl extends GenericDaoImpl<WebhookEntity, WebhookEntityP
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<WebhookEntity> findWebhooksReadyToProcess(Date profileModifiedBefore, int retryDelayMinutes, int maxResults, Set<String> clientsToExclude) {
         TypedQuery<WebhookEntity> query = entityManager.createNamedQuery(WebhookEntity.FIND_WEBHOOKS_READY_TO_PROCESS, WebhookEntity.class);
         query.setParameter("retryDelayMinutes", retryDelayMinutes);
@@ -39,7 +39,7 @@ public class WebhookDaoImpl extends GenericDaoImpl<WebhookEntity, WebhookEntityP
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public long countWebhooksReadyToProcess(Date profileModifiedBefore, int retryDelayMinutes) {
         TypedQuery<BigInteger> query = entityManager.createNamedQuery(WebhookEntity.COUNT_WEBHOOKS_READY_TO_PROCESS, BigInteger.class);
         query.setParameter("retryDelayMinutes", retryDelayMinutes);

--- a/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WorkDaoImpl.java
+++ b/orcid-persistence/src/main/java/org/orcid/persistence/dao/impl/WorkDaoImpl.java
@@ -39,7 +39,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public MinimizedWorkEntity getMinimizedWorkEntity(Long id) {
         TypedQuery<MinimizedWorkEntity> query = entityManager
                 .createQuery("from MinimizedWorkEntity where id = :id", MinimizedWorkEntity.class);
@@ -48,7 +48,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
     
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<MinimizedWorkEntity> getMinimizedWorkEntities(List<Long> ids) {
         // batch up list into sets of 'batchSize';
         List<MinimizedWorkEntity> list = new ArrayList<>();
@@ -61,7 +61,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<MinimizedExtendedWorkEntity> getMinimizedExtendedWorkEntities(List<Long> ids) {
         // batch up list into sets of 50;
         List<MinimizedExtendedWorkEntity> list = new ArrayList<>();
@@ -74,7 +74,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<WorkEntity> getWorkEntities(String orcid, List<Long> ids) {
         // batch up list into sets of 50;
         List<WorkEntity> list = new ArrayList<>();
@@ -189,7 +189,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
      * @return a list of work ids    
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @SuppressWarnings("unchecked")    
     public List<BigInteger> getWorksWithNullRelationship() {
         Query query = entityManager.createNativeQuery("SELECT distinct(work_id) FROM (SELECT work_id, json_array_elements(json_extract_path(external_ids_json, 'workExternalIdentifier')) AS j FROM work where external_ids_json is not null) AS a WHERE (j->>'relationship') is null");                
@@ -209,7 +209,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
      * @return a list of work ids    
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     @SuppressWarnings("unchecked")    
     public List<BigInteger> getWorksByWorkTypeAndExtIdType(String workType, String extIdType) {
         Query query = entityManager.createNativeQuery("SELECT distinct(work_id) FROM (SELECT work_id, json_array_elements(json_extract_path(external_ids_json, 'workExternalIdentifier')) AS j FROM work where work_type=:workType and external_ids_json is not null) AS a WHERE (j->>'workExternalIdentifierType') = :extIdType");
@@ -225,7 +225,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
      * @return the WorkEntity associated with the parameter id
      * */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public WorkEntity getWork(String orcid, Long id) {
         TypedQuery<WorkEntity> query = entityManager.createQuery("FROM WorkEntity WHERE id = :workId and orcid = :orcid", WorkEntity.class);        
         query.setParameter("workId", id);
@@ -235,7 +235,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<WorkLastModifiedEntity> getWorkLastModifiedList(String orcid) {
         Query query = entityManager.createQuery("from WorkLastModifiedEntity w where w.orcid=:orcid order by w.displayIndex desc, w.dateCreated asc");
         query.setParameter("orcid", orcid);
@@ -244,7 +244,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<WorkLastModifiedEntity> getPublicWorkLastModifiedList(String orcid) {
         Query query = entityManager.createQuery("from WorkLastModifiedEntity w where w.visibility='PUBLIC' and w.orcid=:orcid order by w.displayIndex desc, w.dateCreated asc");
         query.setParameter("orcid", orcid);
@@ -253,7 +253,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<WorkLastModifiedEntity> getWorkLastModifiedList(String orcid, List<Long> ids) {
         Query query = entityManager.createQuery("from WorkLastModifiedEntity w where w.orcid=:orcid and id in (:ids) order by w.displayIndex desc, w.dateCreated asc");
         query.setParameter("orcid", orcid);
@@ -270,7 +270,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<WorkEntity> getWorksByOrcidId(String orcid) {
         List<WorkEntity> works = new ArrayList<>();
         List<WorkLastModifiedEntity> lastModifiedWorks = getWorkLastModifiedList(orcid);
@@ -284,7 +284,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean hasPublicWorks(String orcid) {
         Query query = entityManager.createNativeQuery("SELECT count(*) FROM work WHERE orcid=:orcid AND visibility='PUBLIC'");
         query.setParameter("orcid", orcid);
@@ -293,7 +293,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public boolean isPublic(String orcid, List<Long> ids) {
         Query query = entityManager.createNativeQuery("SELECT count(*) FROM work WHERE orcid=:orcid AND visibility='PUBLIC' AND work_id IN :ids");
         query.setParameter("orcid", orcid);
@@ -304,7 +304,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForClientSourceCorrection(int limit, List<String> nonPublicClientIds) {
         Query query = entityManager.createNativeQuery("SELECT work_id FROM work WHERE client_source_id = source_id AND client_source_id IN :nonPublicClientIds");
         query.setParameter("nonPublicClientIds", nonPublicClientIds);
@@ -322,7 +322,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserSourceCorrection(int limit, List<String> publicClientIds) {
         Query query = entityManager.createNativeQuery("SELECT work_id FROM work WHERE client_source_id = source_id AND client_source_id IN :publicClientIds");
         query.setParameter("publicClientIds", publicClientIds);
@@ -340,7 +340,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBOUpdate(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT work_id FROM work WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -358,7 +358,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(String clientDetailsId, int max) {
         Query query = entityManager.createNativeQuery("SELECT work_id FROM work WHERE client_source_id = :clientDetailsId AND assertion_origin_source_id IS NOT NULL");
         query.setParameter("clientDetailsId", clientDetailsId);
@@ -376,7 +376,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsForUserOBORecords(int max) {
         Query query = entityManager.createNativeQuery("SELECT work_id FROM work WHERE assertion_origin_source_id IS NOT NULL");
         query.setMaxResults(max);
@@ -385,7 +385,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
 
     @SuppressWarnings("unchecked")
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<BigInteger> getIdsOfWorksReferencingClientProfiles(int max, List<String> clientProfileOrcidIds) {
         Query query = entityManager.createNativeQuery("SELECT work_id FROM work WHERE source_id IN :ids");
         query.setParameter("ids", clientProfileOrcidIds);
@@ -408,7 +408,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> getWorksByOrcid(String orcid, boolean featuredOnly) {
         String queryText = WORKS_BY_ORCID_WITH_CONTRIBUTORS;
         if (featuredOnly) {
@@ -439,7 +439,7 @@ public class WorkDaoImpl extends GenericDaoImpl<WorkEntity, Long> implements Wor
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(value = "transactionManagerReadOnly", readOnly = true)
     public List<Object[]> getWorksStartingFromWorkId(Long workId, int numberOfWorks) {
         Query query = entityManager.createNativeQuery(
                 "SELECT " +

--- a/orcid-persistence/src/main/resources/orcid-persistence-context.xml
+++ b/orcid-persistence/src/main/resources/orcid-persistence-context.xml
@@ -16,7 +16,7 @@
                
     <context:property-placeholder location="\${org.orcid.config.file}" ignore-resource-not-found="true" ignore-unresolvable="true" />
             
-    <tx:annotation-driven proxy-target-class="true" />
+    <tx:annotation-driven order="2" proxy-target-class="true" />
     
     <context:component-scan
 		base-package="org.orcid.persistence.aop" />

--- a/orcid-test/src/main/resources/properties/test-db.properties
+++ b/orcid-test/src/main/resources/properties/test-db.properties
@@ -16,14 +16,14 @@ org.orcid.persistence.db.testConnectionOnCheckin=true
 org.orcid.persistence.db.preferredTestQuery=select 1
 
 # Read only database
-org.orcid.persistence.db.readonly.url=jdbc:hsqldb:mem:orcidro;sql.syntax_pgs=true
+org.orcid.persistence.db.readonly.url=jdbc:hsqldb:mem:orcid;sql.syntax_pgs=true
 org.orcid.persistence.db.readonly.class=org.hsqldb.jdbcDriver
 org.orcid.persistence.db.readonly.username=sa
 org.orcid.persistence.db.readonly.password=
 org.orcid.persistence.db.readonly.dialect=org.hibernate.dialect.HSQLDialect
 org.orcid.persistence.db.readonly.showSql=false
 org.orcid.persistence.db.readonly.generateDdl=false
-org.orcid.persistence.db.readonly.dataSource=simpleDataSource
+org.orcid.persistence.db.readonly.dataSource=simpleDataSourceReadOnly
 org.orcid.persistence.db.readonly.initialPoolSize=5
 org.orcid.persistence.db.readonly.minPoolSize=5
 org.orcid.persistence.db.readonly.maxPoolSize=20


### PR DESCRIPTION
Implemented the remediation plan for J21-003 to resolve connection misrouting and advisor precedence issues in the persistence and caching layers. Verified that all DAO read operations route to transactionManagerReadOnly and that cache hits are resolved prior to opening transaction boundaries. Changes
Configured advisor ordering in Spring XML contexts by setting <cache:annotation-driven order="1"/> in orcid-core-cache-config.xml and <tx:annotation-driven order="2" proxy-target-class="true"/> in orcid-persistence-context.xml to ensure cache advice executes outermost. Updated @Transactional(readOnly = true) annotations across all DAO interfaces and implementations in orcid-persistence to explicitly specify @Transactional(value = "transactionManagerReadOnly", readOnly = true). Configured read-only test and development properties (test-db.properties and development.properties) to use simpleDataSourceReadOnly / dedicated connection pool properties.