### PR TITLE
Fix for the NullPointerException in PersonDetailsManagerReadOnlyImpl when retrieving public person details for ORCID records that do not contain a record name.

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/PersonDetailsManagerReadOnlyImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/PersonDetailsManagerReadOnlyImpl.java
@@ -152,7 +152,7 @@ public class PersonDetailsManagerReadOnlyImpl extends ManagerReadOnlyBaseImpl im
         Person person = new Person();
 
         Name name = recordNameManager.getRecordName(orcid);
-        if (Visibility.PUBLIC.equals(name.getVisibility())) {
+        if (name != null && Visibility.PUBLIC.equals(name.getVisibility())) {
             person.setName(name);
         }
 

--- a/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/RecordNameManagerReadOnlyImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/read_only/impl/RecordNameManagerReadOnlyImpl.java
@@ -34,7 +34,7 @@ public class RecordNameManagerReadOnlyImpl extends ManagerReadOnlyBaseImpl imple
         try {
             return jpaJaxbNameAdapter.toName(recordNameDao.getRecordName(orcid, getLastModified(orcid)));             
         } catch(Exception e) {
-            LOGGER.error("Exception getting record name", e);
+            LOGGER.error("Exception getting record name for record: '" + orcid + "': " + e.getMessage());
         }
         return null;
     }
@@ -44,7 +44,7 @@ public class RecordNameManagerReadOnlyImpl extends ManagerReadOnlyBaseImpl imple
         try {
             return jpaJaxbNameAdapter.toName(recordNameDao.findByCreditName(creditName));
         } catch(Exception e) {
-            LOGGER.error("Exception getting record name by credit name", e);
+            LOGGER.error("Exception getting record name for credit name: '" + creditName + "': " + e.getMessage());
         }
         return null;
     }

--- a/orcid-core/src/main/java/org/orcid/core/manager/v3/read_only/impl/PersonDetailsManagerReadOnlyImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/v3/read_only/impl/PersonDetailsManagerReadOnlyImpl.java
@@ -156,7 +156,7 @@ public class PersonDetailsManagerReadOnlyImpl extends ManagerReadOnlyBaseImpl im
         Person person = new Person();
 
         Name name = recordNameManager.getRecordName(orcid);
-        if (Visibility.PUBLIC.equals(name.getVisibility())) {
+        if (name != null && Visibility.PUBLIC.equals(name.getVisibility())) {
             person.setName(name);
         }
 

--- a/orcid-core/src/main/java/org/orcid/core/manager/v3/read_only/impl/RecordNameManagerReadOnlyImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/manager/v3/read_only/impl/RecordNameManagerReadOnlyImpl.java
@@ -38,7 +38,7 @@ public class RecordNameManagerReadOnlyImpl extends ManagerReadOnlyBaseImpl imple
             try {
                 return jpaJaxbNameAdapter.toName(recordNameDao.getRecordName(orcid, getLastModified(orcid)));
             } catch (Exception e) {
-                LOGGER.error("Exception getting record name", e);
+                LOGGER.error("Exception getting record name for record: '" + orcid + "': " + e.getMessage());
             }
         }
         return null;
@@ -49,7 +49,7 @@ public class RecordNameManagerReadOnlyImpl extends ManagerReadOnlyBaseImpl imple
         try {
             return jpaJaxbNameAdapter.toName(recordNameDao.findByCreditName(creditName));
         } catch(Exception e) {
-            LOGGER.error("Exception getting record name by credit name", e);
+            LOGGER.error("Exception getting record name for credit name: '" + creditName + "': " + e.getMessage());
         }
         return null;
     }

--- a/orcid-core/src/test/java/org/orcid/core/manager/PersonDetailsManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/PersonDetailsManagerTest.java
@@ -2,6 +2,7 @@ package org.orcid.core.manager;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -141,5 +142,12 @@ public class PersonDetailsManagerTest extends DBUnitTest {
         assertNotNull(person.getName().getGivenNames());
         assertEquals("Given Names", person.getName().getGivenNames().getContent());
         assertEquals(Visibility.PUBLIC, person.getName().getVisibility());
+    }
+
+    @Test
+    public void testGetPublicPersonDetailsWithoutName() {
+        Person person = personDetailsManager.getPublicPersonDetails("0000-0000-0000-0005");
+        assertNotNull(person);
+        assertNull(person.getName());
     }
 }

--- a/orcid-core/src/test/java/org/orcid/core/manager/v3/PersonDetailsManagerTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/manager/v3/PersonDetailsManagerTest.java
@@ -2,6 +2,7 @@ package org.orcid.core.manager.v3;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -152,5 +153,12 @@ public class PersonDetailsManagerTest extends DBUnitTest {
         assertNotNull(person.getName().getGivenNames());
         assertEquals("Given Names", person.getName().getGivenNames().getContent());
         assertEquals(Visibility.PUBLIC, person.getName().getVisibility());
+    }
+
+    @Test
+    public void testGetPublicPersonDetailsWithoutName() {
+        Person person = personDetailsManager.getPublicPersonDetails("0000-0000-0000-0005");
+        assertNotNull(person);
+        assertNull(person.getName());
     }
 }


### PR DESCRIPTION


Updated PersonDetailsManagerReadOnlyImpl.getPublicPersonDetails(String orcid) in both org.orcid.core.manager.v3.read_only.impl and org.orcid.core.manager.read_only.impl to verify name != null before checking name.getVisibility().

Added testGetPublicPersonDetailsWithoutName in both org.orcid.core.manager.v3.PersonDetailsManagerTest and org.orcid.core.manager.PersonDetailsManagerTest to validate profiles with no record name.