### PR TITLE
PD-13495 Fixed null mappings for contributors V2 and V3 both works and fundings

### DIFF
--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/ContributorsRolesAndSequencesMapperV3.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/ContributorsRolesAndSequencesMapperV3.java
@@ -27,6 +27,10 @@ public class ContributorsRolesAndSequencesMapperV3 {
     @Resource(name = "workContributorRoleConverter")
     private ContributorRoleConverter workContributorRoleConverter;
 
+    public void setWorkContributorRoleConverter(ContributorRoleConverter workContributorRoleConverter) {
+        this.workContributorRoleConverter = workContributorRoleConverter;
+    }
+
     public String convertTo(List<ContributorsRolesAndSequences> source) {
         return JsonUtils.convertToJsonString(source);
     }

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV2.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV2.java
@@ -43,12 +43,6 @@ public class FundingContributorsMapperV2 {
     }
 
     public String convertTo(FundingContributors source) {
-        if (source == null) {
-            return null;
-        }
-        if (source.getContributor() != null) {
-            source.getContributor().forEach(this::cleanAndPopulateContributor);
-        }
         return JsonUtils.convertToJsonString(source);
     }
 

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV2.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV2.java
@@ -43,6 +43,9 @@ public class FundingContributorsMapperV2 {
     }
 
     public String convertTo(FundingContributors source) {
+        if (source == null) {
+            return null;
+        }
         return JsonUtils.convertToJsonString(source);
     }
 

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV2.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV2.java
@@ -1,13 +1,21 @@
 package org.orcid.core.adapter.mapstruct;
 
+import java.net.URI;
 import java.util.Iterator;
 
+import jakarta.annotation.Resource;
+
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.orcid.core.contributors.roles.fundings.FundingContributorRoleConverter;
+import org.orcid.core.manager.impl.OrcidUrlManager;
 import org.orcid.core.utils.JsonUtils;
+import org.orcid.jaxb.model.common_v2.ContributorOrcid;
+import org.orcid.jaxb.model.record_v2.FundingContributor;
 import org.orcid.jaxb.model.record_v2.FundingContributors;
+import org.orcid.utils.OrcidStringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -21,14 +29,25 @@ public class FundingContributorsMapperV2 {
 
     private final FundingContributorRoleConverter roleConverter;
 
+    @Autowired(required = false)
+    @Resource(name = "orcidUrlManager")
+    private OrcidUrlManager orcidUrlManager;
+
     // Spring will automatically inject the FundingContributorRoleConverter here
     public FundingContributorsMapperV2(FundingContributorRoleConverter roleConverter) {
         this.roleConverter = roleConverter;
     }
 
+    public void setOrcidUrlManager(OrcidUrlManager orcidUrlManager) {
+        this.orcidUrlManager = orcidUrlManager;
+    }
+
     public String convertTo(FundingContributors source) {
         if (source == null) {
             return null;
+        }
+        if (source.getContributor() != null) {
+            source.getContributor().forEach(this::cleanAndPopulateContributor);
         }
         return JsonUtils.convertToJsonString(source);
     }
@@ -78,11 +97,64 @@ public class FundingContributorsMapperV2 {
         
         // Null-check the converted object and its internal list before iterating
         if (fundingContributors != null && fundingContributors.getContributor() != null) {
-            fundingContributors.getContributor().forEach(c -> 
-                c.setCreditName("".equals(c.getCreditName()) ? null : c.getCreditName())
-            );
+            fundingContributors.getContributor().forEach(this::cleanAndPopulateContributor);
         }
         
         return fundingContributors;
+    }
+
+    public void cleanAndPopulateContributor(FundingContributor c) {
+        if (c == null) {
+            return;
+        }
+        if (c.getCreditName() != null && (c.getCreditName().getContent() == null || StringUtils.isBlank(c.getCreditName().getContent()))) {
+            c.setCreditName(null);
+        }
+
+        if (c.getContributorEmail() != null && (c.getContributorEmail().getValue() == null || StringUtils.isBlank(c.getContributorEmail().getValue()))) {
+            c.setContributorEmail(null);
+        }
+
+        if (c.getContributorOrcid() != null) {
+            ContributorOrcid orcid = c.getContributorOrcid();
+            String path = orcid.getPath();
+            String uriStr = orcid.getUri();
+            String host = orcid.getHost();
+
+            if (StringUtils.isBlank(path) && StringUtils.isNotBlank(uriStr)) {
+                path = OrcidStringUtils.getOrcidNumber(uriStr);
+                orcid.setPath(path);
+            }
+
+            if (StringUtils.isBlank(path)) {
+                c.setContributorOrcid(null);
+            } else {
+                if (StringUtils.isBlank(host) && StringUtils.isNotBlank(uriStr)) {
+                    try {
+                        URI u = new URI(uriStr);
+                        host = u.getHost();
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
+                if (StringUtils.isBlank(host)) {
+                    host = (orcidUrlManager != null && StringUtils.isNotBlank(orcidUrlManager.getBaseHost()))
+                            ? orcidUrlManager.getBaseHost() : "orcid.org";
+                }
+                orcid.setHost(host);
+
+                if (StringUtils.isBlank(uriStr)) {
+                    String baseUrl = (orcidUrlManager != null && StringUtils.isNotBlank(orcidUrlManager.getBaseUriHttp()))
+                            ? orcidUrlManager.getBaseUriHttp() : "http://orcid.org";
+                    orcid.setUri(baseUrl + "/" + path);
+                }
+            }
+        }
+
+        if (c.getContributorAttributes() != null) {
+            if (c.getContributorAttributes().getContributorRole() == null) {
+                c.setContributorAttributes(null);
+            }
+        }
     }
 }

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV3.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV3.java
@@ -1,29 +1,57 @@
 package org.orcid.core.adapter.mapstruct;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import jakarta.annotation.Resource;
 
 import org.apache.commons.lang3.StringUtils;
 import org.orcid.core.contributors.roles.ContributorRoleConverter;
 import org.orcid.core.contributors.roles.InvalidContributorRoleException;
 import org.orcid.core.contributors.roles.credit.CreditRole;
 import org.orcid.core.contributors.roles.fundings.LegacyFundingContributorRole;
+import org.orcid.core.manager.impl.OrcidUrlManager;
 import org.orcid.core.utils.JsonUtils;
+import org.orcid.jaxb.model.v3.release.common.ContributorOrcid;
+import org.orcid.jaxb.model.v3.release.record.FundingContributor;
 import org.orcid.jaxb.model.v3.release.record.FundingContributors;
+import org.orcid.utils.OrcidStringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Replaces the old Orika-only {@code org.orcid.core.adapter.v3.converter.FundingContributorsConverter}.
- * Plain, framework-free conversion logic - no Orika dependency. Not Spring-managed
- * (constructed per mapper-facade build with a runtime role-converter dependency).
+ * Plain, framework-free conversion logic - no Orika dependency.
  */
 public class FundingContributorsMapperV3 {
 
+    @Resource(name = "fundingContributorRoleConverter")
     private ContributorRoleConverter roleConverter;
+
+    @Autowired(required = false)
+    @Resource(name = "orcidUrlManager")
+    private OrcidUrlManager orcidUrlManager;
+
+    public FundingContributorsMapperV3() {
+    }
 
     public FundingContributorsMapperV3(ContributorRoleConverter roleConverter) {
         this.roleConverter = roleConverter;
+    }
+
+    public FundingContributorsMapperV3(ContributorRoleConverter roleConverter, OrcidUrlManager orcidUrlManager) {
+        this.roleConverter = roleConverter;
+        this.orcidUrlManager = orcidUrlManager;
+    }
+
+    public void setRoleConverter(ContributorRoleConverter roleConverter) {
+        this.roleConverter = roleConverter;
+    }
+
+    public void setOrcidUrlManager(OrcidUrlManager orcidUrlManager) {
+        this.orcidUrlManager = orcidUrlManager;
     }
 
     public String convertTo(FundingContributors source) {
@@ -31,29 +59,32 @@ public class FundingContributorsMapperV3 {
             return null;
         }
 
-        // convert role to db format
-        source.getContributor().forEach(c -> {
-            if (c.getContributorAttributes() != null && c.getContributorAttributes().getContributorRole() != null) {
-                String providedRoleValue = c.getContributorAttributes().getContributorRole();
-                String resolvedRoleValue = roleConverter.toDBRole(providedRoleValue);
-                if (resolvedRoleValue == null) {
-                    Map<String, String> exceptionParams = new HashMap<>();
-                    exceptionParams.put("role", providedRoleValue);
+        if (source.getContributor() != null) {
+            // convert role to db format
+            source.getContributor().forEach(c -> {
+                cleanAndPopulateContributor(c);
+                if (c.getContributorAttributes() != null && c.getContributorAttributes().getContributorRole() != null) {
+                    String providedRoleValue = c.getContributorAttributes().getContributorRole();
+                    String resolvedRoleValue = roleConverter.toDBRole(providedRoleValue);
+                    if (resolvedRoleValue == null) {
+                        Map<String, String> exceptionParams = new HashMap<>();
+                        exceptionParams.put("role", providedRoleValue);
 
-                    List<String> legalValues = new ArrayList<>();
-                    for (LegacyFundingContributorRole role : LegacyFundingContributorRole.values()) {
-                        legalValues.add(role.value());
-                    }
-                    for (CreditRole role : CreditRole.values()) {
-                        legalValues.add(role.value());
-                    }
-                    exceptionParams.put("validRoles", legalValues.toString());
+                        List<String> legalValues = new ArrayList<>();
+                        for (LegacyFundingContributorRole role : LegacyFundingContributorRole.values()) {
+                            legalValues.add(role.value());
+                        }
+                        for (CreditRole role : CreditRole.values()) {
+                            legalValues.add(role.value());
+                        }
+                        exceptionParams.put("validRoles", legalValues.toString());
 
-                    throw new InvalidContributorRoleException(exceptionParams);
+                        throw new InvalidContributorRoleException(exceptionParams);
+                    }
+                    c.getContributorAttributes().setContributorRole(resolvedRoleValue);
                 }
-                c.getContributorAttributes().setContributorRole(resolvedRoleValue);
-            }
-        });
+            });
+        }
         return JsonUtils.convertToJsonString(source);
     }
 
@@ -67,14 +98,72 @@ public class FundingContributorsMapperV3 {
             return fundingContributors;
         }
 
-        fundingContributors.getContributor().forEach(c -> c.setCreditName("".equals(c.getCreditName()) ? null : c.getCreditName()));
-
-        // convert role to API format
+        // convert role to API format and normalize/clean contributor fields
         fundingContributors.getContributor().forEach(c -> {
+            cleanAndPopulateContributor(c);
             if (c.getContributorAttributes() != null && c.getContributorAttributes().getContributorRole() != null) {
-                c.getContributorAttributes().setContributorRole(roleConverter.toRoleValue(c.getContributorAttributes().getContributorRole()));
+                String apiRole = roleConverter.toRoleValue(c.getContributorAttributes().getContributorRole());
+                c.getContributorAttributes().setContributorRole(apiRole);
+                if (c.getContributorAttributes().getContributorRole() == null) {
+                    c.setContributorAttributes(null);
+                }
             }
         });
         return fundingContributors;
+    }
+
+    public void cleanAndPopulateContributor(FundingContributor c) {
+        if (c == null) {
+            return;
+        }
+        if (c.getCreditName() != null && (c.getCreditName().getContent() == null || StringUtils.isBlank(c.getCreditName().getContent()))) {
+            c.setCreditName(null);
+        }
+
+        if (c.getContributorEmail() != null && (c.getContributorEmail().getValue() == null || StringUtils.isBlank(c.getContributorEmail().getValue()))) {
+            c.setContributorEmail(null);
+        }
+
+        if (c.getContributorOrcid() != null) {
+            ContributorOrcid orcid = c.getContributorOrcid();
+            String path = orcid.getPath();
+            String uriStr = orcid.getUri();
+            String host = orcid.getHost();
+
+            if (StringUtils.isBlank(path) && StringUtils.isNotBlank(uriStr)) {
+                path = OrcidStringUtils.getOrcidNumber(uriStr);
+                orcid.setPath(path);
+            }
+
+            if (StringUtils.isBlank(path)) {
+                c.setContributorOrcid(null);
+            } else {
+                if (StringUtils.isBlank(host) && StringUtils.isNotBlank(uriStr)) {
+                    try {
+                        URI u = new URI(uriStr);
+                        host = u.getHost();
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
+                if (StringUtils.isBlank(host)) {
+                    host = (orcidUrlManager != null && StringUtils.isNotBlank(orcidUrlManager.getBaseHost()))
+                            ? orcidUrlManager.getBaseHost() : "orcid.org";
+                }
+                orcid.setHost(host);
+
+                if (StringUtils.isBlank(uriStr)) {
+                    String baseUrl = (orcidUrlManager != null && StringUtils.isNotBlank(orcidUrlManager.getBaseUrl()))
+                            ? orcidUrlManager.getBaseUrl() : "https://orcid.org";
+                    orcid.setUri(baseUrl + "/" + path);
+                }
+            }
+        }
+
+        if (c.getContributorAttributes() != null) {
+            if (c.getContributorAttributes().getContributorRole() == null) {
+                c.setContributorAttributes(null);
+            }
+        }
     }
 }

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV3.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV3.java
@@ -62,7 +62,6 @@ public class FundingContributorsMapperV3 {
         if (source.getContributor() != null) {
             // convert role to db format
             source.getContributor().forEach(c -> {
-                cleanAndPopulateContributor(c);
                 if (c.getContributorAttributes() != null && c.getContributorAttributes().getContributorRole() != null) {
                     String providedRoleValue = c.getContributorAttributes().getContributorRole();
                     String resolvedRoleValue = roleConverter.toDBRole(providedRoleValue);

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV2.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV2.java
@@ -42,12 +42,6 @@ public class WorkContributorsMapperV2 {
     }
 
     public String convertTo(WorkContributors source) {
-        if (source == null) {
-            return null;
-        }
-        if (source.getContributor() != null) {
-            source.getContributor().forEach(this::cleanAndPopulateContributor);
-        }
         return JsonUtils.convertToJsonString(source);
     }
 

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV2.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV2.java
@@ -1,13 +1,21 @@
 package org.orcid.core.adapter.mapstruct;
 
+import java.net.URI;
 import java.util.Iterator;
 
+import jakarta.annotation.Resource;
+
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.orcid.core.contributors.roles.works.WorkContributorRoleConverter;
+import org.orcid.core.manager.impl.OrcidUrlManager;
 import org.orcid.core.utils.JsonUtils;
+import org.orcid.jaxb.model.common_v2.Contributor;
+import org.orcid.jaxb.model.common_v2.ContributorOrcid;
 import org.orcid.jaxb.model.record_v2.WorkContributors;
+import org.orcid.utils.OrcidStringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -21,13 +29,24 @@ public class WorkContributorsMapperV2 {
 
     private final WorkContributorRoleConverter roleConverter;
 
+    @Autowired(required = false)
+    @Resource(name = "orcidUrlManager")
+    private OrcidUrlManager orcidUrlManager;
+
     public WorkContributorsMapperV2(WorkContributorRoleConverter roleConverter) {
         this.roleConverter = roleConverter;
+    }
+
+    public void setOrcidUrlManager(OrcidUrlManager orcidUrlManager) {
+        this.orcidUrlManager = orcidUrlManager;
     }
 
     public String convertTo(WorkContributors source) {
         if (source == null) {
             return null;
+        }
+        if (source.getContributor() != null) {
+            source.getContributor().forEach(this::cleanAndPopulateContributor);
         }
         return JsonUtils.convertToJsonString(source);
     }
@@ -73,11 +92,64 @@ public class WorkContributorsMapperV2 {
         WorkContributors workContributors = JsonUtils.convertTreeToValue(tree, WorkContributors.class);
 
         if (workContributors != null && workContributors.getContributor() != null) {
-            workContributors.getContributor().forEach(c -> 
-                c.setCreditName("".equals(c.getCreditName()) ? null : c.getCreditName())
-            );
+            workContributors.getContributor().forEach(this::cleanAndPopulateContributor);
         }
 
         return workContributors;
+    }
+
+    public void cleanAndPopulateContributor(Contributor c) {
+        if (c == null) {
+            return;
+        }
+        if (c.getCreditName() != null && (c.getCreditName().getContent() == null || StringUtils.isBlank(c.getCreditName().getContent()))) {
+            c.setCreditName(null);
+        }
+
+        if (c.getContributorEmail() != null && (c.getContributorEmail().getValue() == null || StringUtils.isBlank(c.getContributorEmail().getValue()))) {
+            c.setContributorEmail(null);
+        }
+
+        if (c.getContributorOrcid() != null) {
+            ContributorOrcid orcid = c.getContributorOrcid();
+            String path = orcid.getPath();
+            String uriStr = orcid.getUri();
+            String host = orcid.getHost();
+
+            if (StringUtils.isBlank(path) && StringUtils.isNotBlank(uriStr)) {
+                path = OrcidStringUtils.getOrcidNumber(uriStr);
+                orcid.setPath(path);
+            }
+
+            if (StringUtils.isBlank(path)) {
+                c.setContributorOrcid(null);
+            } else {
+                if (StringUtils.isBlank(host) && StringUtils.isNotBlank(uriStr)) {
+                    try {
+                        URI u = new URI(uriStr);
+                        host = u.getHost();
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
+                if (StringUtils.isBlank(host)) {
+                    host = (orcidUrlManager != null && StringUtils.isNotBlank(orcidUrlManager.getBaseHost()))
+                            ? orcidUrlManager.getBaseHost() : "orcid.org";
+                }
+                orcid.setHost(host);
+
+                if (StringUtils.isBlank(uriStr)) {
+                    String baseUrl = (orcidUrlManager != null && StringUtils.isNotBlank(orcidUrlManager.getBaseUriHttp()))
+                            ? orcidUrlManager.getBaseUriHttp() : "http://orcid.org";
+                    orcid.setUri(baseUrl + "/" + path);
+                }
+            }
+        }
+
+        if (c.getContributorAttributes() != null) {
+            if (c.getContributorAttributes().getContributorRole() == null && c.getContributorAttributes().getContributorSequence() == null) {
+                c.setContributorAttributes(null);
+            }
+        }
     }
 }

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV2.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV2.java
@@ -42,6 +42,9 @@ public class WorkContributorsMapperV2 {
     }
 
     public String convertTo(WorkContributors source) {
+        if (source == null) {
+            return null;
+        }
         return JsonUtils.convertToJsonString(source);
     }
 

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV3.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV3.java
@@ -73,7 +73,6 @@ public class WorkContributorsMapperV3 {
         if (source.getContributor() != null) {
             // convert role to db format
             source.getContributor().forEach(c -> {
-                cleanAndPopulateContributor(c);
                 if (c.getContributorAttributes() != null && c.getContributorAttributes().getContributorRole() != null) {
                     String providedRoleValue = c.getContributorAttributes().getContributorRole();
                     String resolvedRoleValue = roleConverter.toDBRole(providedRoleValue);

--- a/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV3.java
+++ b/orcid-core/src/main/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV3.java
@@ -1,5 +1,6 @@
 package org.orcid.core.adapter.mapstruct;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -7,17 +8,23 @@ import java.util.Map;
 
 import jakarta.annotation.Resource;
 
+import org.apache.commons.lang3.StringUtils;
 import org.orcid.core.contributors.roles.ContributorRoleConverter;
 import org.orcid.core.contributors.roles.InvalidContributorRoleException;
 import org.orcid.core.contributors.roles.credit.CreditRole;
 import org.orcid.core.contributors.roles.works.LegacyWorkContributorRole;
+import org.orcid.core.manager.impl.OrcidUrlManager;
 import org.orcid.core.utils.JsonUtils;
+import org.orcid.jaxb.model.v3.release.common.Contributor;
 import org.orcid.jaxb.model.v3.release.common.ContributorAttributes;
+import org.orcid.jaxb.model.v3.release.common.ContributorOrcid;
 import org.orcid.jaxb.model.v3.release.record.WorkContributors;
 import org.orcid.pojo.WorkContributorsList;
 import org.orcid.pojo.ajaxForm.PojoUtil;
+import org.orcid.utils.OrcidStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,33 +42,60 @@ public class WorkContributorsMapperV3 {
     @Resource(name = "workContributorRoleConverter")
     private ContributorRoleConverter roleConverter;
 
+    @Autowired(required = false)
+    @Resource(name = "orcidUrlManager")
+    private OrcidUrlManager orcidUrlManager;
+
+    public WorkContributorsMapperV3() {
+    }
+
+    public WorkContributorsMapperV3(ContributorRoleConverter roleConverter) {
+        this.roleConverter = roleConverter;
+    }
+
+    public WorkContributorsMapperV3(ContributorRoleConverter roleConverter, OrcidUrlManager orcidUrlManager) {
+        this.roleConverter = roleConverter;
+        this.orcidUrlManager = orcidUrlManager;
+    }
+
+    public void setRoleConverter(ContributorRoleConverter roleConverter) {
+        this.roleConverter = roleConverter;
+    }
+
+    public void setOrcidUrlManager(OrcidUrlManager orcidUrlManager) {
+        this.orcidUrlManager = orcidUrlManager;
+    }
+
     public String convertTo(WorkContributors source) {
         if (source == null) {
             return null;
         }
-        // convert role to db format
-        source.getContributor().forEach(c -> {
-            if (c.getContributorAttributes() != null && c.getContributorAttributes().getContributorRole() != null) {
-                String providedRoleValue = c.getContributorAttributes().getContributorRole();
-                String resolvedRoleValue = roleConverter.toDBRole(providedRoleValue);
-                if (resolvedRoleValue == null) {
-                    Map<String, String> exceptionParams = new HashMap<>();
-                    exceptionParams.put("role", providedRoleValue);
+        if (source.getContributor() != null) {
+            // convert role to db format
+            source.getContributor().forEach(c -> {
+                cleanAndPopulateContributor(c);
+                if (c.getContributorAttributes() != null && c.getContributorAttributes().getContributorRole() != null) {
+                    String providedRoleValue = c.getContributorAttributes().getContributorRole();
+                    String resolvedRoleValue = roleConverter.toDBRole(providedRoleValue);
+                    if (resolvedRoleValue == null) {
+                        Map<String, String> exceptionParams = new HashMap<>();
+                        exceptionParams.put("role", providedRoleValue);
 
-                    List<String> legalValues = new ArrayList<>();
-                    for (LegacyWorkContributorRole role : LegacyWorkContributorRole.values()) {
-                        legalValues.add(role.value());
-                    }
-                    for (CreditRole role : CreditRole.values()) {
-                        legalValues.add(role.value());
-                    }
-                    exceptionParams.put("validRoles", legalValues.toString());
+                        List<String> legalValues = new ArrayList<>();
+                        for (LegacyWorkContributorRole role : LegacyWorkContributorRole.values()) {
+                            legalValues.add(role.value());
+                        }
+                        for (CreditRole role : CreditRole.values()) {
+                            legalValues.add(role.value());
+                        }
+                        exceptionParams.put("validRoles", legalValues.toString());
 
-                    throw new InvalidContributorRoleException(exceptionParams);
+                        throw new InvalidContributorRoleException(exceptionParams);
+                    }
+                    c.getContributorAttributes().setContributorRole(resolvedRoleValue);
                 }
-                c.getContributorAttributes().setContributorRole(resolvedRoleValue);
-            }
-        });
+            });
+        }
         return JsonUtils.convertToJsonString(source);
     }
 
@@ -70,21 +104,82 @@ public class WorkContributorsMapperV3 {
             return null;
         }
         WorkContributors workContributors = JsonUtils.readObjectFromJsonString(source, WorkContributors.class);
-        if (workContributors == null) {
-            return null;
+        if (workContributors == null || workContributors.getContributor() == null) {
+            return workContributors;
         }
 
-        // convert role to API format
+        // convert role to API format and normalize/clean contributor fields
         workContributors.getContributor().forEach(c -> {
-            // Set the credit name
-            c.setCreditName((c.getCreditName() != null && PojoUtil.isEmpty(c.getCreditName().getContent())) ? null : c.getCreditName());
-
+            cleanAndPopulateContributor(c);
             // Set the contributor attributes
             if (c.getContributorAttributes() != null && c.getContributorAttributes().getContributorRole() != null) {
-                c.getContributorAttributes().setContributorRole(roleConverter.toRoleValue(c.getContributorAttributes().getContributorRole()));
+                String apiRole = roleConverter.toRoleValue(c.getContributorAttributes().getContributorRole());
+                c.getContributorAttributes().setContributorRole(apiRole);
+                if (c.getContributorAttributes().getContributorRole() == null && c.getContributorAttributes().getContributorSequence() == null) {
+                    c.setContributorAttributes(null);
+                }
             }
         });
         return workContributors;
+    }
+
+    public void cleanAndPopulateContributor(Contributor c) {
+        if (c == null) {
+            return;
+        }
+        // Set the credit name
+        if (c.getCreditName() != null && (c.getCreditName().getContent() == null || StringUtils.isBlank(c.getCreditName().getContent()))) {
+            c.setCreditName(null);
+        }
+
+        // Set the contributor email
+        if (c.getContributorEmail() != null && (c.getContributorEmail().getValue() == null || StringUtils.isBlank(c.getContributorEmail().getValue()))) {
+            c.setContributorEmail(null);
+        }
+
+        // Set the contributor orcid
+        if (c.getContributorOrcid() != null) {
+            ContributorOrcid orcid = c.getContributorOrcid();
+            String path = orcid.getPath();
+            String uriStr = orcid.getUri();
+            String host = orcid.getHost();
+
+            if (StringUtils.isBlank(path) && StringUtils.isNotBlank(uriStr)) {
+                path = OrcidStringUtils.getOrcidNumber(uriStr);
+                orcid.setPath(path);
+            }
+
+            if (StringUtils.isBlank(path)) {
+                c.setContributorOrcid(null);
+            } else {
+                if (StringUtils.isBlank(host) && StringUtils.isNotBlank(uriStr)) {
+                    try {
+                        URI u = new URI(uriStr);
+                        host = u.getHost();
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
+                if (StringUtils.isBlank(host)) {
+                    host = (orcidUrlManager != null && StringUtils.isNotBlank(orcidUrlManager.getBaseHost()))
+                            ? orcidUrlManager.getBaseHost() : "orcid.org";
+                }
+                orcid.setHost(host);
+
+                if (StringUtils.isBlank(uriStr)) {
+                    String baseUrl = (orcidUrlManager != null && StringUtils.isNotBlank(orcidUrlManager.getBaseUrl()))
+                            ? orcidUrlManager.getBaseUrl() : "https://orcid.org";
+                    orcid.setUri(baseUrl + "/" + path);
+                }
+            }
+        }
+
+        // Set contributor attributes
+        if (c.getContributorAttributes() != null) {
+            if (c.getContributorAttributes().getContributorRole() == null && c.getContributorAttributes().getContributorSequence() == null) {
+                c.setContributorAttributes(null);
+            }
+        }
     }
 
     public List<WorkContributorsList> getContributorsList(String source) {
@@ -96,11 +191,14 @@ public class WorkContributorsMapperV3 {
         try {
             langList = objectMapper.readValue(source, new TypeReference<List<WorkContributorsList>>(){});
             for (WorkContributorsList workContributorsList : langList) {
-                if (workContributorsList.getContributor() != null && workContributorsList.getContributor().getContributorAttributes() != null) {
-                    ContributorAttributes ca = workContributorsList.getContributor().getContributorAttributes();
-                    String providedRoleValue = ca.getContributorRole();
-                    if (!PojoUtil.isEmpty(providedRoleValue)) {
-                        ca.setContributorRole(roleConverter.toRoleValue(providedRoleValue));
+                if (workContributorsList.getContributor() != null) {
+                    cleanAndPopulateContributor(workContributorsList.getContributor());
+                    if (workContributorsList.getContributor().getContributorAttributes() != null) {
+                        ContributorAttributes ca = workContributorsList.getContributor().getContributorAttributes();
+                        String providedRoleValue = ca.getContributorRole();
+                        if (!PojoUtil.isEmpty(providedRoleValue)) {
+                            ca.setContributorRole(roleConverter.toRoleValue(providedRoleValue));
+                        }
                     }
                 }
             }

--- a/orcid-core/src/main/java/org/orcid/core/contributors/roles/ContributorRoleConverterImpl.java
+++ b/orcid-core/src/main/java/org/orcid/core/contributors/roles/ContributorRoleConverterImpl.java
@@ -48,6 +48,15 @@ public abstract class ContributorRoleConverterImpl implements ContributorRoleCon
         } catch (IllegalArgumentException e) {
             // ignore
         }
+
+        try {
+            CreditRole creditRole = CreditRole.valueOf(roleValue);
+            if (creditRole != null) {
+                return creditRole.name();
+            }
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
         return null;
     }
 
@@ -68,6 +77,16 @@ public abstract class ContributorRoleConverterImpl implements ContributorRoleCon
 
         try {
             CreditRole creditRole = CreditRole.valueOf(dbRoleString);
+            if (creditRole != null) {
+                LegacyContributorRole legacyRole = conversionMappings.get(creditRole);
+                return legacyRole != null ? legacyRole.value() : null;
+            }
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
+
+        try {
+            CreditRole creditRole = CreditRole.fromValue(dbRoleString);
             if (creditRole != null) {
                 LegacyContributorRole legacyRole = conversionMappings.get(creditRole);
                 return legacyRole != null ? legacyRole.value() : null;
@@ -99,6 +118,15 @@ public abstract class ContributorRoleConverterImpl implements ContributorRoleCon
             // ignore
         }
 
+        try {
+            CreditRole creditRole = CreditRole.fromValue(dbRoleString);
+            if (creditRole != null) {
+                return creditRole.value();
+            }
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
+
         return null;
     }
 
@@ -120,6 +148,18 @@ public abstract class ContributorRoleConverterImpl implements ContributorRoleCon
         try {
             if (dbRoleString != null) {
                 CreditRole creditRole = CreditRole.valueOf(dbRoleString);
+                if (creditRole != null) {
+                    LegacyContributorRole legacyRole = conversionMappings.get(creditRole);
+                    return legacyRole != null ? legacyRole.name() : null;
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
+
+        try {
+            if (dbRoleString != null) {
+                CreditRole creditRole = CreditRole.fromValue(dbRoleString);
                 if (creditRole != null) {
                     LegacyContributorRole legacyRole = conversionMappings.get(creditRole);
                     return legacyRole != null ? legacyRole.name() : null;

--- a/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV3Test.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/FundingContributorsMapperV3Test.java
@@ -2,6 +2,7 @@ package org.orcid.core.adapter.mapstruct;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -74,6 +75,84 @@ public class FundingContributorsMapperV3Test {
         assertEquals("some-value", fundingContributors.getContributor().get(0).getContributorAttributes().getContributorRole());
         
         Mockito.verify(mockContributorRoleConverter, Mockito.times(1)).toRoleValue(Mockito.anyString());
+    }
+
+    @Test
+    public void testConvertFromWithMissingHostAndNulls() throws Exception {
+        Mockito.when(mockContributorRoleConverter.toRoleValue(Mockito.anyString())).thenReturn("SUPERVISION");
+        String json = "{\n" +
+                "\t\"contributor\": [{\n" +
+                "\t\t\"contributorOrcid\": {\n" +
+                "\t\t\t\"uri\": \"https://qa.orcid.org/0009-0000-7948-587X\",\n" +
+                "\t\t\t\"path\": \"0009-0000-7948-587X\",\n" +
+                "\t\t\t\"host\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"creditName\": {\n" +
+                "\t\t\t\"content\": \"Test Author\"\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorEmail\": null,\n" +
+                "\t\t\"contributorAttributes\": {\n" +
+                "\t\t\t\"contributorRole\": \"SUPERVISION\"\n" +
+                "\t\t}\n" +
+                "\t}]\n" +
+                "}";
+
+        FundingContributors fundingContributors = fundingContributorsConverter.convertFrom(json);
+        assertNotNull(fundingContributors);
+        assertEquals(1, fundingContributors.getContributor().size());
+        FundingContributor c = fundingContributors.getContributor().get(0);
+        assertNotNull(c.getContributorOrcid());
+        assertEquals("qa.orcid.org", c.getContributorOrcid().getHost());
+        assertEquals("0009-0000-7948-587X", c.getContributorOrcid().getPath());
+        assertEquals("https://qa.orcid.org/0009-0000-7948-587X", c.getContributorOrcid().getUri());
+        assertNotNull(c.getCreditName());
+        assertEquals("Test Author", c.getCreditName().getContent());
+        assertNull(c.getContributorEmail());
+        assertNotNull(c.getContributorAttributes());
+        assertEquals("SUPERVISION", c.getContributorAttributes().getContributorRole());
+
+        // Verify XML marshalling succeeds
+        jakarta.xml.bind.JAXBContext context = jakarta.xml.bind.JAXBContext.newInstance(FundingContributors.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(fundingContributors, writer);
+        assertTrue(writer.toString().contains("qa.orcid.org"));
+    }
+
+    @Test
+    public void testConvertFromCleansEmptyXmlValueFields() throws Exception {
+        String json = "{\n" +
+                "\t\"contributor\": [{\n" +
+                "\t\t\"contributorOrcid\": {\n" +
+                "\t\t\t\"uri\": null,\n" +
+                "\t\t\t\"path\": null,\n" +
+                "\t\t\t\"host\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"creditName\": {\n" +
+                "\t\t\t\"content\": \"   \"\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorEmail\": {\n" +
+                "\t\t\t\"value\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorAttributes\": {\n" +
+                "\t\t\t\"contributorRole\": null\n" +
+                "\t\t}\n" +
+                "\t}]\n" +
+                "}";
+
+        FundingContributors fundingContributors = fundingContributorsConverter.convertFrom(json);
+        assertNotNull(fundingContributors);
+        assertEquals(1, fundingContributors.getContributor().size());
+        FundingContributor c = fundingContributors.getContributor().get(0);
+        assertNull(c.getContributorOrcid());
+        assertNull(c.getCreditName());
+        assertNull(c.getContributorEmail());
+        assertNull(c.getContributorAttributes());
+
+        // Verify XML marshalling succeeds without AccessorException
+        jakarta.xml.bind.JAXBContext context = jakarta.xml.bind.JAXBContext.newInstance(FundingContributors.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(fundingContributors, writer);
+        assertNotNull(writer.toString());
     }
     
     private FundingContributors getFundingContributors() {

--- a/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV2Test.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV2Test.java
@@ -76,6 +76,85 @@ public class WorkContributorsMapperV2Test {
         assertNull(workContributors.getContributor().get(0).getContributorAttributes().getContributorRole());
         assertNull(workContributors.getContributor().get(1).getContributorAttributes().getContributorRole());
     }
+
+    @Test
+    public void testConvertFromWithMissingHostAndNulls() throws Exception {
+        Mockito.when(mockContributorRoleConverter.toLegacyRoleName(Mockito.anyString())).thenReturn("AUTHOR");
+        String json = "{\n" +
+                "\t\"contributor\": [{\n" +
+                "\t\t\"contributorOrcid\": {\n" +
+                "\t\t\t\"uri\": \"https://qa.orcid.org/0009-0000-7948-587X\",\n" +
+                "\t\t\t\"path\": \"0009-0000-7948-587X\",\n" +
+                "\t\t\t\"host\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"creditName\": {\n" +
+                "\t\t\t\"content\": \"Test Author\"\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorEmail\": null,\n" +
+                "\t\t\"contributorAttributes\": {\n" +
+                "\t\t\t\"contributorSequence\": null,\n" +
+                "\t\t\t\"contributorRole\": \"WRITING_ORIGINAL_DRAFT\"\n" +
+                "\t\t}\n" +
+                "\t}]\n" +
+                "}";
+
+        WorkContributors workContributors = workContributorsMapper.convertFrom(json);
+        assertNotNull(workContributors);
+        assertEquals(1, workContributors.getContributor().size());
+        Contributor c = workContributors.getContributor().get(0);
+        assertNotNull(c.getContributorOrcid());
+        assertEquals("qa.orcid.org", c.getContributorOrcid().getHost());
+        assertEquals("0009-0000-7948-587X", c.getContributorOrcid().getPath());
+        assertNotNull(c.getCreditName());
+        assertEquals("Test Author", c.getCreditName().getContent());
+        assertNull(c.getContributorEmail());
+        assertNotNull(c.getContributorAttributes());
+        assertEquals(ContributorRole.AUTHOR, c.getContributorAttributes().getContributorRole());
+
+        // Verify XML marshalling succeeds
+        jakarta.xml.bind.JAXBContext context = jakarta.xml.bind.JAXBContext.newInstance(WorkContributors.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(workContributors, writer);
+        assertTrue(writer.toString().contains("qa.orcid.org"));
+    }
+
+    @Test
+    public void testConvertFromCleansEmptyXmlValueFields() throws Exception {
+        String json = "{\n" +
+                "\t\"contributor\": [{\n" +
+                "\t\t\"contributorOrcid\": {\n" +
+                "\t\t\t\"uri\": null,\n" +
+                "\t\t\t\"path\": null,\n" +
+                "\t\t\t\"host\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"creditName\": {\n" +
+                "\t\t\t\"content\": \"   \"\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorEmail\": {\n" +
+                "\t\t\t\"value\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorAttributes\": {\n" +
+                "\t\t\t\"contributorSequence\": null,\n" +
+                "\t\t\t\"contributorRole\": null\n" +
+                "\t\t}\n" +
+                "\t}]\n" +
+                "}";
+
+        WorkContributors workContributors = workContributorsMapper.convertFrom(json);
+        assertNotNull(workContributors);
+        assertEquals(1, workContributors.getContributor().size());
+        Contributor c = workContributors.getContributor().get(0);
+        assertNull(c.getContributorOrcid());
+        assertNull(c.getCreditName());
+        assertNull(c.getContributorEmail());
+        assertNull(c.getContributorAttributes());
+
+        // Verify XML marshalling succeeds without AccessorException
+        jakarta.xml.bind.JAXBContext context = jakarta.xml.bind.JAXBContext.newInstance(WorkContributors.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(workContributors, writer);
+        assertNotNull(writer.toString());
+    }
     
     private WorkContributors getWorkContributors() {
         WorkContributors workContributors = new WorkContributors();

--- a/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV3Test.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/mapstruct/WorkContributorsMapperV3Test.java
@@ -2,6 +2,7 @@ package org.orcid.core.adapter.mapstruct;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -82,6 +83,87 @@ public class WorkContributorsMapperV3Test {
         assertEquals("some-value", workContributors.getContributor().get(1).getContributorAttributes().getContributorRole());
         
         Mockito.verify(mockContributorRoleConverter, Mockito.times(2)).toRoleValue(Mockito.anyString());
+    }
+
+    @Test
+    public void testConvertFromWithMissingHostAndNulls() throws Exception {
+        Mockito.when(mockContributorRoleConverter.toRoleValue(Mockito.anyString())).thenReturn("http://credit.niso.org/contributor-roles/data-curation/");
+        String json = "{\n" +
+                "\t\"contributor\": [{\n" +
+                "\t\t\"contributorOrcid\": {\n" +
+                "\t\t\t\"uri\": \"https://qa.orcid.org/0009-0000-7948-587X\",\n" +
+                "\t\t\t\"path\": \"0009-0000-7948-587X\",\n" +
+                "\t\t\t\"host\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"creditName\": {\n" +
+                "\t\t\t\"content\": \"Test Author\"\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorEmail\": null,\n" +
+                "\t\t\"contributorAttributes\": {\n" +
+                "\t\t\t\"contributorSequence\": null,\n" +
+                "\t\t\t\"contributorRole\": \"http://credit.niso.org/contributor-roles/data-curation/\"\n" +
+                "\t\t}\n" +
+                "\t}]\n" +
+                "}";
+
+        WorkContributors workContributors = workContributorsMapper.convertFrom(json);
+        assertNotNull(workContributors);
+        assertEquals(1, workContributors.getContributor().size());
+        Contributor c = workContributors.getContributor().get(0);
+        assertNotNull(c.getContributorOrcid());
+        assertEquals("qa.orcid.org", c.getContributorOrcid().getHost());
+        assertEquals("0009-0000-7948-587X", c.getContributorOrcid().getPath());
+        assertEquals("https://qa.orcid.org/0009-0000-7948-587X", c.getContributorOrcid().getUri());
+        assertNotNull(c.getCreditName());
+        assertEquals("Test Author", c.getCreditName().getContent());
+        assertNull(c.getContributorEmail());
+        assertNotNull(c.getContributorAttributes());
+        assertEquals("http://credit.niso.org/contributor-roles/data-curation/", c.getContributorAttributes().getContributorRole());
+        assertNull(c.getContributorAttributes().getContributorSequence());
+
+        // Verify XML marshalling succeeds
+        jakarta.xml.bind.JAXBContext context = jakarta.xml.bind.JAXBContext.newInstance(WorkContributors.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(workContributors, writer);
+        assertTrue(writer.toString().contains("qa.orcid.org"));
+    }
+
+    @Test
+    public void testConvertFromCleansEmptyXmlValueFields() throws Exception {
+        String json = "{\n" +
+                "\t\"contributor\": [{\n" +
+                "\t\t\"contributorOrcid\": {\n" +
+                "\t\t\t\"uri\": null,\n" +
+                "\t\t\t\"path\": null,\n" +
+                "\t\t\t\"host\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"creditName\": {\n" +
+                "\t\t\t\"content\": \"   \"\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorEmail\": {\n" +
+                "\t\t\t\"value\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorAttributes\": {\n" +
+                "\t\t\t\"contributorSequence\": null,\n" +
+                "\t\t\t\"contributorRole\": null\n" +
+                "\t\t}\n" +
+                "\t}]\n" +
+                "}";
+
+        WorkContributors workContributors = workContributorsMapper.convertFrom(json);
+        assertNotNull(workContributors);
+        assertEquals(1, workContributors.getContributor().size());
+        Contributor c = workContributors.getContributor().get(0);
+        assertNull(c.getContributorOrcid());
+        assertNull(c.getCreditName());
+        assertNull(c.getContributorEmail());
+        assertNull(c.getContributorAttributes());
+
+        // Verify XML marshalling succeeds without AccessorException
+        jakarta.xml.bind.JAXBContext context = jakarta.xml.bind.JAXBContext.newInstance(WorkContributors.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(workContributors, writer);
+        assertNotNull(writer.toString());
     }
     
     private WorkContributors getWorkContributors() {

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbWorkAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v2/latest/JpaJaxbWorkAdapterTest.java
@@ -257,6 +257,51 @@ public class JpaJaxbWorkAdapterTest extends MockSourceNameCache {
     }
 
     @Test
+    public void fromWorkEntityWithContributorsMissingHostTest() throws Exception {
+        orcidUrlManager.setBaseUrl("https://testserver.orcid.org");
+        WorkEntity work = getWorkEntity();
+        work.setContributorsJson("{\n" +
+                "\t\"contributor\": [{\n" +
+                "\t\t\"contributorOrcid\": {\n" +
+                "\t\t\t\"uri\": \"https://qa.orcid.org/0009-0000-7948-587X\",\n" +
+                "\t\t\t\"path\": \"0009-0000-7948-587X\",\n" +
+                "\t\t\t\"host\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"creditName\": {\n" +
+                "\t\t\t\"content\": \"Test Author\"\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorEmail\": null,\n" +
+                "\t\t\"contributorAttributes\": {\n" +
+                "\t\t\t\"contributorSequence\": null,\n" +
+                "\t\t\t\"contributorRole\": \"AUTHOR\"\n" +
+                "\t\t}\n" +
+                "\t}]\n" +
+                "}");
+
+        Work mappedWork = jpaJaxbWorkAdapter.toWork(work);
+        assertNotNull(mappedWork.getWorkContributors());
+        assertEquals(1, mappedWork.getWorkContributors().getContributor().size());
+        org.orcid.jaxb.model.common_v2.Contributor c = mappedWork.getWorkContributors().getContributor().get(0);
+        assertNotNull(c.getContributorOrcid());
+        assertEquals("qa.orcid.org", c.getContributorOrcid().getHost());
+        assertEquals("0009-0000-7948-587X", c.getContributorOrcid().getPath());
+        assertNotNull(c.getCreditName());
+        assertEquals("Test Author", c.getCreditName().getContent());
+        assertNull(c.getContributorEmail());
+        assertNotNull(c.getContributorAttributes());
+        assertNull(c.getContributorAttributes().getContributorSequence());
+        assertEquals(org.orcid.jaxb.model.common_v2.ContributorRole.AUTHOR, c.getContributorAttributes().getContributorRole());
+
+        // Verify JAXB XML serialization works without AccessorException
+        JAXBContext context = JAXBContext.newInstance(Work.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(mappedWork, writer);
+        String xml = writer.toString();
+        assertTrue(xml.contains("qa.orcid.org"));
+        assertTrue(xml.contains("Test Author"));
+    }
+
+    @Test
     public void fromWorkEntityToWorkSummaryTest() throws IllegalAccessException {
         WorkEntity work = getWorkEntity();
         assertNotNull(work);

--- a/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbWorkAdapterTest.java
+++ b/orcid-core/src/test/java/org/orcid/core/adapter/v3/JpaJaxbWorkAdapterTest.java
@@ -34,6 +34,7 @@ import org.orcid.jaxb.model.common.Iso3166Country;
 import org.orcid.jaxb.model.common.Relationship;
 import org.orcid.jaxb.model.common.WorkType;
 import org.orcid.jaxb.model.v3.release.common.Visibility;
+import org.orcid.jaxb.model.v3.release.common.Contributor;
 import org.orcid.jaxb.model.v3.release.record.ExternalID;
 import org.orcid.jaxb.model.v3.release.record.Work;
 import org.orcid.jaxb.model.v3.release.record.summary.WorkSummary;
@@ -225,6 +226,51 @@ public class JpaJaxbWorkAdapterTest extends MockSourceNameCache {
         Work mappedWork = jpaJaxbWorkAdapter.toWork(work);
 
         assertNull(mappedWork.getUrl());
+    }
+
+    @Test
+    public void fromWorkEntityWithContributorsMissingHostTest() throws Exception {
+        orcidUrlManager.setBaseUrl("https://testserver.orcid.org");
+        WorkEntity work = getWorkEntity();
+        work.setContributorsJson("{\n" +
+                "\t\"contributor\": [{\n" +
+                "\t\t\"contributorOrcid\": {\n" +
+                "\t\t\t\"uri\": \"https://qa.orcid.org/0009-0000-7948-587X\",\n" +
+                "\t\t\t\"path\": \"0009-0000-7948-587X\",\n" +
+                "\t\t\t\"host\": null\n" +
+                "\t\t},\n" +
+                "\t\t\"creditName\": {\n" +
+                "\t\t\t\"content\": \"Test Author\"\n" +
+                "\t\t},\n" +
+                "\t\t\"contributorEmail\": null,\n" +
+                "\t\t\"contributorAttributes\": {\n" +
+                "\t\t\t\"contributorSequence\": null,\n" +
+                "\t\t\t\"contributorRole\": \"http://credit.niso.org/contributor-roles/data-curation/\"\n" +
+                "\t\t}\n" +
+                "\t}]\n" +
+                "}");
+
+        Work mappedWork = jpaJaxbWorkAdapter.toWork(work);
+        assertNotNull(mappedWork.getWorkContributors());
+        assertEquals(1, mappedWork.getWorkContributors().getContributor().size());
+        Contributor c = mappedWork.getWorkContributors().getContributor().get(0);
+        assertNotNull(c.getContributorOrcid());
+        assertEquals("qa.orcid.org", c.getContributorOrcid().getHost());
+        assertEquals("0009-0000-7948-587X", c.getContributorOrcid().getPath());
+        assertNotNull(c.getCreditName());
+        assertEquals("Test Author", c.getCreditName().getContent());
+        assertNull(c.getContributorEmail());
+        assertNotNull(c.getContributorAttributes());
+        assertNull(c.getContributorAttributes().getContributorSequence());
+        assertEquals("http://credit.niso.org/contributor-roles/data-curation/", c.getContributorAttributes().getContributorRole());
+
+        // Verify JAXB XML serialization works without AccessorException
+        JAXBContext context = JAXBContext.newInstance(Work.class);
+        java.io.StringWriter writer = new java.io.StringWriter();
+        context.createMarshaller().marshal(mappedWork, writer);
+        String xml = writer.toString();
+        assertTrue(xml.contains("qa.orcid.org"));
+        assertTrue(xml.contains("Test Author"));
     }
 
     @Test


### PR DESCRIPTION
Resolved the issue where contributor in works and fundings was missing its host value when serialized or returned via API endpoints.

Fixed null/empty @XmlValue field issues in contributor mappers to ensure contributors serialize cleanly to XML without AccessorException.