### PR TITLE
Error response from /funding endpoint for GET XML request where source is user

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbFundingAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/impl/JpaJaxbFundingAdapterImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import java.math.BigDecimal;
 
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -91,6 +92,19 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = ".", target = "source")
     public abstract Funding toFunding(ProfileFundingEntity profileFundingEntity);
 
+    @AfterMapping
+    protected void afterToFunding(ProfileFundingEntity entity, @MappingTarget Funding funding) {
+        if (funding.getTitle() != null && funding.getTitle().getTranslatedTitle() != null && funding.getTitle().getTranslatedTitle().getContent() == null) {
+            funding.getTitle().setTranslatedTitle(null);
+        }
+        if (funding.getOrganizationDefinedType() != null && (funding.getOrganizationDefinedType().getContent() == null || funding.getOrganizationDefinedType().getContent().trim().isEmpty())) {
+            funding.setOrganizationDefinedType(null);
+        }
+        if (funding.getAmount() != null && funding.getAmount().getContent() == null && funding.getAmount().getCurrencyCode() == null) {
+            funding.setAmount(null);
+        }
+    }
+
     @Override
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "dateCreated", target = "createdDate.value")
@@ -109,6 +123,13 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
     @Mapping(source = "org.orgDisambiguated.id", target = "organization.disambiguatedOrganization.id")
     @Mapping(source = ".", target = "source")
     public abstract FundingSummary toFundingSummary(ProfileFundingEntity profileFundingEntity);
+
+    @AfterMapping
+    protected void afterToFundingSummary(ProfileFundingEntity entity, @MappingTarget FundingSummary fundingSummary) {
+        if (fundingSummary.getTitle() != null && fundingSummary.getTitle().getTranslatedTitle() != null && fundingSummary.getTitle().getTranslatedTitle().getContent() == null) {
+            fundingSummary.getTitle().setTranslatedTitle(null);
+        }
+    }
 
     @Override
     public abstract List<Funding> toFunding(Collection<ProfileFundingEntity> fundingEntities);

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbFundingAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbFundingAdapterImpl.java
@@ -101,6 +101,12 @@ public abstract class JpaJaxbFundingAdapterImpl implements JpaJaxbFundingAdapter
         if (funding.getTitle() != null && funding.getTitle().getTranslatedTitle() != null && funding.getTitle().getTranslatedTitle().getContent() == null) {
             funding.getTitle().setTranslatedTitle(null);
         }
+        if (funding.getOrganizationDefinedType() != null && (funding.getOrganizationDefinedType().getContent() == null || funding.getOrganizationDefinedType().getContent().trim().isEmpty())) {
+            funding.setOrganizationDefinedType(null);
+        }
+        if (funding.getAmount() != null && funding.getAmount().getContent() == null && funding.getAmount().getCurrencyCode() == null) {
+            funding.setAmount(null);
+        }
     }
 
     @Override

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbResearchResourceAdapterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/v3/impl/JpaJaxbResearchResourceAdapterImpl.java
@@ -112,6 +112,16 @@ public abstract class JpaJaxbResearchResourceAdapterImpl implements JpaJaxbResea
     @Mapping(source = ".", target = "source")
     public abstract ResearchResource toModel(ResearchResourceEntity entity);
 
+    @AfterMapping
+    protected void removeEmptyOptionalTitleFields(ResearchResourceEntity entity, @MappingTarget ResearchResource researchResource) {
+        if (researchResource.getProposal() != null && researchResource.getProposal().getTitle() != null) {
+            org.orcid.jaxb.model.v3.release.record.ResearchResourceTitle title = researchResource.getProposal().getTitle();
+            if (title.getTranslatedTitle() != null && title.getTranslatedTitle().getContent() == null && title.getTranslatedTitle().getLanguageCode() == null) {
+                title.setTranslatedTitle(null);
+            }
+        }
+    }
+
     @Override
     @Mapping(source = "id", target = "putCode")
     @Mapping(source = "title", target = "proposal.title.title.content")
@@ -126,6 +136,16 @@ public abstract class JpaJaxbResearchResourceAdapterImpl implements JpaJaxbResea
     @Mapping(source = "lastModified", target = "lastModifiedDate.value")
     @Mapping(source = ".", target = "source")
     public abstract ResearchResourceSummary toSummary(ResearchResourceEntity entity);
+
+    @AfterMapping
+    protected void removeEmptyOptionalTitleFields(ResearchResourceEntity entity, @MappingTarget ResearchResourceSummary researchResourceSummary) {
+        if (researchResourceSummary.getProposal() != null && researchResourceSummary.getProposal().getTitle() != null) {
+            org.orcid.jaxb.model.v3.release.record.ResearchResourceTitle title = researchResourceSummary.getProposal().getTitle();
+            if (title.getTranslatedTitle() != null && title.getTranslatedTitle().getContent() == null && title.getTranslatedTitle().getLanguageCode() == null) {
+                title.setTranslatedTitle(null);
+            }
+        }
+    }
 
     // ========================================================================
     // Custom Helper Mappings: Hosts (ResearchResourceHosts <-> List<OrgEntity>)

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbFundingAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbFundingAdapterTest.java
@@ -133,6 +133,13 @@ public class JpaJaxbFundingAdapterTest {
         assertEquals("ES", funding.getTitle().getTranslatedTitle().getLanguageCode());
         assertEquals(FundingType.SALARY_AWARD, funding.getType());
         assertEquals(Visibility.PRIVATE, funding.getVisibility());
+        assertNull(funding.getOrganizationDefinedType());
+
+        // Verify JAXB marshalling succeeds without AccessorException
+        JAXBContext context = JAXBContext.newInstance(Funding.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(funding, writer);
+        assertNotNull(writer.toString());
     }
 
     @Test

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbFundingAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbFundingAdapterTest.java
@@ -196,6 +196,13 @@ public class JpaJaxbFundingAdapterTest {
         
         assertNotNull(funding.getOrganization());
         assertNotNull(funding.getOrganization().getAddress());
+        assertNull(funding.getOrganizationDefinedType());
+
+        // Verify JAXB marshalling succeeds without AccessorException
+        JAXBContext context = JAXBContext.newInstance(Funding.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(funding, writer);
+        assertNotNull(writer.toString());
     }
 
     @Test


### PR DESCRIPTION


Fixed HTTP 500 AccessorException: Object must have some value in its @XmlValue field when accessing funding endpoints (e.g., /v3.0/{orcid}/funding/{putCode}).

Prevented MapStruct from generating empty JAXB objects for optional @XmlValue fields when the underlying database entity attributes are null.